### PR TITLE
Fix httpx usage after upgrade

### DIFF
--- a/internal/probe/webserver.go
+++ b/internal/probe/webserver.go
@@ -43,6 +43,10 @@ func performWebServerProbe(targets []string) ([]URLDetails, []string, error) {
 		},
 	}
 
+	if err := options.ValidateOptions(); err != nil {
+		return urls, errors, err
+	}
+
 	httpxRunner, err := runner.New(&options)
 	if err != nil {
 		return urls, errors, err


### PR DESCRIPTION
After upgrading httpx, some nil pointer errors were resolved by validating the options like in this example: https://github.com/projectdiscovery/httpx/blob/main/examples/simple/main.go#L29