### PR TITLE
WebScan App Enumerate K8s: Rewrite w/o Nuclei + Clean Up

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -9,6 +9,7 @@ import (
 	webscan "github.com/Method-Security/webscan/generated/go"
 	"github.com/Method-Security/webscan/internal/graphql"
 	"github.com/Method-Security/webscan/internal/grpc"
+	"github.com/Method-Security/webscan/internal/k8s"
 	"github.com/Method-Security/webscan/internal/requests"
 	"github.com/Method-Security/webscan/internal/swagger"
 	"github.com/Method-Security/webscan/internal/vuln"
@@ -37,61 +38,47 @@ func (a *WebScan) initFingerprintCommand() {
 		
 The fingerprint command identifies the type of web application running on the target URL. 
 It uses custom templates to match URLs hosting different types of web applications or cloud services
-such as Swagger, gRPC, GraphQL, Kubernetes, and cloud buckets.`,
+such as Swagger, gRPC, GraphQL, and cloud buckets.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 			if target == "" {
 				err = errors.New("target flag is required")
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 
 			tags, err := cmd.Flags().GetStringSlice("tags")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 			if len(tags) == 0 {
-				tags = []string{"swagger", "k8s", "graphql", "grpc", "bucket"}
+				tags = []string{"swagger", "graphql", "grpc", "bucket"}
 			}
 			rawSeverity, err := cmd.Flags().GetStringSlice("severity")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 			severity := parseSeverityIntoString(rawSeverity)
 			defaultTemplateDirectory, err := cmd.Flags().GetString("defaultTemplateDirectory")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 
 			customTemplateDirectory, err := cmd.Flags().GetString("customTemplateDirectory")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
 			report, err := vuln.PerformVulnScan(cmd.Context(), target, tags, severity, defaultTemplateDirectory, customTemplateDirectory)
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 			}
 			a.OutputSignal.Content = report
 		},
@@ -116,87 +103,12 @@ The enumerate command details the routes and endpoints for an API application.
 It extracts information such as available endpoints, HTTP methods, query parameters, and authentication mechanisms.`,
 	}
 
-	enumerateCmd.AddCommand(a.initSwaggerEnumerateCommand())
-	enumerateCmd.AddCommand(a.initGrpcEnumerateCommand())
 	enumerateCmd.AddCommand(a.initGraphqlEnumerateCommand())
+	enumerateCmd.AddCommand(a.initGrpcEnumerateCommand())
+	enumerateCmd.AddCommand(a.initK8sEnumerateCommand())
+	enumerateCmd.AddCommand(a.initSwaggerEnumerateCommand())
 
 	a.AppCmd.AddCommand(enumerateCmd)
-}
-
-func (a *WebScan) initSwaggerEnumerateCommand() *cobra.Command {
-	swaggerCmd := &cobra.Command{
-		Use:   "swagger",
-		Short: "Perform a Swagger enumeration scan against a target",
-		Long: `Perform a Swagger enumeration scan against a target.
-		
-This involves fetching and parsing the Swagger (OpenAPI) documentation to extract details about the available endpoints, 
-HTTP methods, query parameters, and authentication mechanisms.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			defer a.OutputSignal.PanicHandler(cmd.Context())
-			target, err := cmd.Flags().GetString("target")
-			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
-				return
-			}
-			if target == "" {
-				err = errors.New("target flag is required")
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
-				return
-			}
-
-			noSandbox, err := cmd.Flags().GetBool("no-sandbox")
-			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
-				return
-			}
-
-			report := swagger.PerformSwaggerScan(cmd.Context(), target, noSandbox)
-			a.OutputSignal.Content = report
-		},
-	}
-
-	swaggerCmd.Flags().String("target", "", "URL target to perform Swagger enumeration against")
-	swaggerCmd.Flags().Bool("no-sandbox", false, "Disable sandbox mode for Swagger scan")
-	return swaggerCmd
-}
-
-func (a *WebScan) initGrpcEnumerateCommand() *cobra.Command {
-	grpcCmd := &cobra.Command{
-		Use:   "grpc",
-		Short: "Perform a gRPC enumeration scan against a target",
-		Long: `Perform a gRPC enumeration scan against a target.
-		
-This involves connecting to the gRPC server, using reflection to discover available services and methods, 
-and extracting details about the methods, including their input and output types.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			defer a.OutputSignal.PanicHandler(cmd.Context())
-			target, err := cmd.Flags().GetString("target")
-			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
-				return
-			}
-			if target == "" {
-				err = errors.New("target flag is required")
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
-				return
-			}
-			report := grpc.PerformGRPCScan(cmd.Context(), target)
-			a.OutputSignal.Content = report
-		},
-	}
-
-	grpcCmd.Flags().String("target", "", "URL target to perform gRPC enumeration against")
-	return grpcCmd
 }
 
 func (a *WebScan) initGraphqlEnumerateCommand() *cobra.Command {
@@ -211,25 +123,115 @@ and extracting details about the fields and their types.`,
 			defer a.OutputSignal.PanicHandler(cmd.Context())
 			target, err := cmd.Flags().GetString("target")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				a.OutputSignal.AddError(err)
 				return
 			}
-			if target == "" {
-				err = errors.New("target flag is required")
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
-				return
-			}
+
 			report := graphql.PerformGraphQLScan(cmd.Context(), target)
 			a.OutputSignal.Content = report
 		},
 	}
 
 	graphqlCmd.Flags().String("target", "", "URL target to perform GraphQL enumeration against")
+
+	_ = graphqlCmd.MarkFlagRequired("target")
+
 	return graphqlCmd
+}
+
+func (a *WebScan) initGrpcEnumerateCommand() *cobra.Command {
+	grpcCmd := &cobra.Command{
+		Use:   "grpc",
+		Short: "Perform a gRPC enumeration scan against a target",
+		Long: `Perform a gRPC enumeration scan against a target.
+		
+This involves connecting to the gRPC server, using reflection to discover available services and methods, 
+and extracting details about the methods, including their input and output types.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+			target, err := cmd.Flags().GetString("target")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report := grpc.PerformGRPCScan(cmd.Context(), target)
+			a.OutputSignal.Content = report
+		},
+	}
+
+	grpcCmd.Flags().String("target", "", "URL target to perform gRPC enumeration against")
+
+	_ = grpcCmd.MarkFlagRequired("target")
+
+	return grpcCmd
+}
+
+func (a *WebScan) initK8sEnumerateCommand() *cobra.Command {
+	k8sCmd := &cobra.Command{
+		Use:   "k8s",
+		Short: "Perform a K8s enumeration scan against a target",
+		Long:  `Perform a K8s enumeration scan against a target.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+			target, err := cmd.Flags().GetString("target")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report := k8s.PerformK8sScan(cmd.Context(), target, timeout)
+			a.OutputSignal.Content = report
+		},
+	}
+
+	k8sCmd.Flags().Int("timeout", 3000, "Timeout per request (milliseconds)")
+	k8sCmd.Flags().String("target", "", "URL target to perform K8s enumeration against")
+
+	_ = k8sCmd.MarkFlagRequired("target")
+
+	return k8sCmd
+}
+
+func (a *WebScan) initSwaggerEnumerateCommand() *cobra.Command {
+	swaggerCmd := &cobra.Command{
+		Use:   "swagger",
+		Short: "Perform a Swagger enumeration scan against a target",
+		Long: `Perform a Swagger enumeration scan against a target.
+		
+This involves fetching and parsing the Swagger (OpenAPI) documentation to extract details about the available endpoints, 
+HTTP methods, query parameters, and authentication mechanisms.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+			target, err := cmd.Flags().GetString("target")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			noSandbox, err := cmd.Flags().GetBool("no-sandbox")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report := swagger.PerformSwaggerScan(cmd.Context(), target, noSandbox)
+			a.OutputSignal.Content = report
+		},
+	}
+
+	swaggerCmd.Flags().String("target", "", "URL target to perform Swagger enumeration against")
+	swaggerCmd.Flags().Bool("no-sandbox", false, "Disable sandbox mode for Swagger scan")
+
+	_ = swaggerCmd.MarkFlagRequired("target")
+
+	return swaggerCmd
 }
 
 func (a *WebScan) initRequestsCommand() {

--- a/fern/definition/k8s.yml
+++ b/fern/definition/k8s.yml
@@ -1,0 +1,18 @@
+imports: 
+  common: ./common.yml
+types:
+  K8sPathInfo:
+    properties:
+      path: string 
+      method: common.HttpMethod
+      response_status: optional<integer>
+      response_headers: optional<map<string, string>>
+      response_body: optional<string>
+      finding: boolean
+      timestamp: datetime
+  K8sReport:
+    properties:
+      target: string
+      k8sPaths: optional<list<K8sPathInfo>>
+      isCluster: boolean
+      errors: optional<list<string>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -928,6 +928,115 @@ func (g *GraphQlType) String() string {
 	return fmt.Sprintf("%#v", g)
 }
 
+type K8SPathInfo struct {
+	Path            string            `json:"path" url:"path"`
+	Method          HttpMethod        `json:"method" url:"method"`
+	ResponseStatus  *int              `json:"response_status,omitempty" url:"response_status,omitempty"`
+	ResponseHeaders map[string]string `json:"response_headers,omitempty" url:"response_headers,omitempty"`
+	ResponseBody    *string           `json:"response_body,omitempty" url:"response_body,omitempty"`
+	Finding         bool              `json:"finding" url:"finding"`
+	Timestamp       time.Time         `json:"timestamp" url:"timestamp"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (k *K8SPathInfo) GetExtraProperties() map[string]interface{} {
+	return k.extraProperties
+}
+
+func (k *K8SPathInfo) UnmarshalJSON(data []byte) error {
+	type embed K8SPathInfo
+	var unmarshaler = struct {
+		embed
+		Timestamp *core.DateTime `json:"timestamp"`
+	}{
+		embed: embed(*k),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
+		return err
+	}
+	*k = K8SPathInfo(unmarshaler.embed)
+	k.Timestamp = unmarshaler.Timestamp.Time()
+
+	extraProperties, err := core.ExtractExtraProperties(data, *k)
+	if err != nil {
+		return err
+	}
+	k.extraProperties = extraProperties
+
+	k._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (k *K8SPathInfo) MarshalJSON() ([]byte, error) {
+	type embed K8SPathInfo
+	var marshaler = struct {
+		embed
+		Timestamp *core.DateTime `json:"timestamp"`
+	}{
+		embed:     embed(*k),
+		Timestamp: core.NewDateTime(k.Timestamp),
+	}
+	return json.Marshal(marshaler)
+}
+
+func (k *K8SPathInfo) String() string {
+	if len(k._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(k._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(k); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", k)
+}
+
+type K8SReport struct {
+	Target    string         `json:"target" url:"target"`
+	K8SPaths  []*K8SPathInfo `json:"k8sPaths,omitempty" url:"k8sPaths,omitempty"`
+	IsCluster bool           `json:"isCluster" url:"isCluster"`
+	Errors    []string       `json:"errors,omitempty" url:"errors,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (k *K8SReport) GetExtraProperties() map[string]interface{} {
+	return k.extraProperties
+}
+
+func (k *K8SReport) UnmarshalJSON(data []byte) error {
+	type unmarshaler K8SReport
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*k = K8SReport(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *k)
+	if err != nil {
+		return err
+	}
+	k.extraProperties = extraProperties
+
+	k._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (k *K8SReport) String() string {
+	if len(k._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(k._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(k); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", k)
+}
+
 type PageCaptureReport struct {
 	Target      string   `json:"target" url:"target"`
 	HtmlEncoded *string  `json:"html_encoded,omitempty" url:"html_encoded,omitempty"`

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -1,0 +1,95 @@
+package k8s
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	webscan "github.com/Method-Security/webscan/generated/go"
+)
+
+func PerformK8sScan(ctx context.Context, target string, timeout int) *webscan.K8SReport {
+	resources := &webscan.K8SReport{Target: target, IsCluster: false}
+	var errors []string
+
+	k8sHeaders := []string{"X-Kubernetes-Pf-Flowschema-Uid", "X-Kubernetes-Pf-Prioritylevel-Uid"}
+	paths := []string{"/api", "/livez", "/version"}
+
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	isCluster := false
+	var K8sPaths []*webscan.K8SPathInfo
+	for _, path := range paths {
+		pathHit := false
+		fullURL := fmt.Sprintf("%s%s", target, path)
+		req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+		if err != nil {
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		err = resp.Body.Close()
+		if err != nil {
+			errors = append(errors, err.Error())
+			continue
+		}
+
+		// Check for Kubernetes headers
+		headers := make(map[string]string)
+		for key, values := range resp.Header {
+			headers[key] = values[0]
+			if contains(k8sHeaders, key) {
+				pathHit = true
+			}
+		}
+
+		// Marshal data
+		bodyStr := string(body)
+		statusCode := resp.StatusCode
+		pathInfo := webscan.K8SPathInfo{
+			Path:            path,
+			Method:          webscan.HttpMethodGet,
+			ResponseHeaders: headers,
+			ResponseBody:    &bodyStr,
+			ResponseStatus:  &statusCode,
+			Timestamp:       time.Now(),
+			Finding:         pathHit,
+		}
+		K8sPaths = append(K8sPaths, &pathInfo)
+		isCluster = isCluster || pathHit
+	}
+
+	resources.K8SPaths = K8sPaths
+	resources.IsCluster = isCluster
+	resources.Errors = errors
+	return resources
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Done

- Rewrote external enumerate K8s CLI w/o Nuclei
- Clean up some other code

## Data Example

```
{
    "content": {
        "target": "https://XXXXX.gr7.us-east-1.eks.amazonaws.com",
        "k8sPaths": [
            {
                "path": "/api",
                "method": "GET",
                "response_status": 403,
                "response_headers": {
                    "Audit-Id": "XXXX",
                    "Cache-Control": "no-cache, private",
                    "Content-Length": "188",
                    "Content-Type": "application/json",
                    "Date": "Mon, 11 Nov 2024 18:47:23 GMT",
                    "X-Content-Type-Options": "nosniff",
                    "X-Kubernetes-Pf-Flowschema-Uid": "XXXXX",
                    "X-Kubernetes-Pf-Prioritylevel-Uid": "XXXX"
                },
                "response_body": "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"forbidden: User \\\"system:anonymous\\\" cannot get path \\\"/api\\\"\",\"reason\":\"Forbidden\",\"details\":{},\"code\":403}\n",
                "finding": true,
                "timestamp": "2024-11-11T13:47:23-05:00"
            },
            {
                "path": "/livez",
                "method": "GET",
                "response_status": 200,
                "response_headers": {
                    "Audit-Id": "XXXX",
                    "Cache-Control": "no-cache, private",
                    "Content-Length": "2",
                    "Content-Type": "text/plain; charset=utf-8",
                    "Date": "Mon, 11 Nov 2024 18:47:23 GMT",
                    "X-Content-Type-Options": "nosniff",
                    "X-Kubernetes-Pf-Flowschema-Uid": "XXXX",
                    "X-Kubernetes-Pf-Prioritylevel-Uid": "XXXX"
                },
                "response_body": "ok",
                "finding": true,
                "timestamp": "2024-11-11T13:47:23-05:00"
            },
            {
                "path": "/version",
                "method": "GET",
                "response_status": 200,
                "response_headers": {
                    "Audit-Id": "XXXX",
                    "Cache-Control": "no-cache, private",
                    "Content-Length": "277",
                    "Content-Type": "application/json",
                    "Date": "Mon, 11 Nov 2024 18:47:23 GMT",
                    "X-Kubernetes-Pf-Flowschema-Uid": "XXXX",
                    "X-Kubernetes-Pf-Prioritylevel-Uid": "XXXX"
                },
                "response_body": "{\n  \"major\": \"1\",\n  \"minor\": \"28+\",\n  \"gitVersion\": \"v1.28.13-eks-a737599\",\n  \"gitCommit\": \"XXXXX\",\n  \"gitTreeState\": \"clean\",\n  \"buildDate\": \"2024-08-26T21:27:49Z\",\n  \"goVersion\": \"go1.22.5\",\n  \"compiler\": \"gc\",\n  \"platform\": \"linux/amd64\"\n}",
                "finding": true,
                "timestamp": "2024-11-11T13:47:23-05:00"
            }
        ],
        "isCluster": true
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2024-11-11T13:47:23.433571-05:00",
    "status": 0
}
```

