### PR TITLE
Webscan App Requests: Add 'encoded' flag + logic

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -241,29 +243,32 @@ The requests command allows you to send custom HTTP requests to a target URL wit
 			defer a.OutputSignal.PanicHandler(cmd.Context())
 			baseURL, err := cmd.Flags().GetString("baseUrl")
 			if err != nil || baseURL == "" {
-				a.handleError(cmd, "baseUrl flag is required")
+				a.OutputSignal.AddError(err)
 				return
 			}
 
 			path, err := cmd.Flags().GetString("path")
 			if err != nil || path == "" {
-				a.handleError(cmd, "path flag is required")
+				a.OutputSignal.AddError(err)
 				return
 			}
 
 			method, err := cmd.Flags().GetString("method")
 			if err != nil || method == "" {
-				a.handleError(cmd, "method flag is required")
+				a.OutputSignal.AddError(err)
 				return
 			}
 
-			params := webscan.RequestParams{
-				PathParams:      cmd.Flag("pathParams").Value.String(),
-				QueryParams:     cmd.Flag("queryParams").Value.String(),
-				HeaderParams:    cmd.Flag("headerParams").Value.String(),
-				BodyParams:      cmd.Flag("bodyParams").Value.String(),
-				FormParams:      cmd.Flag("formParams").Value.String(),
-				MultipartParams: cmd.Flag("multipartParams").Value.String(),
+			isEncoded, err := cmd.Flags().GetBool("encodedParams")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			params, err := DecodeAndSetParams(cmd, isEncoded)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
 			}
 
 			vulnTypes, _ := cmd.Flags().GetStringSlice("vulnType")
@@ -288,12 +293,80 @@ The requests command allows you to send custom HTTP requests to a target URL wit
 	requestsCmd.Flags().String("bodyParams", "", "Body parameters as a JSON string (optional)")
 	requestsCmd.Flags().String("formParams", "", "Form parameters as a JSON string (optional)")
 	requestsCmd.Flags().String("multipartParams", "", "Multipart form parameters as a JSON string (optional)")
+	requestsCmd.Flags().Bool("encodedParams", false, "Request parameters base64 encoded")
+
 	requestsCmd.Flags().StringSlice("vulnType", []string{}, "Types of vulnerabilities to check (optional)")
+
+	_ = requestsCmd.MarkFlagRequired("baseUrl")
+	_ = requestsCmd.MarkFlagRequired("path")
+	_ = requestsCmd.MarkFlagRequired("method")
 
 	a.AppCmd.AddCommand(requestsCmd)
 }
 
-func (a *WebScan) handleError(cmd *cobra.Command, errMsg string) {
-	a.OutputSignal.ErrorMessage = &errMsg
-	a.OutputSignal.Status = 1
+// DecodeAndSetParams decodes flags as base64 if isEncoded is true, and parses JSON for all params.
+func DecodeAndSetParams(cmd *cobra.Command, isEncoded bool) (webscan.RequestParams, error) {
+	getFlagValue := func(flagName string) (string, error) {
+		flagValue := cmd.Flag(flagName).Value.String()
+		if isEncoded {
+			decodedBytes, err := base64.StdEncoding.DecodeString(flagValue)
+			if err != nil {
+				return "", err
+			}
+			return string(decodedBytes), nil
+		}
+		return flagValue, nil
+	}
+
+	params := webscan.RequestParams{}
+
+	// Helper function to test if decode JSON for each parameter
+	decodeJSON := func(flagValue string, target interface{}) error {
+		if flagValue == "" {
+			return nil
+		}
+		if err := json.Unmarshal([]byte(flagValue), &target); err != nil {
+			return errors.New("failed to parse as JSON: " + err.Error())
+		}
+		return nil
+	}
+
+	// Decode and parse each parameter
+	if pathParams, err := getFlagValue("pathParams"); err == nil {
+		if err := decodeJSON(pathParams, &params.PathParams); err != nil {
+			return params, err
+		}
+	}
+
+	if queryParams, err := getFlagValue("queryParams"); err == nil {
+		if err := decodeJSON(queryParams, &params.QueryParams); err != nil {
+			return params, err
+		}
+	}
+
+	if headerParams, err := getFlagValue("headerParams"); err == nil {
+		if err := decodeJSON(headerParams, &params.HeaderParams); err != nil {
+			return params, err
+		}
+	}
+
+	if bodyParams, err := getFlagValue("bodyParams"); err == nil {
+		if err := decodeJSON(bodyParams, &params.BodyParams); err != nil {
+			return params, err
+		}
+	}
+
+	if formParams, err := getFlagValue("formParams"); err == nil {
+		if err := decodeJSON(formParams, &params.FormParams); err != nil {
+			return params, err
+		}
+	}
+
+	if multipartParams, err := getFlagValue("multipartParams"); err == nil {
+		if err := decodeJSON(multipartParams, &params.MultipartParams); err != nil {
+			return params, err
+		}
+	}
+
+	return params, nil
 }


### PR DESCRIPTION
### Problem

1. Platform sends params as base64 encoded strings, but the user of the CLI shouldnt have to encode the params if they don't need too
2. JSON Parsing errors

### Solution

1. Add a flag that signifies that the sent in params are base64 encoded

### Example Command + Data

```
% method app requests --baseUrl=https://xxxx.com --path=/test_post --method=POST --vulnType=COMMAND --output json --bodyParams=IntcInVzZXJuYW1lXCI6IFwiYWJjZGVmZ2hpajsgZWNobyB2dWxuZXJhYmxlXCIsIFwicGFzc3dvcmRcIjogXCJhYmNkZWZnaGlqOyBlY2hvIHZ1bG5lcmFibGVcIn0i --headerParams=IntcIkNvbnRlbnQtVHlwZVwiOiBcImFwcGxpY2F0aW9uL2pzb25cIn0i --encodedParams

{
    "content": {
        "baseUrl": "https://xxxx.com",
        "path": "/test_post",
        "method": "POST",
        "headerParams": {
            "Content-Type": "application/json"
        },
        "bodyParams": "{\"username\": \"abcdefghij; echo vulnerable\", \"password\": \"abcdefghij; echo vulnerable\"}",
        "vulnTypes": [
            "COMMAND"
        ],
        "statusCode": 403,
        "responseBody": "<HTML><HEAD>\n<TITLE>Access Denied</TITLE> .... \",
        "responseHeaders": {
            "Content-Length": "368",
            "Content-Type": "text/html",
            "Date": "Wed, 30 Oct 2024 13:30:34 GMT",
            "Expires": "Wed, 30 Oct 2024 13:30:34 GMT",
            "Link": "<https://satchel.xxx.com>; rel=preconnect, <https://p11.techlab-cdn.com>; rel=preconnect; crossorigin, <https://tags.tiqcdn.com>; rel=preconnect",
            "Mime-Version": "1.0",
            "Strict-Transport-Security": "max-age=31536000 ; includeSubDomains"
        }
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2024-10-30T09:30:34.05102-04:00",
    "status": 0
}


```

