### PR TITLE
Philip/met 1715 webscan development new nuclei template

### DIFF
--- a/configs/configs/templates/custom/k8s-detect.yaml
+++ b/configs/configs/templates/custom/k8s-detect.yaml
@@ -32,3 +32,4 @@ requests:
         group: 1
         regex:
           - "HTTP/1.1 ([0-9]{3})"
+          

--- a/configs/configs/templates/custom/k8s-detect.yaml
+++ b/configs/configs/templates/custom/k8s-detect.yaml
@@ -1,0 +1,34 @@
+id: k8s-detect
+
+info:
+  name: k8s Cluster - Detect
+  author: MethodSecurity
+  severity: info
+  description: Checks common k8s fingerprints to identify a k8s cluster
+  reference: https://kubernetes.io/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cwe-id: CWE-200
+  tags: exposure,api,k8s
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/api"
+      - "{{BaseURL}}/livez"
+      - "{{BaseURL}}/version"
+    matchers:
+      - type: word
+        words:
+          - "Kubernetes-Pf-Flowschema-Uid"
+          - "Kubernetes-Pf-Prioritylevel-Uid"
+        part: header
+        condition: and
+
+    extractors: 
+      - type: regex
+        name: "Status"
+        part: response
+        group: 1
+        regex:
+          - "HTTP/1.1 ([0-9]{3})"


### PR DESCRIPTION
Summary
This template will be used to identify k8s clusters given a url + port passed in via the target flag

Logic
The template uses common k8s headers as a fingerprinting technique and returns the status code if they are detected. Filtering does not happen based on status code since if these headers are detected we can be (pretty) certain that the endpoint is a k8s cluster and regardless of the status code I believe this adds value.

Testing
This template was tested using the endpoint 'localhost:Minikube Port #' and 'k8s-dev.*****.ts.net'

Note
For k8s-dev.weasel-minnow.ts.net the port (443) was automatically added to the target by the Nuclei SDK