### PR TITLE
Web Scan Request Model Fix

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	webscan "github.com/Method-Security/webscan/generated/go"
 	"github.com/Method-Security/webscan/internal/graphql"
@@ -278,7 +277,6 @@ The requests command allows you to send custom HTTP requests to a target URL wit
 			report := requests.PerformRequestScan(baseURL, path, method, params, vulnTypes)
 
 			if len(report.Errors) > 0 {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", err)
 				a.OutputSignal.Status = 1
 			}
 
@@ -357,9 +355,7 @@ func DecodeAndSetParams(cmd *cobra.Command, isEncoded bool) (webscan.RequestPara
 	}
 
 	if bodyParams, err := getFlagValue("bodyParams"); err == nil {
-		if err := decodeJSON(bodyParams); err != nil {
-			return params, err
-		}
+		params.BodyParams = bodyParams
 	}
 
 	if formParams, err := getFlagValue("formParams"); err == nil {

--- a/fern/definition/fingerprint.yml
+++ b/fern/definition/fingerprint.yml
@@ -7,6 +7,7 @@ types:
     enum:
       - MD2RSA
       - MD5RSA
+      - MD5ECDSA
       - SHA1RSA
       - SHA256RSA
       - SHA384RSA
@@ -23,10 +24,19 @@ types:
       - Ed25519
   PublicKeyAlgorithm:
     enum:
-      - RSA
+      - DES
+      - DH1024
+      - DH512
+      - DH768
       - DSA
+      - DSA1024
       - ECDSA
+      - ECDSASHA1
+      - ECDHSHA1
       - Ed25519
+      - RC4
+      - RSA
+      - RSA1024
       - Unknown
   Certificate:
     properties:

--- a/fern/definition/requests.yaml
+++ b/fern/definition/requests.yaml
@@ -12,13 +12,13 @@ types:
       pathParams: optional<map<string, string>>
       queryParams: optional<map<string, string>>
       headerParams: optional<map<string, string>>
-      bodyParams: optional<string>  
+      bodyParams: optional<string>
       formParams: optional<map<string, string>>  
-      multipartParams: optional<map<string, string>>  
+      multipartParams: optional<map<string, string>>
       vulnTypes: optional<list<VulnType>>
-      statusCode: integer
-      responseBody: string
-      responseHeaders: map<string, string>
+      statusCode: optional<integer>
+      responseBody: optional<string>
+      responseHeaders: optional<map<string, string>>
       errors: optional<list<string>>
 
   VulnType:

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -263,23 +263,50 @@ func (h *HttpHeaders) String() string {
 type PublicKeyAlgorithm string
 
 const (
-	PublicKeyAlgorithmRsa     PublicKeyAlgorithm = "RSA"
-	PublicKeyAlgorithmDsa     PublicKeyAlgorithm = "DSA"
-	PublicKeyAlgorithmEcdsa   PublicKeyAlgorithm = "ECDSA"
-	PublicKeyAlgorithmEd25519 PublicKeyAlgorithm = "Ed25519"
-	PublicKeyAlgorithmUnknown PublicKeyAlgorithm = "Unknown"
+	PublicKeyAlgorithmDes       PublicKeyAlgorithm = "DES"
+	PublicKeyAlgorithmDh1024    PublicKeyAlgorithm = "DH1024"
+	PublicKeyAlgorithmDh512     PublicKeyAlgorithm = "DH512"
+	PublicKeyAlgorithmDh768     PublicKeyAlgorithm = "DH768"
+	PublicKeyAlgorithmDsa       PublicKeyAlgorithm = "DSA"
+	PublicKeyAlgorithmDsa1024   PublicKeyAlgorithm = "DSA1024"
+	PublicKeyAlgorithmEcdsa     PublicKeyAlgorithm = "ECDSA"
+	PublicKeyAlgorithmEcdsasha1 PublicKeyAlgorithm = "ECDSASHA1"
+	PublicKeyAlgorithmEcdhsha1  PublicKeyAlgorithm = "ECDHSHA1"
+	PublicKeyAlgorithmEd25519   PublicKeyAlgorithm = "Ed25519"
+	PublicKeyAlgorithmRc4       PublicKeyAlgorithm = "RC4"
+	PublicKeyAlgorithmRsa       PublicKeyAlgorithm = "RSA"
+	PublicKeyAlgorithmRsa1024   PublicKeyAlgorithm = "RSA1024"
+	PublicKeyAlgorithmUnknown   PublicKeyAlgorithm = "Unknown"
 )
 
 func NewPublicKeyAlgorithmFromString(s string) (PublicKeyAlgorithm, error) {
 	switch s {
-	case "RSA":
-		return PublicKeyAlgorithmRsa, nil
+	case "DES":
+		return PublicKeyAlgorithmDes, nil
+	case "DH1024":
+		return PublicKeyAlgorithmDh1024, nil
+	case "DH512":
+		return PublicKeyAlgorithmDh512, nil
+	case "DH768":
+		return PublicKeyAlgorithmDh768, nil
 	case "DSA":
 		return PublicKeyAlgorithmDsa, nil
+	case "DSA1024":
+		return PublicKeyAlgorithmDsa1024, nil
 	case "ECDSA":
 		return PublicKeyAlgorithmEcdsa, nil
+	case "ECDSASHA1":
+		return PublicKeyAlgorithmEcdsasha1, nil
+	case "ECDHSHA1":
+		return PublicKeyAlgorithmEcdhsha1, nil
 	case "Ed25519":
 		return PublicKeyAlgorithmEd25519, nil
+	case "RC4":
+		return PublicKeyAlgorithmRc4, nil
+	case "RSA":
+		return PublicKeyAlgorithmRsa, nil
+	case "RSA1024":
+		return PublicKeyAlgorithmRsa1024, nil
 	case "Unknown":
 		return PublicKeyAlgorithmUnknown, nil
 	}
@@ -296,6 +323,7 @@ type SignatureAlgorithm string
 const (
 	SignatureAlgorithmMd2Rsa       SignatureAlgorithm = "MD2RSA"
 	SignatureAlgorithmMd5Rsa       SignatureAlgorithm = "MD5RSA"
+	SignatureAlgorithmMd5Ecdsa     SignatureAlgorithm = "MD5ECDSA"
 	SignatureAlgorithmSha1Rsa      SignatureAlgorithm = "SHA1RSA"
 	SignatureAlgorithmSha256Rsa    SignatureAlgorithm = "SHA256RSA"
 	SignatureAlgorithmSha384Rsa    SignatureAlgorithm = "SHA384RSA"
@@ -318,6 +346,8 @@ func NewSignatureAlgorithmFromString(s string) (SignatureAlgorithm, error) {
 		return SignatureAlgorithmMd2Rsa, nil
 	case "MD5RSA":
 		return SignatureAlgorithmMd5Rsa, nil
+	case "MD5ECDSA":
+		return SignatureAlgorithmMd5Ecdsa, nil
 	case "SHA1RSA":
 		return SignatureAlgorithmSha1Rsa, nil
 	case "SHA256RSA":

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -1257,8 +1257,8 @@ type RequestReport struct {
 	FormParams      map[string]string `json:"formParams,omitempty" url:"formParams,omitempty"`
 	MultipartParams map[string]string `json:"multipartParams,omitempty" url:"multipartParams,omitempty"`
 	VulnTypes       []VulnType        `json:"vulnTypes,omitempty" url:"vulnTypes,omitempty"`
-	StatusCode      int               `json:"statusCode" url:"statusCode"`
-	ResponseBody    string            `json:"responseBody" url:"responseBody"`
+	StatusCode      *int              `json:"statusCode,omitempty" url:"statusCode,omitempty"`
+	ResponseBody    *string           `json:"responseBody,omitempty" url:"responseBody,omitempty"`
 	ResponseHeaders map[string]string `json:"responseHeaders,omitempty" url:"responseHeaders,omitempty"`
 	Errors          []string          `json:"errors,omitempty" url:"errors,omitempty"`
 

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -40,6 +40,9 @@ func PerformRequestScan(baseURL, path, method string, params webscan.RequestPara
 	report.QueryParams = parsedParams.QueryParams
 	report.HeaderParams = parsedParams.HeaderParams
 	report.BodyParams = &parsedParams.BodyParams
+	if parsedParams.BodyParams == "" {
+		report.BodyParams = nil
+	}
 	report.FormParams = parsedParams.FormParams
 	report.MultipartParams = parsedParams.MultipartParams
 
@@ -179,6 +182,8 @@ func parseAllParams(params webscan.RequestParams) (webscan.ParsedParams, error) 
 		return parsed, fmt.Errorf("failed to parse header parameters: %v", err)
 	}
 
+	parsed.BodyParams = params.BodyParams
+
 	parsed.FormParams, err = parseJSONParams(params.FormParams)
 	if err != nil {
 		return parsed, fmt.Errorf("failed to parse form parameters: %v", err)
@@ -306,8 +311,8 @@ func populateReport(report *webscan.RequestReport, statusCode int, headers map[s
 		}
 	}
 
-	report.ResponseBody = body
-	report.StatusCode = statusCode
+	report.ResponseBody = &body
+	report.StatusCode = &statusCode
 
 	if len(params.PathParams) > 0 {
 		report.PathParams = params.PathParams


### PR DESCRIPTION
## Update

* Update returned model so that response fields are optional
* Also cleaned up `BodyParms` as they weren't being parsed

## Data

```
{
    "content": {
        "baseUrl": "https://xxxx.biz",
        "path": "/",
        "method": "GET",
        "errors": [
            "failed to perform request: Get \"https://xxxx.biz/\": tls: failed to verify certificate: x509: certificate is valid for *.xxxx.net, xxxx.net, not xxxx.biz"
        ]
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2024-11-12T23:17:09.420097-05:00",
    "status": 1
}
```