### PR TITLE
route capture no static assets

### DIFF
--- a/cmd/routecapture.go
+++ b/cmd/routecapture.go
@@ -18,6 +18,7 @@ func (a *WebScan) InitRoutecaptureCommand() {
 	routeCaptureCmd.PersistentFlags().String("target", "", "URL target to perform webpage capture")
 	routeCaptureCmd.PersistentFlags().String("browserPath", "", "Path to a browser executable")
 	routeCaptureCmd.PersistentFlags().Bool("base-urls-only", true, "Only match routes and urls that share the base URLs domain")
+	routeCaptureCmd.PersistentFlags().Bool("capture-static-assets", false, "Capture the routes and urls of static assets such as images, css, and js files")
 	routeCaptureCmd.PersistentFlags().Int("timeout", 30, "Timeout in seconds for the capture")
 	routeCaptureCmd.PersistentFlags().Int("minDOMStabalizeTime", 5, "Minimum time in seconds to wait for DOM to stabilize, currently only used in screenshots")
 
@@ -46,12 +47,13 @@ func (a *WebScan) InitRoutecaptureCommand() {
 			}
 
 			baseURLsOnly, _ := cmd.Flags().GetBool("base-urls-only")
+			captureStaticAssets, _ := cmd.Flags().GetBool("capture-static-assets")
 
 			timeout, _ := cmd.Flags().GetInt("timeout")
 			minDOMStabalizeTime, _ := cmd.Flags().GetInt("minDOMStabalizeTime")
 
 			// Extract the routes and links
-			report := routecapture.PerformRouteCapture(cmd.Context(), target, webscan.PageCaptureMethodRequest, baseURLsOnly, timeout, minDOMStabalizeTime, insecure, browserPath, nil, nil, nil)
+			report := routecapture.PerformRouteCapture(cmd.Context(), target, webscan.PageCaptureMethodRequest, baseURLsOnly, captureStaticAssets, timeout, minDOMStabalizeTime, insecure, browserPath, nil, nil, nil)
 			a.OutputSignal.Content = report
 		},
 	}
@@ -71,6 +73,7 @@ func (a *WebScan) InitRoutecaptureCommand() {
 			}
 
 			baseURLsOnly, _ := cmd.Flags().GetBool("base-urls-only")
+			captureStaticAssets, _ := cmd.Flags().GetBool("capture-static-assets")
 
 			var browserPath *string
 			if path, err := cmd.Flags().GetString("browserPath"); err == nil {
@@ -86,7 +89,7 @@ func (a *WebScan) InitRoutecaptureCommand() {
 			minDOMStabalizeTime, _ := cmd.Flags().GetInt("minDOMStabalizeTime")
 
 			// Extract the routes and links
-			report := routecapture.PerformRouteCapture(cmd.Context(), target, webscan.PageCaptureMethodBrowser, baseURLsOnly, timeout, minDOMStabalizeTime, false, browserPath, nil, nil, nil)
+			report := routecapture.PerformRouteCapture(cmd.Context(), target, webscan.PageCaptureMethodBrowser, baseURLsOnly, captureStaticAssets, timeout, minDOMStabalizeTime, false, browserPath, nil, nil, nil)
 			a.OutputSignal.Content = report
 		},
 	}
@@ -113,6 +116,7 @@ func (a *WebScan) InitRoutecaptureCommand() {
 			}
 
 			baseURLsOnly, _ := cmd.Flags().GetBool("base-urls-only")
+			captureStaticAssets, _ := cmd.Flags().GetBool("capture-static-assets")
 
 			token, err := getFlagOrEnvironmentVariable(cmd, "token", "BROWSERBASE_TOKEN")
 			if err != nil {
@@ -137,7 +141,7 @@ func (a *WebScan) InitRoutecaptureCommand() {
 			}
 
 			// Extract the routes and links
-			report := routecapture.PerformRouteCapture(cmd.Context(), target, webscan.PageCaptureMethodBrowserbase, baseURLsOnly, timeout, minDOMStabalizeTime, false, nil, &token, &project, &options)
+			report := routecapture.PerformRouteCapture(cmd.Context(), target, webscan.PageCaptureMethodBrowserbase, baseURLsOnly, captureStaticAssets, timeout, minDOMStabalizeTime, false, nil, &token, &project, &options)
 			a.OutputSignal.Content = report
 		},
 	}

