### PR TITLE
Route Capture nil Pointer Bug

### DIFF
--- a/internal/routecapture/helpers.go
+++ b/internal/routecapture/helpers.go
@@ -118,12 +118,14 @@ func mergeBodyParams(params1 []*webscan.BodyParams, params2 []*webscan.BodyParam
 	}
 	for _, param := range params2 {
 		if _, exists := paramMap[param.Name]; !exists {
-			existingParam := paramMap[param.Name]
-			if existingParam.ExampleValues != nil && param.ExampleValues != nil {
-				existingParam.ExampleValues = append(existingParam.ExampleValues, param.ExampleValues...)
-			} else if param.ExampleValues != nil {
-				existingParam.ExampleValues = param.ExampleValues
-			} // else existingParam.ExampleValues is already set
+			existingParam, exists := paramMap[param.Name]
+			if exists {
+				if existingParam.ExampleValues != nil && param.ExampleValues != nil {
+					existingParam.ExampleValues = append(existingParam.ExampleValues, param.ExampleValues...)
+				} else if param.ExampleValues != nil {
+					existingParam.ExampleValues = param.ExampleValues
+				}
+			}
 			paramMap[param.Name] = existingParam
 		}
 	}


### PR DESCRIPTION
## Bug

* Nil point bug from `routecapture browser --output json --base-urls-only --timeout 30 --target https://pulse.dev.reports.pulse.com:443`
* Nil pointer due to bad map key

## Fix

* Check to see if value exists