### PR TITLE
Web Page Capture: Updated CLI

### DIFF
--- a/cmd/webpagecapture.go
+++ b/cmd/webpagecapture.go
@@ -22,13 +22,26 @@ func (a *WebScan) InitWebpagecaptureCommand() {
 				return
 			}
 
-			report := webpagecapture.PerformWebpageCapture(cmd.Context(), target)
+			noSandbox, err := cmd.Flags().GetBool("no-sandbox")
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
 
+			report, err := webpagecapture.PerformWebpageCapture(cmd.Context(), noSandbox, target)
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+			}
 			a.OutputSignal.Content = report
 		},
 	}
 
 	webpagecaptureCmd.Flags().String("target", "", "Url target to perform webpage HTML capture")
+	webpagecaptureCmd.Flags().Bool("no-sandbox", false, "Disable sandbox mode for scan")
 
 	var chromiumPath string
 	webpageScreenshotCmd := &cobra.Command{


### PR DESCRIPTION
**Update**
- Emulated `webscan app swagger` and used the chromedp package to render the HTML to ensure that we pull the full HTML from the webpage
- Error Logic nits

**Example Signal**
`method webpagecapture --target https://www.blackstone.com/`


```
{
    "content": {
        "target": "https://www.blackstone.com/",
        "html_encoded": "XXXX"
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2024-09-16T16:01:17.428588-04:00",
    "status": 0
}
```