### PR TITLE
Web Scan Header Server Overload Cmd

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,15 +1,11 @@
 package cmd
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 
-	webscan "github.com/Method-Security/webscan/generated/go"
 	"github.com/Method-Security/webscan/internal/graphql"
 	"github.com/Method-Security/webscan/internal/grpc"
 	"github.com/Method-Security/webscan/internal/k8s"
-	"github.com/Method-Security/webscan/internal/requests"
 	"github.com/Method-Security/webscan/internal/swagger"
 	"github.com/Method-Security/webscan/internal/vuln"
 	"github.com/spf13/cobra"
@@ -26,7 +22,6 @@ func (a *WebScan) InitAppCommand() {
 	a.RootCmd.AddCommand(a.AppCmd)
 	a.initFingerprintCommand()
 	a.initEnumerateCommand()
-	a.initRequestsCommand()
 }
 
 func (a *WebScan) initFingerprintCommand() {
@@ -231,146 +226,4 @@ HTTP methods, query parameters, and authentication mechanisms.`,
 	_ = swaggerCmd.MarkFlagRequired("target")
 
 	return swaggerCmd
-}
-
-func (a *WebScan) initRequestsCommand() {
-	requestsCmd := &cobra.Command{
-		Use:   "requests",
-		Short: "Perform custom requests against a target route",
-		Long: `Perform custom requests against a target route of an API Application using specified parameters.
-		
-The requests command allows you to send custom HTTP requests to a target URL with specified method, path, and optional parameters including query, path, header, body, form, and multipart form data.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			defer a.OutputSignal.PanicHandler(cmd.Context())
-			baseURL, err := cmd.Flags().GetString("baseUrl")
-			if err != nil || baseURL == "" {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			path, err := cmd.Flags().GetString("path")
-			if err != nil || path == "" {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			method, err := cmd.Flags().GetString("method")
-			if err != nil || method == "" {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			isEncoded, err := cmd.Flags().GetBool("encodedParams")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			params, err := DecodeAndSetParams(cmd, isEncoded)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			vulnTypes, _ := cmd.Flags().GetStringSlice("vulnType")
-
-			report := requests.PerformRequestScan(baseURL, path, method, params, vulnTypes)
-
-			if len(report.Errors) > 0 {
-				a.OutputSignal.Status = 1
-			}
-
-			a.OutputSignal.Content = report
-		},
-	}
-
-	requestsCmd.Flags().String("baseUrl", "", "Base URL of the target")
-	requestsCmd.Flags().String("path", "", "Path to append to the base URL")
-	requestsCmd.Flags().String("method", "", "HTTP method to use (GET, POST, etc.)")
-	requestsCmd.Flags().String("pathParams", "", "Path parameters as a JSON string (optional)")
-	requestsCmd.Flags().String("queryParams", "", "Query parameters as a JSON string (optional)")
-	requestsCmd.Flags().String("headerParams", "", "Header parameters as a JSON string (optional)")
-	requestsCmd.Flags().String("bodyParams", "", "Body parameters as a JSON string (optional)")
-	requestsCmd.Flags().String("formParams", "", "Form parameters as a JSON string (optional)")
-	requestsCmd.Flags().String("multipartParams", "", "Multipart form parameters as a JSON string (optional)")
-	requestsCmd.Flags().Bool("encodedParams", false, "Request parameters base64 encoded")
-
-	requestsCmd.Flags().StringSlice("vulnType", []string{}, "Types of vulnerabilities to check (optional)")
-
-	_ = requestsCmd.MarkFlagRequired("baseUrl")
-	_ = requestsCmd.MarkFlagRequired("path")
-	_ = requestsCmd.MarkFlagRequired("method")
-
-	a.AppCmd.AddCommand(requestsCmd)
-}
-
-// DecodeAndSetParams decodes flags as base64 if isEncoded is true, and parses JSON for all params.
-func DecodeAndSetParams(cmd *cobra.Command, isEncoded bool) (webscan.RequestParams, error) {
-	getFlagValue := func(flagName string) (string, error) {
-		flagValue := cmd.Flag(flagName).Value.String()
-		if isEncoded {
-			decodedBytes, err := base64.StdEncoding.DecodeString(flagValue)
-			if err != nil {
-				return "", err
-			}
-			return string(decodedBytes), nil
-		}
-		return flagValue, nil
-	}
-
-	params := webscan.RequestParams{}
-
-	// Helper function to test if decode JSON for each parameter
-	decodeJSON := func(flagValue string) error {
-		if flagValue == "" {
-			return nil
-		}
-		var result map[string]string
-		if err := json.Unmarshal([]byte(flagValue), &result); err != nil {
-			return errors.New("failed to parse as JSON: " + err.Error())
-		}
-		return nil
-	}
-
-	// Decode and parse each parameter
-	if pathParams, err := getFlagValue("pathParams"); err == nil {
-		if err := decodeJSON(pathParams); err != nil {
-			return params, err
-		}
-		params.PathParams = pathParams
-	}
-
-	if queryParams, err := getFlagValue("queryParams"); err == nil {
-		if err := decodeJSON(queryParams); err != nil {
-			return params, err
-		}
-		params.QueryParams = queryParams
-	}
-
-	if headerParams, err := getFlagValue("headerParams"); err == nil {
-		if err := decodeJSON(headerParams); err != nil {
-			return params, err
-		}
-		params.HeaderParams = headerParams
-	}
-
-	if bodyParams, err := getFlagValue("bodyParams"); err == nil {
-		params.BodyParams = bodyParams
-	}
-
-	if formParams, err := getFlagValue("formParams"); err == nil {
-		if err := decodeJSON(formParams); err != nil {
-			return params, err
-		}
-		params.FormParams = formParams
-	}
-
-	if multipartParams, err := getFlagValue("multipartParams"); err == nil {
-		if err := decodeJSON(multipartParams); err != nil {
-			return params, err
-		}
-		params.MultipartParams = multipartParams
-	}
-
-	return params, nil
 }

--- a/cmd/requests.go
+++ b/cmd/requests.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"encoding/base64"
+
+	webscan "github.com/Method-Security/webscan/generated/go"
+	"github.com/Method-Security/webscan/internal/requests"
+	"github.com/spf13/cobra"
+)
+
+func (a *WebScan) InitRequestsCommand() {
+
+	requestsCmd := &cobra.Command{
+		Use:   "requests",
+		Short: "Perform a custom request against a target",
+		Long:  `Perform a custom reques against a target using specified parameters`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
+			// Required parameters
+			baseURL, err := cmd.Flags().GetString("baseUrl")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			path, err := cmd.Flags().GetString("path")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			method, err := cmd.Flags().GetString("method")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Optional parameters
+			isEncoded, err := cmd.Flags().GetBool("encodedParams")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			params, err := DecodeAndSetParams(cmd, isEncoded)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			vulnTypes, err := cmd.Flags().GetStringSlice("vulnType")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report := requests.PerformRequestScan(baseURL, path, method, *params, vulnTypes)
+			if len(report.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
+
+			a.OutputSignal.Content = report
+		},
+	}
+
+	requestsCmd.PersistentFlags().String("baseUrl", "", "Base URL of the target")
+	requestsCmd.PersistentFlags().String("path", "", "Path to append to the base URL")
+	requestsCmd.PersistentFlags().String("method", "", "HTTP method to use (GET, POST, etc.)")
+	requestsCmd.Flags().String("pathParams", "", "Path parameters as a JSON string (optional)")
+	requestsCmd.Flags().String("queryParams", "", "Query parameters as a JSON string (optional)")
+	requestsCmd.Flags().String("headerParams", "", "Header parameters as a JSON string (optional)")
+	requestsCmd.Flags().String("bodyParams", "", "Body parameters as a JSON string (optional)")
+	requestsCmd.Flags().String("formParams", "", "Form parameters as a JSON string (optional)")
+	requestsCmd.Flags().String("multipartParams", "", "Multipart form parameters as a JSON string (optional)")
+	requestsCmd.Flags().Bool("encodedParams", false, "Request parameters base64 encoded")
+	requestsCmd.PersistentFlags().StringSlice("vulnType", []string{}, "Types of vulnerabilities to check (optional)")
+
+	_ = requestsCmd.MarkFlagRequired("baseUrl")
+	_ = requestsCmd.MarkFlagRequired("path")
+	_ = requestsCmd.MarkFlagRequired("method")
+
+	headerCmd := &cobra.Command{
+		Use:   "headers",
+		Short: "Perform specfic header injection requests",
+		Long:  `Perform specfic header injection requests`,
+	}
+
+	serverOverloadCmd := &cobra.Command{
+		Use:   "serveroverload",
+		Short: "Serveroverload header injection requests.",
+		Long:  `Execute HTTP requests with crafted headers to identify potential server overload vulnerabilities triggered by specfic headers.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
+			// Required Parameters
+			baseURL, err := cmd.Flags().GetString("baseUrl")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			path, err := cmd.Flags().GetString("path")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			method, err := cmd.Flags().GetString("method")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Server Overload parameters
+			payloadSize, err := cmd.Flags().GetInt("size")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report := requests.PerformServerOverloadHeaderRequests(baseURL, path, method, payloadSize)
+			if len(report.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
+
+			a.OutputSignal.Content = report
+
+		},
+	}
+	serverOverloadCmd.Flags().Int("size", 100, "Character and Header count for dynamically configured Server Overload headers")
+
+	headerCmd.AddCommand(serverOverloadCmd)
+	requestsCmd.AddCommand(headerCmd)
+	a.RootCmd.AddCommand(requestsCmd)
+}
+
+// DecodeAndSetParams decodes flags as base64 if isEncoded is true, and parses JSON for all params.
+func DecodeAndSetParams(cmd *cobra.Command, isEncoded bool) (*webscan.RequestParams, error) {
+	getFlagValue := func(flagName string) (string, error) {
+		flagValue := cmd.Flag(flagName).Value.String()
+		if isEncoded {
+			decodedBytes, err := base64.StdEncoding.DecodeString(flagValue)
+			if err != nil {
+				return "", err
+			}
+			return string(decodedBytes), nil
+		}
+		return flagValue, nil
+	}
+	params := webscan.RequestParams{}
+
+	// Decode and parse each parameter
+	pathParams, err := getFlagValue("pathParams")
+	if err != nil {
+		return nil, err
+	}
+	params.PathParams = pathParams
+
+	queryParams, err := getFlagValue("queryParams")
+	if err != nil {
+		return nil, err
+	}
+	params.QueryParams = queryParams
+
+	headerParams, err := getFlagValue("headerParams")
+	if err != nil {
+		return nil, err
+	}
+	params.HeaderParams = headerParams
+
+	bodyParams, err := getFlagValue("bodyParams")
+	if err != nil {
+		return nil, err
+	}
+	params.BodyParams = bodyParams
+
+	formParams, err := getFlagValue("formParams")
+	if err != nil {
+		return nil, err
+	}
+	params.FormParams = formParams
+
+	multipartParams, err := getFlagValue("multipartParams")
+	if err != nil {
+		return nil, err
+	}
+	params.MultipartParams = multipartParams
+
+	return &params, nil
+}

--- a/fern/definition/requests.yaml
+++ b/fern/definition/requests.yaml
@@ -1,9 +1,35 @@
 imports:
   routes: ./routes.yml
   common: ./common.yml
-
 types:
-
+  VulnType:
+    enum:
+    - IDOR
+    - PATH_TRAVERSAL
+    - RCE
+    - SQLI
+    - XSS
+    - CORS_HEADER_INJECTION
+    - ESCAPE_HEADERS_INJECTION
+    - HTTP_HEADERS_INJECTION
+    - SENSITIVE_EXPOSED_HEADER_INJECTION
+    - SERVER_OVERLOAD_HEADER_INJECTION
+  RequestParams:
+    properties:
+      pathParams: string
+      queryParams: string
+      headerParams: string
+      bodyParams: string
+      formParams: string
+      multipartParams: string
+  ParsedRequestParams:
+    properties:
+      pathParams: map<string, string>
+      queryParams: map<string, string>
+      headerParams: map<string, string>
+      bodyParams: string
+      formParams: map<string, string>
+      multipartParams: map<string, string>
   RequestReport:
     properties:
       baseUrl: string
@@ -20,32 +46,7 @@ types:
       responseBody: optional<string>
       responseHeaders: optional<map<string, string>>
       errors: optional<list<string>>
-
-  VulnType:
-    enum:
-      - COMMAND
-      - SQL
-      - XSS
-      - AUTH
-      - SENSITIVEERROR
-      - SQLINJECTION
-      - TEMPLATE
-      - NOSQL
-
-  RequestParams:
+  MultipleRequestReport:
     properties:
-      pathParams: string
-      queryParams: string
-      headerParams: string
-      bodyParams: string
-      formParams: string
-      multipartParams: string
-
-  ParsedParams:
-    properties:
-      pathParams: map<string, string>
-      queryParams: map<string, string>
-      headerParams: map<string, string>
-      bodyParams: string
-      formParams: map<string, string>
-      multipartParams: map<string, string>
+      requests: list<RequestReport>
+      errors: optional<list<string>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -1154,7 +1154,49 @@ func (p *PageScreenshotReport) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
-type ParsedParams struct {
+type MultipleRequestReport struct {
+	Requests []*RequestReport `json:"requests,omitempty" url:"requests,omitempty"`
+	Errors   []string         `json:"errors,omitempty" url:"errors,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (m *MultipleRequestReport) GetExtraProperties() map[string]interface{} {
+	return m.extraProperties
+}
+
+func (m *MultipleRequestReport) UnmarshalJSON(data []byte) error {
+	type unmarshaler MultipleRequestReport
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = MultipleRequestReport(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *m)
+	if err != nil {
+		return err
+	}
+	m.extraProperties = extraProperties
+
+	m._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (m *MultipleRequestReport) String() string {
+	if len(m._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(m._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(m); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", m)
+}
+
+type ParsedRequestParams struct {
 	PathParams      map[string]string `json:"pathParams,omitempty" url:"pathParams,omitempty"`
 	QueryParams     map[string]string `json:"queryParams,omitempty" url:"queryParams,omitempty"`
 	HeaderParams    map[string]string `json:"headerParams,omitempty" url:"headerParams,omitempty"`
@@ -1166,17 +1208,17 @@ type ParsedParams struct {
 	_rawJSON        json.RawMessage
 }
 
-func (p *ParsedParams) GetExtraProperties() map[string]interface{} {
+func (p *ParsedRequestParams) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
-func (p *ParsedParams) UnmarshalJSON(data []byte) error {
-	type unmarshaler ParsedParams
+func (p *ParsedRequestParams) UnmarshalJSON(data []byte) error {
+	type unmarshaler ParsedRequestParams
 	var value unmarshaler
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	*p = ParsedParams(value)
+	*p = ParsedRequestParams(value)
 
 	extraProperties, err := core.ExtractExtraProperties(data, *p)
 	if err != nil {
@@ -1188,7 +1230,7 @@ func (p *ParsedParams) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *ParsedParams) String() string {
+func (p *ParsedRequestParams) String() string {
 	if len(p._rawJSON) > 0 {
 		if value, err := core.StringifyJSON(p._rawJSON); err == nil {
 			return value
@@ -1303,34 +1345,40 @@ func (r *RequestReport) String() string {
 type VulnType string
 
 const (
-	VulnTypeCommand        VulnType = "COMMAND"
-	VulnTypeSql            VulnType = "SQL"
-	VulnTypeXss            VulnType = "XSS"
-	VulnTypeAuth           VulnType = "AUTH"
-	VulnTypeSensitiveerror VulnType = "SENSITIVEERROR"
-	VulnTypeSqlinjection   VulnType = "SQLINJECTION"
-	VulnTypeTemplate       VulnType = "TEMPLATE"
-	VulnTypeNosql          VulnType = "NOSQL"
+	VulnTypeIdor                            VulnType = "IDOR"
+	VulnTypePathTraversal                   VulnType = "PATH_TRAVERSAL"
+	VulnTypeRce                             VulnType = "RCE"
+	VulnTypeSqli                            VulnType = "SQLI"
+	VulnTypeXss                             VulnType = "XSS"
+	VulnTypeCorsHeaderInjection             VulnType = "CORS_HEADER_INJECTION"
+	VulnTypeEscapeHeadersInjection          VulnType = "ESCAPE_HEADERS_INJECTION"
+	VulnTypeHttpHeadersInjection            VulnType = "HTTP_HEADERS_INJECTION"
+	VulnTypeSensitiveExposedHeaderInjection VulnType = "SENSITIVE_EXPOSED_HEADER_INJECTION"
+	VulnTypeServerOverloadHeaderInjection   VulnType = "SERVER_OVERLOAD_HEADER_INJECTION"
 )
 
 func NewVulnTypeFromString(s string) (VulnType, error) {
 	switch s {
-	case "COMMAND":
-		return VulnTypeCommand, nil
-	case "SQL":
-		return VulnTypeSql, nil
+	case "IDOR":
+		return VulnTypeIdor, nil
+	case "PATH_TRAVERSAL":
+		return VulnTypePathTraversal, nil
+	case "RCE":
+		return VulnTypeRce, nil
+	case "SQLI":
+		return VulnTypeSqli, nil
 	case "XSS":
 		return VulnTypeXss, nil
-	case "AUTH":
-		return VulnTypeAuth, nil
-	case "SENSITIVEERROR":
-		return VulnTypeSensitiveerror, nil
-	case "SQLINJECTION":
-		return VulnTypeSqlinjection, nil
-	case "TEMPLATE":
-		return VulnTypeTemplate, nil
-	case "NOSQL":
-		return VulnTypeNosql, nil
+	case "CORS_HEADER_INJECTION":
+		return VulnTypeCorsHeaderInjection, nil
+	case "ESCAPE_HEADERS_INJECTION":
+		return VulnTypeEscapeHeadersInjection, nil
+	case "HTTP_HEADERS_INJECTION":
+		return VulnTypeHttpHeadersInjection, nil
+	case "SENSITIVE_EXPOSED_HEADER_INJECTION":
+		return VulnTypeSensitiveExposedHeaderInjection, nil
+	case "SERVER_OVERLOAD_HEADER_INJECTION":
+		return VulnTypeServerOverloadHeaderInjection, nil
 	}
 	var t VulnType
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -163,8 +163,8 @@ func parseJSONParams(jsonStr string) (map[string]string, error) {
 	return params, nil
 }
 
-func parseAllParams(params webscan.RequestParams) (webscan.ParsedParams, error) {
-	var parsed webscan.ParsedParams
+func parseAllParams(params webscan.RequestParams) (webscan.ParsedRequestParams, error) {
+	var parsed webscan.ParsedRequestParams
 	var err error
 
 	parsed.PathParams, err = parseJSONParams(params.PathParams)
@@ -220,7 +220,7 @@ func constructURL(baseURL, path string, pathParams, queryParams map[string]strin
 	return fullURL, nil
 }
 
-func prepareRequestBody(params webscan.ParsedParams) (io.Reader, string, error) {
+func prepareRequestBody(params webscan.ParsedRequestParams) (io.Reader, string, error) {
 	if params.BodyParams != "" {
 		if !json.Valid([]byte(params.BodyParams)) {
 			return nil, "", fmt.Errorf("invalid JSON in body parameters")
@@ -303,7 +303,7 @@ func sendFastHTTPRequest(method, url string, body string, contentType string, he
 	return resp, nil
 }
 
-func populateReport(report *webscan.RequestReport, statusCode int, headers map[string]string, body string, params webscan.ParsedParams, vulnTypes []string) {
+func populateReport(report *webscan.RequestReport, statusCode int, headers map[string]string, body string, params webscan.ParsedRequestParams, vulnTypes []string) {
 	if headers != nil {
 		report.ResponseHeaders = make(map[string]string)
 		for key, values := range headers {

--- a/internal/requests/serveroverload.go
+++ b/internal/requests/serveroverload.go
@@ -1,0 +1,55 @@
+package requests
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	webscan "github.com/Method-Security/webscan/generated/go"
+)
+
+func PerformServerOverloadHeaderRequests(baseURL, path, method string, payloadSize int) *webscan.MultipleRequestReport {
+	report := webscan.MultipleRequestReport{}
+	var errors []string
+
+	var requestReports []*webscan.RequestReport
+
+	serverOverloadHeaders := GenerateServerOverloadHeaders(payloadSize)
+	for _, headers := range serverOverloadHeaders {
+		jsonHeaders, err := json.Marshal(headers)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Error marshaling headers to JSON: %v", err))
+			continue
+		}
+
+		serverOverloadParams := webscan.RequestParams{}
+		serverOverloadParams.HeaderParams = string(jsonHeaders)
+
+		requestReport := PerformRequestScan(baseURL, path, method, serverOverloadParams, []string{"SERVER_OVERLOAD_HEADER_INJECTION"})
+		errors = append(errors, requestReport.Errors...)
+		requestReports = append(requestReports, &requestReport)
+	}
+
+	report.Requests = requestReports
+	report.Errors = errors
+	return &report
+}
+
+// GenerateServerOverloadHeaders dynamically generates headers based on payload size.
+func GenerateServerOverloadHeaders(payloadSize int) []map[string]string {
+	headersList := []map[string]string{}
+
+	// Very large header value to test buffer limits
+	headersList = append(headersList, map[string]string{
+		"X-Large-Header": strings.Repeat("A", payloadSize),
+	})
+
+	// Excessive number of headers to test large header counts
+	excessiveHeaders := map[string]string{}
+	for i := 0; i < payloadSize; i++ {
+		excessiveHeaders[fmt.Sprintf("X-Header-%d", i)] = "test"
+	}
+	headersList = append(headersList, excessiveHeaders)
+
+	return headersList
+}

--- a/main.go
+++ b/main.go
@@ -14,14 +14,15 @@ func main() {
 
 	webscan := cmd.NewWebScan(version)
 	webscan.InitRootCommand()
-	webscan.InitFuzzCommand()
-	webscan.InitWebServerCommand()
-	webscan.InitSpiderCommand()
-	webscan.InitVulnCommand()
 	webscan.InitAppCommand()
 	webscan.InitFingerprintCommand()
+	webscan.InitFuzzCommand()
 	webscan.InitPagecaptureCommand()
+	webscan.InitRequestsCommand()
 	webscan.InitRoutecaptureCommand()
+	webscan.InitSpiderCommand()
+	webscan.InitVulnCommand()
+	webscan.InitWebServerCommand()
 
 	if err := webscan.RootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
### Problem

The precompiled _Server Overload_ headers where too large for the CLI to process as instruction flags.

### Solution

To resolve this I implement a separate command specifically for handling Server Overload headers. This command will encapsulate the logic for generating and managing large headers, avoiding overloading the CLI. (Under the hood it still uses the general request function but with a layer between that generates the large headers to inject)

### Note

The other _Header Injection_ tools will still use the `webscan requests` command to send there requests since all reasons previously discussed still stand

> 1. I forsee the AI writing a lot of these injections in the future so it made sense to follow the same paradime of interacting with the CLI that we set in the Route Injection Simulate Tool where the parameters are generated in the Compiler then sent in via flags. Also I see us wanting to scope the AI to generate Header Injections that are in specific buckets so I see the hardcoded injection lists as examples that can be sent to the AI which wouldn't be enabled if they where held in the CLI
> 
> 2. It didn't make sense to me to create a new CLI that has the same functionality as `web app requests` and I didn't want to alter the `web app requests` CLI in a way that required the Tool to interact with it in a different way than existing tools do (Route Injection)
> 

I view this inconsistent architecture as being acceptable since how Server Overload Header injections 'finds' vulnerabilities sits in a different category than the other header injection tools. The others, and this is where the AI will be useful, use targeted headers to exploit specific vulnerabilities in CORS, HTTP, ESCAPE, and SENSITIVE DATA EXPOSED where SERVER OVERLOAD is really just about brute forcing via size.

That said I could see another Header Injection module that tries to overload the server through 'weird' misconfigurations as opposed to relying on size. This tool would be implemented like the other Header Injection Tools

### Other Fixes

- Cleaned up the `webscan app` command by removing the `requests` subcommand and making it its own top level command

- Cleaned up `Requests` Fern definition