### PR TITLE
capture fixes

### DIFF
--- a/cmd/pagecapture.go
+++ b/cmd/pagecapture.go
@@ -189,7 +189,12 @@ func (a *WebScan) InitPagecaptureCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			_ = capturer.Close(cmd.Context())
+			err = capturer.Close(cmd.Context())
+			if err != nil {
+				log.Debug("Failed to close browserbase capturer", svc1log.SafeParam("error", err.Error()))
+				a.OutputSignal.AddError(err)
+				return
+			}
 			log.Info("Page capture successful", svc1log.SafeParam("target", target))
 			a.OutputSignal.Content = result.ToPageCaptureReport()
 		},

--- a/cmd/pagecapture.go
+++ b/cmd/pagecapture.go
@@ -22,8 +22,16 @@ func (a *WebScan) InitPagecaptureCommand() {
 
 	pageScreenshotCmd := &cobra.Command{
 		Use:   "screenshot",
-		Short: "Perform a fully rendered webpage screenshot capture using a headless browser",
-		Long:  `Perform a fully rendered webpage screenshot capture using a headless browser`,
+		Short: "Perform a webpage screenshot and HTML capture against a URL target",
+		Long:  `Perform a webpage screenshot and HTML capture against a URL target`,
+	}
+	pageScreenshotCmd.PersistentFlags().String("target", "", "URL target to perform webpage capture")
+	pageScreenshotCmd.PersistentFlags().Int("timeout", 30, "Timeout in seconds for the capture")
+
+	browserScreenshotCmd := &cobra.Command{
+		Use:   "browser",
+		Short: "Perform a fully rendered webpage screenshot and HTML capture capture using a headless browser",
+		Long:  `Perform a fully rendered webpage screenshot and HTML capture capture using a headless browser`,
 		Run: func(cmd *cobra.Command, args []string) {
 			log := svc1log.FromContext(cmd.Context())
 
@@ -54,10 +62,76 @@ func (a *WebScan) InitPagecaptureCommand() {
 			a.OutputSignal.Content = report
 		},
 	}
+	browserScreenshotCmd.PersistentFlags().String("browserPath", "", "Path to a browser executable")
 
-	pageScreenshotCmd.PersistentFlags().String("target", "", "URL target to perform webpage capture")
-	pageScreenshotCmd.PersistentFlags().String("browserPath", "", "Path to a browser executable")
-	pageScreenshotCmd.PersistentFlags().Int("timeout", 30, "Timeout in seconds for the capture")
+	pageScreenshotCmd.AddCommand(browserScreenshotCmd)
+
+	browserbaseScreenshotCmd := &cobra.Command{
+		Use:   "browserbase",
+		Short: "Perform a fully rendered webpage screenshot and HTML capture using Browserbase",
+		Long:  `Perform a fully rendered webpage screenshot and HTML capture using Browserbase. Useful for avoiding bot detection or maintaining stealth`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			countries, _ := cmd.Flags().GetStringArray("country")
+			if len(countries) > 0 {
+				_ = cmd.MarkFlagRequired("proxy")
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			log := svc1log.FromContext(cmd.Context())
+			target, err := cmd.Flags().GetString("target")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			token, err := getFlagOrEnvironmentVariable(cmd, "token", "BROWSERBASE_TOKEN")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			project, err := getFlagOrEnvironmentVariable(cmd, "project", "BROWSERBASE_PROJECT")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			timeout, _ := cmd.Flags().GetInt("timeout")
+			proxy, _ := cmd.Flags().GetBool("proxy")
+			countries, _ := cmd.Flags().GetStringArray("country")
+
+			var options []browserbase.Option
+			if proxy && len(countries) > 0 {
+				options = append(options, browserbase.WithProxyCountries(countries))
+			} else if proxy {
+				options = append(options, browserbase.WithProxy())
+			}
+
+			client := browserbase.NewBrowserbaseClient(token, project, browserbase.NewBrowserbaseOptions(cmd.Context(), options...))
+			capturer := capture.NewBrowserbasePageCapturer(cmd.Context(), timeout, client)
+
+			if capturer == nil {
+				a.OutputSignal.AddError(fmt.Errorf("failed to create browserbase capturer"))
+				return
+			}
+
+			report := capturer.CaptureScreenshot(cmd.Context(), target, &capture.Options{})
+
+			err = capturer.Close(cmd.Context())
+			if err != nil {
+				log.Debug("Failed to close browserbase capturer", svc1log.SafeParam("error", err.Error()))
+				a.OutputSignal.AddError(err)
+				return
+			}
+			log.Info("Screenshot capture successful", svc1log.SafeParam("target", target))
+			a.OutputSignal.Content = report
+		},
+	}
+	browserbaseScreenshotCmd.Flags().String("token", "", "Browserbase API token")
+	browserbaseScreenshotCmd.Flags().String("project", "", "Browserbase project ID")
+	browserbaseScreenshotCmd.Flags().Bool("proxy", false, "Instruct Browserbase to use a proxy")
+	browserbaseScreenshotCmd.Flags().StringArray("country", []string{}, "List of countries to use for the proxy")
+
+	pageScreenshotCmd.AddCommand(browserbaseScreenshotCmd)
 
 	htmlCaptureCmd := &cobra.Command{
 		Use:   "html",

--- a/docs/docs/pagecapture.md
+++ b/docs/docs/pagecapture.md
@@ -99,30 +99,63 @@ Global Flags:
   -v, --verbose              Verbose output
 ```
 
-### Screenshot
+### Screenshot Browser
 
 #### Usage
 
 ```bash
-webscan pagecapture screenshot --target https://example.com
+webscan pagecapture screenshot browser --target https://example.com
 ```
 
 #### Help Text
 
 ```bash
-Perform a fully rendered webpage screenshot capture using a headless browser
+Perform a fully rendered webpage screenshot and HTML capture using a headless browser
 
 Usage:
-  webscan pagecapture screenshot [flags]
+  webscan pagecapture screenshot browser [flags]
 
 Flags:
-  -h, --help            help for screenshot
-      --target string   URL target to perform webpage capture
-      --timeout int     Timeout in seconds for the capture (default 30)
+      --browserPath string   Path to a browser executable
+  -h, --help                 help for browser
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
   -f, --output-file string   Path to output file. If blank, will output to STDOUT
   -q, --quiet                Suppress output
+      --target string        URL target to perform webpage capture
+      --timeout int          Timeout in seconds for the capture (default 30)
+  -v, --verbose              Verbose output
+```
+
+### Screenshot Browserbase
+
+#### Usage
+
+```bash
+webscan pagecapture screenshot browser --target https://example.com
+```
+
+#### Help Text
+
+```bash
+Perform a fully rendered webpage screenshot and HTML capture using Browserbase. Useful for avoiding bot detection or maintaining stealth
+
+Usage:
+  webscan pagecapture screenshot browserbase [flags]
+
+Flags:
+      --country stringArray   List of countries to use for the proxy
+  -h, --help                  help for browserbase
+      --project string        Browserbase project ID
+      --proxy                 Instruct Browserbase to use a proxy
+      --token string          Browserbase API token
+
+Global Flags:
+  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string   Path to output file. If blank, will output to STDOUT
+  -q, --quiet                Suppress output
+      --target string        URL target to perform webpage capture
+      --timeout int          Timeout in seconds for the capture (default 30)
   -v, --verbose              Verbose output
 ```

--- a/internal/capture/screenshot.go
+++ b/internal/capture/screenshot.go
@@ -12,6 +12,10 @@ import (
 	"github.com/ysmood/gson"
 )
 
+func (b *BrowserbasePageCapturer) CaptureScreenshot(ctx context.Context, url string, options *Options) webscan.PageScreenshotReport {
+	return b.Capturer.CaptureScreenshot(ctx, url, options)
+}
+
 func (b *BrowserPageCapturer) CaptureScreenshot(ctx context.Context, url string, options *Options) webscan.PageScreenshotReport {
 	log := svc1log.FromContext(ctx)
 

--- a/internal/routecapture/routecapture.go
+++ b/internal/routecapture/routecapture.go
@@ -137,6 +137,8 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod websc
 		// Extract the routes and urls
 		routes, urls, errors = extractRoutes(ctx, target, htmlContent, baseURLsOnly, timeout, webscan.PageCaptureMethodRequest, nil)
 
+		_ = capturer.Close(ctx)
+
 	default:
 		report.Errors = append(report.Errors, "Unsupported capture method")
 		return report


### PR DESCRIPTION
This fixes two bugs:

1. The error was not being handled when there were redirects causing the page not being able to load when tracking network requests
2. Browserbase capturers weren't able to be closed for some reason, so there is a timeout set and we log the error until further investigation can be done

This also adds support for screenshot to use browserbase