### PR TITLE
Web Probe: Added 'method 'parameter to enable WAF bot detection

### DIFF
--- a/cmd/webserver.go
+++ b/cmd/webserver.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	webscan "github.com/Method-Security/webscan/generated/go/webserver"
 	webserver "github.com/Method-Security/webscan/internal/webserver"
 	"github.com/spf13/cobra"
@@ -90,8 +92,36 @@ func (a *WebScan) InitWebserverCommand() {
 				return
 			}
 
+			method, err := cmd.Flags().GetString("method")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			methodEnum, err := webscan.NewWebserverProbeMethodFromString(strings.ToUpper(method))
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			var browserPath *string
+			var minDOMStabalizeTime *int
+			if methodEnum == webscan.WebserverProbeMethodBrowserbase {
+				bPath, err := cmd.Flags().GetString("browserpath")
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				browserPath = &bPath
+				domTime, err := cmd.Flags().GetInt("mindomstabalizetime")
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
+				}
+				minDOMStabalizeTime = &domTime
+			}
+
 			// Load configuration
-			config := LoadWebserverProbeConfig(targets, timeout)
+			config := LoadWebserverProbeConfig(targets, timeout, methodEnum, browserPath, minDOMStabalizeTime)
 
 			// Generate report
 			report := webserver.PerformWebserverProbe(cmd.Context(), config)
