### PR TITLE
New Subcommand: Spider Bodygrab

### DIFF
--- a/cmd/spider.go
+++ b/cmd/spider.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"bufio"
+	"errors"
+	"os"
+
 	"github.com/Method-Security/webscan/internal/spider"
 	"github.com/spf13/cobra"
 )
@@ -33,5 +37,97 @@ func (a *WebScan) InitSpiderCommand() {
 
 	spiderCmd.Flags().String("targets", "", "Url targets to perform web spidering, comma delimited list")
 
+	bodyGrabCmd := &cobra.Command{
+		Use:   "bodygrab",
+		Short: "Given a Url grab the response body",
+		Long:  `Given a Url grab the response body`,
+		Run: func(cmd *cobra.Command, args []string) {
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
+
+			filePaths, err := cmd.Flags().GetStringSlice("files")
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
+			fileTargets, err := getTargetsFromFiles(filePaths)
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
+
+			allTargets := append(targets, fileTargets...)
+
+			if len(allTargets) == 0 {
+				err = errors.New("no targets specified")
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
+
+			setHTTP, err := cmd.Flags().GetBool("https")
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
+
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+				return
+			}
+
+			report, err := spider.BodyGrab(allTargets, setHTTP, timeout)
+			if err != nil {
+				errorMessage := err.Error()
+				a.OutputSignal.ErrorMessage = &errorMessage
+				a.OutputSignal.Status = 1
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	bodyGrabCmd.Flags().StringSlice("targets", []string{}, "URL targets to analyze")
+	bodyGrabCmd.Flags().StringSlice("files", []string{}, "Paths to files containing the list of targets")
+	bodyGrabCmd.Flags().Bool("https", false, "Only check sites with secure SSL")
+	bodyGrabCmd.Flags().Int("timeout", 10, "Request timeout in seconds")
+
+	spiderCmd.AddCommand(bodyGrabCmd)
+
 	a.RootCmd.AddCommand(spiderCmd)
+}
+
+func getTargetsFromFiles(paths []string) ([]string, error) {
+	targets := []string{}
+	for _, path := range paths {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		err = file.Close()
+		if err != nil {
+			return nil, err
+		}
+		var lines []string
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+		targets = append(targets, lines...)
+	}
+	return targets, nil
 }

--- a/fern/definition/bodygrab.yml
+++ b/fern/definition/bodygrab.yml
@@ -1,0 +1,10 @@
+types:
+  BodyGrab:
+    properties:
+      target: string
+      statusCode: integer
+      responseBody: string
+  BodyGrabReport:
+    properties:
+      bodyGrabs: optional<list<BodyGrab>>
+      errors: optional<list<string>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -9,6 +9,91 @@ import (
 	time "time"
 )
 
+type BodyGrab struct {
+	Target       string `json:"target" url:"target"`
+	StatusCode   int    `json:"statusCode" url:"statusCode"`
+	ResponseBody string `json:"responseBody" url:"responseBody"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (b *BodyGrab) GetExtraProperties() map[string]interface{} {
+	return b.extraProperties
+}
+
+func (b *BodyGrab) UnmarshalJSON(data []byte) error {
+	type unmarshaler BodyGrab
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BodyGrab(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+
+	b._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (b *BodyGrab) String() string {
+	if len(b._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(b._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(b); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", b)
+}
+
+type BodyGrabReport struct {
+	BodyGrabs []*BodyGrab `json:"bodyGrabs,omitempty" url:"bodyGrabs,omitempty"`
+	Errors    []string    `json:"errors,omitempty" url:"errors,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (b *BodyGrabReport) GetExtraProperties() map[string]interface{} {
+	return b.extraProperties
+}
+
+func (b *BodyGrabReport) UnmarshalJSON(data []byte) error {
+	type unmarshaler BodyGrabReport
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BodyGrabReport(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+
+	b._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (b *BodyGrabReport) String() string {
+	if len(b._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(b._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(b); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", b)
+}
+
 type TlsVersion string
 
 const (

--- a/internal/spider/bodygrab.go
+++ b/internal/spider/bodygrab.go
@@ -1,0 +1,69 @@
+package spider
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"time"
+
+	webscan "github.com/Method-Security/webscan/generated/go"
+)
+
+func BodyGrab(targets []string, setHTTP bool, timeout int) (*webscan.BodyGrabReport, error) {
+	resources := webscan.BodyGrabReport{}
+	errs := []string{}
+
+	httpClient := createHTTPClient(setHTTP, timeout)
+
+	var bodyGrabResults []*webscan.BodyGrab
+	for _, target := range targets {
+
+		responseBody, statusCode, err := bodyGrab(target, httpClient)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		bodyGrabResult := webscan.BodyGrab{
+			Target:       target,
+			ResponseBody: responseBody,
+			StatusCode:   statusCode,
+		}
+		bodyGrabResults = append(bodyGrabResults, &bodyGrabResult)
+	}
+
+	resources.BodyGrabs = bodyGrabResults
+	resources.Errors = errs
+	return &resources, nil
+}
+
+func createHTTPClient(setHTTP bool, timeout int) *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !setHTTP},
+	}
+	return &http.Client{
+		Timeout:   time.Duration(timeout) * time.Second,
+		Transport: tr,
+	}
+}
+
+func bodyGrab(url string, client *http.Client) (string, int, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", 0, err
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", 0, err
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return "", 0, err
+	}
+
+	statusCode := resp.StatusCode
+	body := string(bodyBytes)
+
+	return body, statusCode, nil
+}


### PR DESCRIPTION
## Description
- Given a Target(s) return 
   - Response Body
   - Status code
   
## Purpose
- The Response Body of a target is valuable data that can spawn multiple Analyzes (ie. Subdomain Takeovers)

## Example

```
"bodyGrabs": [
            {
                "target": "https://www.xxxx.com/cdn-cgi/scripts/5c5dd728/cloudflare-static/",
                "statusCode": 404,
                "responseBody": "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n"
            }
        ]
 }
```
