### PR TITLE
remove vendor field from gomod entry in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    vendor: true
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Getting `The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed` when I try to trigger dependabot manually, although oddly enough the automated PRs still seem to work.

Same as https://github.com/dependabot/dependabot-core/issues/8948#issuecomment-2522129687, which links to docs mentioning we shouldn't include `vendor` for `gomod`.