### PR TITLE
Webscan Fuzz Path: Return Fuzz Metadata

### DIFF
--- a/fern/definition/fuzzpath.yml
+++ b/fern/definition/fuzzpath.yml
@@ -32,6 +32,9 @@ types:
   TargetInfo:
     properties:
       target: string
+      startTimestamp: datetime
+      endTimestamp: datetime
+      requestCount: integer
       fuzzAttempts: list<FuzzAttemptInfo>
   FuzzPathReport:
     properties:

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -1153,8 +1153,11 @@ func (r *ResponseInfo) String() string {
 }
 
 type TargetInfo struct {
-	Target       string             `json:"target" url:"target"`
-	FuzzAttempts []*FuzzAttemptInfo `json:"fuzzAttempts,omitempty" url:"fuzzAttempts,omitempty"`
+	Target         string             `json:"target" url:"target"`
+	StartTimestamp time.Time          `json:"startTimestamp" url:"startTimestamp"`
+	EndTimestamp   time.Time          `json:"endTimestamp" url:"endTimestamp"`
+	RequestCount   int                `json:"requestCount" url:"requestCount"`
+	FuzzAttempts   []*FuzzAttemptInfo `json:"fuzzAttempts,omitempty" url:"fuzzAttempts,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
@@ -1165,12 +1168,20 @@ func (t *TargetInfo) GetExtraProperties() map[string]interface{} {
 }
 
 func (t *TargetInfo) UnmarshalJSON(data []byte) error {
-	type unmarshaler TargetInfo
-	var value unmarshaler
-	if err := json.Unmarshal(data, &value); err != nil {
+	type embed TargetInfo
+	var unmarshaler = struct {
+		embed
+		StartTimestamp *core.DateTime `json:"startTimestamp"`
+		EndTimestamp   *core.DateTime `json:"endTimestamp"`
+	}{
+		embed: embed(*t),
+	}
+	if err := json.Unmarshal(data, &unmarshaler); err != nil {
 		return err
 	}
-	*t = TargetInfo(value)
+	*t = TargetInfo(unmarshaler.embed)
+	t.StartTimestamp = unmarshaler.StartTimestamp.Time()
+	t.EndTimestamp = unmarshaler.EndTimestamp.Time()
 
 	extraProperties, err := core.ExtractExtraProperties(data, *t)
 	if err != nil {
@@ -1180,6 +1191,20 @@ func (t *TargetInfo) UnmarshalJSON(data []byte) error {
 
 	t._rawJSON = json.RawMessage(data)
 	return nil
+}
+
+func (t *TargetInfo) MarshalJSON() ([]byte, error) {
+	type embed TargetInfo
+	var marshaler = struct {
+		embed
+		StartTimestamp *core.DateTime `json:"startTimestamp"`
+		EndTimestamp   *core.DateTime `json:"endTimestamp"`
+	}{
+		embed:          embed(*t),
+		StartTimestamp: core.NewDateTime(t.StartTimestamp),
+		EndTimestamp:   core.NewDateTime(t.EndTimestamp),
+	}
+	return json.Marshal(marshaler)
 }
 
 func (t *TargetInfo) String() string {

--- a/internal/fuzz/fuzz.go
+++ b/internal/fuzz/fuzz.go
@@ -34,7 +34,7 @@ func PerformPathFuzz(ctx context.Context, config *webscan.FuzzPathConfig) (*webs
 	// Loop through targets
 	var targets []*webscan.TargetInfo
 	for _, target := range config.Targets {
-		targetInfo := webscan.TargetInfo{Target: target}
+		targetInfo := webscan.TargetInfo{Target: target, RequestCount: len(config.Paths) * config.Retries, StartTimestamp: time.Now()}
 
 		// Get baseline
 		baselineSize, baselineWords, err := baseLine(target)
@@ -104,6 +104,7 @@ func PerformPathFuzz(ctx context.Context, config *webscan.FuzzPathConfig) (*webs
 			}
 		}
 		targetInfo.FuzzAttempts = fuzzAttempts
+		targetInfo.EndTimestamp = time.Now()
 		targets = append(targets, &targetInfo)
 	}
 


### PR DESCRIPTION
## Signal Update

- Start Time of Fuzz
- End Time of Fuzz
- Count of paths tried

## Purpose

- Enable creation of a Multiple HTTP RR Pair object

## Question

I don't see the value of returning a list of all the paths tried. This creates  bloated signal with data that isn't used in the processor. The only reason I can see to do this is to be able to surface in the UX the paths tried to the user but I see this as a p2 and something we should focus on when we have an 'events' primitive (or something like it) that can store this data in a more correct manner. Lmk if you agree

## Note 1

Initially I was thinking of adding rate limit detection logic to this tool. I realized this would overly complicate the processor + CLI and break our paradigm of keeping tools scoped to one function. I will create a separate subcommand that creates 'alot' of requests and returns rate limit specific data

## Note 2

I am feeling a lot of pain trying to communicate the outcome of an 'event' via ontology objects. I think we need to reprioritize creating an 'events' primitive. RFC will be sent on Monday