### PR TITLE
WebScan Response HeaderGrab Command

### DIFF
--- a/cmd/webserver.go
+++ b/cmd/webserver.go
@@ -51,6 +51,44 @@ func (a *WebScan) InitWebServerCommand() {
 
 	webServerCmd.AddCommand(probeCmd)
 
+	headerCmd := &cobra.Command{
+		Use:   "header",
+		Short: "Perform actions on a webservers headers",
+		Long:  `Perform actions on a webservers headers`,
+	}
+
+	headerGrabCmd := &cobra.Command{
+		Use:   "grab",
+		Short: "Grab the response headers given a URL of a webserver",
+		Long:  `Grab the response headers given a URL of a webserver`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report, err := webserver.PerformHeaderGrab(cmd.Context(), targets, timeout)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+			}
+			a.OutputSignal.Content = report
+
+		},
+	}
+
+	headerGrabCmd.Flags().StringSlice("targets", []string{}, "Url of target")
+	headerGrabCmd.Flags().Int("timeout", 5, "Timeout limit in seconds")
+	headerCmd.AddCommand(headerGrabCmd)
+	webServerCmd.AddCommand(headerCmd)
+
 	enumerationCmd := &cobra.Command{
 		Use:   "enumerate",
 		Short: "Enumerate a specific type of web server",

--- a/fern/definition/headergrab.yml
+++ b/fern/definition/headergrab.yml
@@ -1,0 +1,22 @@
+imports:
+  common: ./common.yml
+types:
+  HeaderResponseInfo:
+    properties:
+      statusCode: optional<integer>
+      headers: optional<map<string,string>>
+      error: optional<string>
+  HeaderRequestInfo:
+    properties:
+      method: common.HttpMethod
+      url: string
+  HeaderGrabInfo:
+    properties:
+      target: string
+      request: HeaderRequestInfo
+      response: optional<HeaderResponseInfo>
+      timestamp: datetime
+  HeaderGrabReport:
+    properties:
+      targets: optional<list<HeaderGrabInfo>>
+      errors: optional<list<string>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -928,6 +928,195 @@ func (g *GraphQlType) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+type HeaderGrabInfo struct {
+	Target    string              `json:"target" url:"target"`
+	Request   *HeaderRequestInfo  `json:"request,omitempty" url:"request,omitempty"`
+	Response  *HeaderResponseInfo `json:"response,omitempty" url:"response,omitempty"`
+	Timestamp time.Time           `json:"timestamp" url:"timestamp"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderGrabInfo) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderGrabInfo) UnmarshalJSON(data []byte) error {
+	type embed HeaderGrabInfo
+	var unmarshaler = struct {
+		embed
+		Timestamp *core.DateTime `json:"timestamp"`
+	}{
+		embed: embed(*h),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*h = HeaderGrabInfo(unmarshaler.embed)
+	h.Timestamp = unmarshaler.Timestamp.Time()
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderGrabInfo) MarshalJSON() ([]byte, error) {
+	type embed HeaderGrabInfo
+	var marshaler = struct {
+		embed
+		Timestamp *core.DateTime `json:"timestamp"`
+	}{
+		embed:     embed(*h),
+		Timestamp: core.NewDateTime(h.Timestamp),
+	}
+	return json.Marshal(marshaler)
+}
+
+func (h *HeaderGrabInfo) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
+type HeaderGrabReport struct {
+	Targets []*HeaderGrabInfo `json:"targets,omitempty" url:"targets,omitempty"`
+	Errors  []string          `json:"errors,omitempty" url:"errors,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderGrabReport) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderGrabReport) UnmarshalJSON(data []byte) error {
+	type unmarshaler HeaderGrabReport
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HeaderGrabReport(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderGrabReport) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
+type HeaderRequestInfo struct {
+	Method HttpMethod `json:"method" url:"method"`
+	Url    string     `json:"url" url:"url"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderRequestInfo) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderRequestInfo) UnmarshalJSON(data []byte) error {
+	type unmarshaler HeaderRequestInfo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HeaderRequestInfo(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderRequestInfo) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
+type HeaderResponseInfo struct {
+	StatusCode *int              `json:"statusCode,omitempty" url:"statusCode,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty" url:"headers,omitempty"`
+	Error      *string           `json:"error,omitempty" url:"error,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderResponseInfo) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderResponseInfo) UnmarshalJSON(data []byte) error {
+	type unmarshaler HeaderResponseInfo
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HeaderResponseInfo(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderResponseInfo) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
 type PageCaptureReport struct {
 	Target      string   `json:"target" url:"target"`
 	HtmlEncoded *string  `json:"html_encoded,omitempty" url:"html_encoded,omitempty"`

--- a/internal/webserver/headergrab.go
+++ b/internal/webserver/headergrab.go
@@ -1,0 +1,72 @@
+package webserver
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	webscan "github.com/Method-Security/webscan/generated/go"
+)
+
+func PerformHeaderGrab(ctx context.Context, targets []string, timeout int) (*webscan.HeaderGrabReport, error) {
+	report := &webscan.HeaderGrabReport{}
+	errors := []string{}
+
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	headerGrabInfos := []*webscan.HeaderGrabInfo{}
+	for _, target := range targets {
+		headerGrabInfo := webscan.HeaderGrabInfo{
+			Target:    target,
+			Timestamp: time.Now(),
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+		if err != nil {
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		headerGrabInfo.Request = &webscan.HeaderRequestInfo{
+			Method: webscan.HttpMethodGet,
+			Url:    target,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			errorMsg := err.Error()
+			headerGrabInfo.Response = &webscan.HeaderResponseInfo{
+				Error: &errorMsg,
+			}
+			headerGrabInfos = append(headerGrabInfos, &headerGrabInfo)
+			continue
+		}
+
+		headers := map[string]string{}
+		for key, values := range resp.Header {
+			headers[key] = values[0]
+		}
+		headerGrabInfo.Response = &webscan.HeaderResponseInfo{
+			StatusCode: &resp.StatusCode,
+			Headers:    headers,
+		}
+
+		err = resp.Body.Close()
+		if err != nil {
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		headerGrabInfos = append(headerGrabInfos, &headerGrabInfo)
+	}
+
+	report.Targets = headerGrabInfos
+	report.Errors = errors
+
+	return report, nil
+}


### PR DESCRIPTION
## CLI Structure

```
% method webserver header grab -h                                        
Grab the response headers given a URL of a webserver

Usage:
  webscan webserver header grab [flags]

Flags:
  -h, --help              help for header grab
      --targets strings   Url of target
      --timeout int       Timeout limit in seconds (default 5)

Global Flags:
  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
  -f, --output-file string   Path to output file. If blank, will output to STDOUT
  -q, --quiet                Suppress output
  -v, --verbose              Verbose output
```

## Data Example

```
{
    "content": {
        "targets": [
            {
                "target": "https://rei.com",
                "request": {
                    "method": "GET",
                    "url": "https://rei.com"
                },
                "response": {
                    "statusCode": 403,
                    "headers": {
                        "Cache-Control": "max-age=300",
                        "Content-Length": "355",
                        "Content-Type": "text/html",
                        "Date": "Tue, 05 Nov 2024 17:18:01 GMT",
                        "Expires": "Tue, 05 Nov 2024 17:23:01 GMT",
                        "Link": "<https://satchel.rei.com>; rel=preconnect, <https://p11.techlab-cdn.com>; rel=preconnect; crossorigin, <https://tags.tiqcdn.com>; rel=preconnect",
                        "Mime-Version": "1.0",
                        "Set-Cookie": "akamai_session=23.48.200.8.15878531730827081153; path=/; domain=.rei.com",
                        "Strict-Transport-Security": "max-age=31536000 ; includeSubDomains"
                    }
                },
                "timestamp": "2024-11-05T12:18:01-05:00"
            }
        ]
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2024-11-05T12:18:01.136433-05:00",
    "status": 0
}
```