--- a/internal/routecapture/htmlExtractors.go
+++ b/internal/routecapture/htmlExtractors.go
@@ -11,7 +11,7 @@ import (
 // extractFormRoutes extracts WebRoutes from form elements in the HTML document
 // It returns a slice of WebRoutes, a slice of URLs and a slice of errors
 // WebRoutes are merged to only return unique routes
-func extractFormRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool) ([]*webscan.WebRoute, []string, []string) {
+func extractFormRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool, captureStaticAssets bool) ([]*webscan.WebRoute, []string, []string) {
 	routes := []*webscan.WebRoute{}
 	urls := make(map[string]struct{})
 	errors := []string{}
@@ -30,7 +30,7 @@ func extractFormRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool)
 		fullURL := resolveURL(baseURL, action)
 
 		// Check if the URL is allowed
-		if !isURLAllowed(baseURL, fullURL, baseURLsOnly) {
+		if !isURLAllowed(baseURL, fullURL, baseURLsOnly, captureStaticAssets) {
 			return
 		}
 
@@ -89,7 +89,7 @@ func extractFormRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool)
 	return mergeWebRoutes(routes), setToListString(urls), []string{}
 }
 
-func extractAnchorRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool) ([]*webscan.WebRoute, []string, []string) {
+func extractAnchorRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool, captureStaticAssets bool) ([]*webscan.WebRoute, []string, []string) {
 	routes := []*webscan.WebRoute{}
 	urls := make(map[string]struct{})
 	errors := []string{}
@@ -107,7 +107,7 @@ func extractAnchorRoutes(doc *goquery.Document, baseURL string, baseURLsOnly boo
 			}
 
 			// Check if the URL is allowed
-			if !isURLAllowed(baseURL, fullURL, baseURLsOnly) {
+			if !isURLAllowed(baseURL, fullURL, baseURLsOnly, captureStaticAssets) {
 				return
 			}
 			urls[urlNoQuery] = struct{}{}
@@ -132,7 +132,7 @@ func extractAnchorRoutes(doc *goquery.Document, baseURL string, baseURLsOnly boo
 	return mergeWebRoutes(routes), setToListString(urls), errors
 }
 
-func extractLinkRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool) ([]*webscan.WebRoute, []string, []string) {
+func extractLinkRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool, captureStaticAssets bool) ([]*webscan.WebRoute, []string, []string) {
 	routes := []*webscan.WebRoute{}
 	urls := make(map[string]struct{})
 	errors := []string{}
@@ -150,7 +150,7 @@ func extractLinkRoutes(doc *goquery.Document, baseURL string, baseURLsOnly bool)
 			}
 
 			// Check if the URL is allowed
-			if !isURLAllowed(baseURL, fullURL, baseURLsOnly) {
+			if !isURLAllowed(baseURL, fullURL, baseURLsOnly, captureStaticAssets) {
 				return
 			}
 

--- a/internal/routecapture/networkExtractors.go
+++ b/internal/routecapture/networkExtractors.go
@@ -13,7 +13,7 @@ import (
 )
 
 // extractNetworkRoutes fetches network requests, parses them, and populates []WebRoute.
-func extractNetworkRoutes(ctx context.Context, b *capture.BrowserPageCapturer, target string, baseURLsOnly bool) ([]*webscan.WebRoute, []string, []string) {
+func extractNetworkRoutes(ctx context.Context, b *capture.BrowserPageCapturer, target string, baseURLsOnly bool, captureStaticAssets bool) ([]*webscan.WebRoute, []string, []string) {
 	routes := []*webscan.WebRoute{}
 	urls := make(map[string]struct{})
 	errors := []string{}
@@ -94,8 +94,8 @@ func extractNetworkRoutes(ctx context.Context, b *capture.BrowserPageCapturer, t
 		}
 
 		// Skip requests that don't match the base domain when baseURLsOnly is true
-		if !isURLAllowed(target, reqURL.String(), baseURLsOnly) {
-			log.Debug("Skipping URL, not part of base", svc1log.SafeParam("url", reqURL.String()), svc1log.SafeParam("target", target))
+		if !isURLAllowed(target, reqURL.String(), baseURLsOnly, captureStaticAssets) {
+			log.Debug("Skipping URL", svc1log.SafeParam("url", reqURL.String()), svc1log.SafeParam("target", target))
 			continue
 		}
 


### PR DESCRIPTION
Static assets (e.g. css) were being captured as routes and urls, this gets rid of those by default