@@ -104,6 +134,9 @@ func (a *WebScan) InitWebserverCommand() {
 
 	probeCmd.Flags().StringSlice("targets", []string{}, "Address targets to perform web application probing agains, comma delimited list")
 	probeCmd.Flags().Int("timeout", 30, "Timeout limit (seconds)")
+	probeCmd.Flags().String("method", "REQUEST", "Method to use for probing")
+	probeCmd.Flags().String("browserpath", "", "Path to a browser executable")
+	probeCmd.Flags().Int("mindomstabalizetime", 5, "Minimum time in seconds to wait for DOM to stabilize")
 
 	_ = probeCmd.MarkFlagRequired("targets")
 
@@ -153,11 +186,15 @@ func (a *WebScan) InitWebserverCommand() {
 	a.RootCmd.AddCommand(webserverCmd)
 }
 
-func LoadWebserverProbeConfig(targets []string, timeout int) *webscan.WebserverProbeConfig {
+func LoadWebserverProbeConfig(targets []string, timeout int, method webscan.WebserverProbeMethod, browserPath *string, minDOMStabalizeTime *int) *webscan.WebserverProbeConfig {
 	config := &webscan.WebserverProbeConfig{
-		Targets: targets,
-		Timeout: timeout,
+		Targets:             targets,
+		Timeout:             timeout,
+		Method:              method,
+		BrowserPath:         browserPath,
+		MinDomStabalizeTime: minDOMStabalizeTime,
 	}
+
 	return config
 }
 

--- a/fern/definition/webserver/probe.yml
+++ b/fern/definition/webserver/probe.yml
@@ -1,15 +1,22 @@
 types:
   # Config Struct
+  WebserverProbeMethod:
+    enum:
+      - REQUEST
+      - BROWSERBASE
   WebserverProbeConfig:
     properties:
       targets: list<string>
       timeout: integer
+      method: WebserverProbeMethod
+      browserPath: optional<string>
+      minDOMStabalizeTime: optional<integer>
   # WebserverProbeUrl Struct
   WebserverProbeUrlDetails:
     properties:
       url: string 
-      status: integer
-      title: string
+      status: optional<integer>
+      title: optional<string>
   WebserverProbeReport:
     properties:
       targets: list<string>

--- a/generated/go/webserver/types.go
+++ b/generated/go/webserver/types.go
@@ -138,8 +138,11 @@ func (w *WebserverHeadergrabReport) String() string {
 }
 
 type WebserverProbeConfig struct {
-	Targets []string `json:"targets,omitempty" url:"targets,omitempty"`
-	Timeout int      `json:"timeout" url:"timeout"`
+	Targets             []string             `json:"targets,omitempty" url:"targets,omitempty"`
+	Timeout             int                  `json:"timeout" url:"timeout"`
+	Method              WebserverProbeMethod `json:"method" url:"method"`
+	BrowserPath         *string              `json:"browserPath,omitempty" url:"browserPath,omitempty"`
+	MinDomStabalizeTime *int                 `json:"minDOMStabalizeTime,omitempty" url:"minDOMStabalizeTime,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
@@ -177,6 +180,28 @@ func (w *WebserverProbeConfig) String() string {
 		return value
 	}
 	return fmt.Sprintf("%#v", w)
+}
+
+type WebserverProbeMethod string
+
+const (
+	WebserverProbeMethodRequest     WebserverProbeMethod = "REQUEST"
+	WebserverProbeMethodBrowserbase WebserverProbeMethod = "BROWSERBASE"
+)
+
+func NewWebserverProbeMethodFromString(s string) (WebserverProbeMethod, error) {
+	switch s {
+	case "REQUEST":
+		return WebserverProbeMethodRequest, nil
+	case "BROWSERBASE":
+		return WebserverProbeMethodBrowserbase, nil
+	}
+	var t WebserverProbeMethod
+	return "", fmt.Errorf("%s is not a valid %T", s, t)
+}
+
+func (w WebserverProbeMethod) Ptr() *WebserverProbeMethod {
+	return &w
 }
 
 type WebserverProbeReport struct {
@@ -223,9 +248,9 @@ func (w *WebserverProbeReport) String() string {
 }
 
 type WebserverProbeUrlDetails struct {
-	Url    string `json:"url" url:"url"`
-	Status int    `json:"status" url:"status"`
-	Title  string `json:"title" url:"title"`
+	Url    string  `json:"url" url:"url"`
+	Status *int    `json:"status,omitempty" url:"status,omitempty"`
+	Title  *string `json:"title,omitempty" url:"title,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage

--- a/internal/webserver/probe.go
+++ b/internal/webserver/probe.go
@@ -2,13 +2,23 @@ package webapplication
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	webscan "github.com/Method-Security/webscan/generated/go/webserver"
+	"github.com/Method-Security/webscan/internal/capture"
 	"github.com/projectdiscovery/httpx/runner"
 )
 
-func performWebserverProbe(ctx context.Context, targets []string, timeout time.Duration) ([]*webscan.WebserverProbeUrlDetails, []string, error) {
+func performWebserverProbe(ctx context.Context, targets []string, timeout time.Duration, method webscan.WebserverProbeMethod, browserPath *string, minDOMStabalizeTime *int) ([]*webscan.WebserverProbeUrlDetails, []string, error) {
+	// Toggle on method selected
+	if method == webscan.WebserverProbeMethodBrowserbase {
+		return performBrowserProbe(ctx, targets, timeout, browserPath, *minDOMStabalizeTime)
+	}
+	return performHttpxProbe(ctx, targets, timeout)
+}
+
+func performHttpxProbe(ctx context.Context, targets []string, timeout time.Duration) ([]*webscan.WebserverProbeUrlDetails, []string, error) {
 	errors := []string{}
 	urls := []*webscan.WebserverProbeUrlDetails{}
 
@@ -19,26 +29,33 @@ func performWebserverProbe(ctx context.Context, targets []string, timeout time.D
 	options := runner.Options{
 		Methods:         "GET",
 		InputTargetHost: targets,
+		RandomAgent:     true,
+		FollowRedirects: true,
+		NoFallback:      true,
+		Debug:           true,
 		OnResult: func(r runner.Result) {
-			// handle error
+			// If there's an HTTP response (even from a WAF), append the URL
 			if r.Err != nil {
 				errors = append(errors, r.Err.Error())
 			}
 			urlDetails := webscan.WebserverProbeUrlDetails{
 				Url:    r.URL,
-				Status: r.StatusCode,
-				Title:  r.Title,
+				Status: &r.StatusCode,
+				Title:  &r.Title,
 			}
 			urls = append(urls, &urlDetails)
 		},
 	}
 
+	// Validate HTTPX options
 	if err := options.ValidateOptions(); err != nil {
 		return urls, errors, err
 	}
 
+	// Initialize HTTPX
 	httpxRunner, err := runner.New(&options)
 	if err != nil {
+		fmt.Printf("Failed to initialize HTTPX: %v\n", err)
 		return urls, errors, err
 	}
 	defer httpxRunner.Close()
@@ -47,28 +64,62 @@ func performWebserverProbe(ctx context.Context, targets []string, timeout time.D
 	done := make(chan struct{})
 
 	go func() {
+		fmt.Println("Running HTTPX Enumeration...")
 		httpxRunner.RunEnumeration()
 		close(done)
 	}()
-
 	select {
 	case <-ctx.Done():
-		// Timeout reached
+		fmt.Println("CTX Timeout reached before completion")
 		return urls, errors, ctx.Err()
 	case <-done:
-		// Enumeration completed successfully
+		fmt.Println("Httpx scan completed successfully")
 		return urls, errors, nil
 	}
+}
+
+func performBrowserProbe(ctx context.Context, targets []string, timeout time.Duration, browserPath *string, minDOMStabalizeTime int) ([]*webscan.WebserverProbeUrlDetails, []string, error) {
+	errors := []string{}
+	urls := []*webscan.WebserverProbeUrlDetails{}
+
+	for _, target := range targets {
+		capturer := capture.NewBrowserPageCapturer(browserPath, int(timeout.Seconds()), minDOMStabalizeTime)
+
+		// Try HTTPS first
+		targetURL := "https://" + target
+		result, err := capturer.Capture(ctx, targetURL, &capture.Options{})
+		if err != nil {
+			// If HTTPS fails, try HTTP
+			targetURL = "http://" + target
+			result, err = capturer.Capture(ctx, targetURL, &capture.Options{})
+			if err != nil {
+				errors = append(errors, "invalid address "+target)
+				continue
+			}
+		}
+
+		urlDetails := &webscan.WebserverProbeUrlDetails{
+			Url:    targetURL,
+			Status: result.StatusCode,
+		}
+
+		urls = append(urls, urlDetails)
+
+		_ = capturer.Close(ctx)
+	}
+
+	return urls, errors, nil
 }
 
 // PerformWebserverProbe performs a server probe against the provided targets, returning a ProbeReport with the
 // results of the probe.
 func PerformWebserverProbe(ctx context.Context, config *webscan.WebserverProbeConfig) *webscan.WebserverProbeReport {
-	urls, errors, err := performWebserverProbe(ctx, config.Targets, time.Duration(config.Timeout)*time.Second)
+
+	urls, errors, err := performWebserverProbe(ctx, config.Targets, time.Duration(config.Timeout)*time.Second,
+		config.Method, config.BrowserPath, config.MinDomStabalizeTime)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
-
 	report := webscan.WebserverProbeReport{
 		Targets: config.Targets,
 		Urls:    urls,


### PR DESCRIPTION
## Problem

- `hotel-onyx.com` had a human validation check that was preventing a positive response at this address
- Verified by using Burp Suite

## Solution

- Enable the tool to toggle on `httpx` (normal go request) and `browserbase` which enables browser verification
- Also set httpx to use 'random agent' although this is still flapping

## Data

### HTTPX Example

```
% method webserver probe --targets hotel-onyx.com -o json --method REQUEST
{
    "content": {
        "targets": [
            "hotel-onyx.com"
        ],
        "errors": [
            "context deadline exceeded"
        ]
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2025-02-05T15:29:11.30195-05:00",
    "status": 1
}
```

### Browserbase Example

```
% method webserver probe --targets hotel-onyx.com -o json --method BROWSERBASE
{
    "content": {
        "targets": [
            "hotel-onyx.com"
        ],
        "urls": [
            {
                "url": "https://hotel-onyx.com"
            }
        ]
    },
    "started_at": "0001-01-01T00:00:00Z",
    "completed_at": "2025-02-05T15:29:45.597344-05:00",
    "status": 0
}

```


