### PR TITLE
Improved azure check to allow finding custom bucket domains

### DIFF
--- a/configs/configs/templates/custom/azure-blob-storage-container-detect.yaml
+++ b/configs/configs/templates/custom/azure-blob-storage-container-detect.yaml
@@ -21,11 +21,13 @@ requests:
       - type: status
         status:
           - 200
+          - 403
 
-      - type: regex
-        part: host
-        regex:
-          - '[a-z0-9]+\.blob\.core\.windows\.net'
+      - type: dsl
+        dsl:
+          - 'contains(to_lower(server), "microsoft-httpapi/2.0")'
+          - 'contains(to_lower(header), "x-ms-request-id")'
+        condition: and
 
     extractors:        
       - type: dsl


### PR DESCRIPTION
Azure blob storage can be hosted on custom domains, and 403s are returned when it is a valid bucket but unauthorized. Both improvements made to the template.