### PR TITLE
Madhav/met 1960 webscan sends back response properties in swagger routes v2

### DIFF
--- a/fern/definition/routes.yml
+++ b/fern/definition/routes.yml
@@ -47,6 +47,7 @@ types:
       method: string
       type: APIType
       description: string
+      responseProperties: optional<map<string, list<string>>>
   RoutesReport:
     properties:
       target: string

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -809,12 +809,13 @@ func (o *OAuthFlows) String() string {
 }
 
 type Route struct {
-	Path        string               `json:"path" url:"path"`
-	QueryParams []string             `json:"queryParams,omitempty" url:"queryParams,omitempty"`
-	Security    *SecurityRequirement `json:"security,omitempty" url:"security,omitempty"`
-	Method      string               `json:"method" url:"method"`
-	Type        ApiType              `json:"type" url:"type"`
-	Description string               `json:"description" url:"description"`
+	Path               string               `json:"path" url:"path"`
+	QueryParams        []string             `json:"queryParams,omitempty" url:"queryParams,omitempty"`
+	Security           *SecurityRequirement `json:"security,omitempty" url:"security,omitempty"`
+	Method             string               `json:"method" url:"method"`
+	Type               ApiType              `json:"type" url:"type"`
+	Description        string               `json:"description" url:"description"`
+	ResponseProperties map[string][]string  `json:"responseProperties,omitempty" url:"responseProperties,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage

--- a/generated/python/resources/routes/route.py
+++ b/generated/python/resources/routes/route.py
@@ -16,6 +16,9 @@ class Route(UniversalBaseModel):
     method: str
     type: ApiType
     description: str
+    response_properties: typing.Optional[typing.Dict[str, typing.List[str]]] = pydantic.Field(
+        alias="responseProperties", default=None
+    )
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow")  # type: ignore # Pydantic v2

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -226,8 +226,10 @@ func handleSwaggerV2(document libopenapi.Document, report *webscan.RoutesReport)
 
 	// Extract security definitions
 	securityDefinitions := make(map[string]*v2.SecurityScheme)
-	for pair := model.SecurityDefinitions.Definitions.Oldest(); pair != nil; pair = pair.Next() {
-		securityDefinitions[pair.Key] = pair.Value
+	if model.SecurityDefinitions != nil {
+		for pair := model.SecurityDefinitions.Definitions.Oldest(); pair != nil; pair = pair.Next() {
+			securityDefinitions[pair.Key] = pair.Value
+		}
 	}
 
 	// Add security schemes to the report
@@ -246,6 +248,16 @@ func handleSwaggerV2(document libopenapi.Document, report *webscan.RoutesReport)
 		for opPair := pathItem.GetOperations().Oldest(); opPair != nil; opPair = opPair.Next() {
 			method := opPair.Key
 			operation := opPair.Value
+
+			var responseProperties map[string][]string
+			if strings.ToUpper(method) == "GET" {
+				var err error
+				responseProperties, err = extractResponsePropertiesV2(operation)
+				if err != nil {
+					responseProperties = nil
+				}
+			}
+
 			securityRequirements := convertSecurityRequirementsV2(operation.Security)
 			route := webscan.Route{
 				Path:        path,
@@ -255,6 +267,11 @@ func handleSwaggerV2(document libopenapi.Document, report *webscan.RoutesReport)
 				Type:        webscan.ApiTypeSwaggerV2,
 				Description: operation.Description,
 			}
+
+			if responseProperties != nil {
+				route.ResponseProperties = responseProperties
+			}
+
 			report.Routes = append(report.Routes, &route)
 		}
 	}
@@ -315,6 +332,16 @@ func handleOpenAPIV3(document libopenapi.Document, report *webscan.RoutesReport,
 		for opPair := pathItem.GetOperations().Oldest(); opPair != nil; opPair = opPair.Next() {
 			method := opPair.Key
 			operation := opPair.Value
+
+			var responseProperties map[string][]string
+			if strings.ToUpper(method) == "GET" {
+				var err error
+				responseProperties, err = extractResponsePropertiesV3(operation)
+				if err != nil {
+					responseProperties = nil
+				}
+			}
+
 			securityRequirements := convertSecurityRequirementsV3(operation.Security)
 			route := webscan.Route{
 				Path:        path,
@@ -324,11 +351,34 @@ func handleOpenAPIV3(document libopenapi.Document, report *webscan.RoutesReport,
 				Type:        webscan.ApiTypeSwaggerV3,
 				Description: operation.Description,
 			}
+
+			if responseProperties != nil {
+				route.ResponseProperties = responseProperties
+			}
+
 			report.Routes = append(report.Routes, &route)
 		}
 	}
 
 	return nil
+}
+
+// Helper function to get the first layer of schema properties recursively
+func getSchemaPropertiesRecursive(schema *base.Schema) []string {
+	var properties []string
+	if schema.Properties != nil {
+		for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+			propName := pair.Key
+			properties = append(properties, propName)
+			// Recursively get properties of nested schemas
+			nestedSchema := pair.Value.Schema()
+			if nestedSchema != nil {
+				nestedProperties := getSchemaPropertiesRecursive(nestedSchema)
+				properties = append(properties, nestedProperties...)
+			}
+		}
+	}
+	return properties
 }
 
 // getQueryParamsV2 extracts query parameters from the operation parameters for Swagger (OpenAPI 2.0)
@@ -505,4 +555,57 @@ func convertSecurityRequirementsV3(security []*base.SecurityRequirement) *websca
 		return nil
 	}
 	return req
+}
+
+func extractResponsePropertiesV2(operation *v2.Operation) (map[string][]string, error) {
+	responseProperties := make(map[string][]string)
+	if operation.Responses != nil && operation.Responses.Codes != nil {
+		for respPair := operation.Responses.Codes.Oldest(); respPair != nil; respPair = respPair.Next() {
+			statusCode := respPair.Key
+			response := respPair.Value
+
+			if response.Schema != nil {
+				schema := response.Schema.Schema()
+				if schema != nil {
+					properties := getSchemaPropertiesRecursive(schema)
+					if len(properties) > 0 {
+						responseProperties[statusCode] = properties
+					}
+				}
+			}
+		}
+	}
+	if len(responseProperties) == 0 {
+		return nil, fmt.Errorf("no response properties found")
+	}
+	return responseProperties, nil
+}
+
+func extractResponsePropertiesV3(operation *v3.Operation) (map[string][]string, error) {
+	responseProperties := make(map[string][]string)
+	if operation.Responses != nil && operation.Responses.Codes != nil {
+		for respPair := operation.Responses.Codes.Oldest(); respPair != nil; respPair = respPair.Next() {
+			statusCode := respPair.Key
+			response := respPair.Value
+
+			if response.Content != nil {
+				for contentPair := response.Content.Oldest(); contentPair != nil; contentPair = contentPair.Next() {
+					mediaTypeObject := contentPair.Value
+					if mediaTypeObject.Schema != nil {
+						schema := mediaTypeObject.Schema.Schema()
+						if schema != nil {
+							properties := getSchemaPropertiesRecursive(schema)
+							if len(properties) > 0 {
+								responseProperties[statusCode] = properties
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(responseProperties) == 0 {
+		return nil, fmt.Errorf("no response properties found")
+	}
+	return responseProperties, nil
 }


### PR DESCRIPTION
- Updating webscan tool to send back the top-level properties of an route response as a list of strings.
- Route object in Fern updated accordingly
- Will be used for sensitive values exposed analysis