### PR TITLE
madhav/met-1934 make routes optional in report

### DIFF
--- a/fern/definition/routes.yml
+++ b/fern/definition/routes.yml
@@ -54,7 +54,7 @@ types:
       baseEndpointUrl: string
       version: optional<string>
       schemaUrl: optional<string>
-      routes: list<Route>
+      routes: optional<list<Route>>
       securitySchemes: optional<map<SecuritySchemeName, SecurityScheme>>
       security: optional<list<SecurityRequirement>>
       queries: optional<list<graphql.GraphQLQuery>>


### PR DESCRIPTION
Make routes field optional so parsing doesn't fail in the processor when there are errors passed through the report. 