### PR TITLE
Layer 7 Apache + Nginx Server Fingerprinting

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -87,6 +87,7 @@ for the specified resource type.`,
 	resourceTypes := strings.Join([]string{
 		string(webscan.AppFingerprintResourceTypeApiapplication),
 		string(webscan.AppFingerprintResourceTypeCloudbucket),
+		string(webscan.AppFingerprintResourceTypeWebapplication),
 	}, ", ")
 	apiApplicationModules := strings.Join([]string{
 		string(webscan.ApiApplicationModuleFastapi),
@@ -100,10 +101,14 @@ for the specified resource type.`,
 		string(webscan.CloudBucketModuleAwss3),
 		string(webscan.CloudBucketModuleAzureblob),
 	}, ", ")
+	webApplicationModules := strings.Join([]string{
+		string(webscan.WebApplicationModuleApache),
+		string(webscan.WebApplicationModuleNginx),
+	}, ", ")
 
 	fingerprintCmd.Flags().StringSlice("targets", []string{}, "URL target to perform fingerprint against")
 	fingerprintCmd.Flags().String("resourcetype", "", fmt.Sprintf("Resource type to fingerprint (%s)", resourceTypes))
-	fingerprintCmd.Flags().StringSlice("modules", []string{}, fmt.Sprintf("Modules to run (APIApplication: %s; CloudBucket: %s)", apiApplicationModules, cloudBucketModules))
+	fingerprintCmd.Flags().StringSlice("modules", []string{}, fmt.Sprintf("Modules to run (APIApplication: %s; CloudBucket: %s; WebApplication: %s)", apiApplicationModules, cloudBucketModules, webApplicationModules))
 	fingerprintCmd.Flags().Int("timeout", 30, "Timeout per request (seconds)")
 	fingerprintCmd.Flags().Bool("successfulonly", false, "Only show successful attempts")
 
@@ -295,6 +300,15 @@ func validateFingerprintResourseModuleSelection(resourceType webscan.AppFingerpr
 				return nil, err
 			}
 			moduleEnum := webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(moduleName)
+			moduleEnums = append(moduleEnums, moduleEnum)
+		}
+	} else if resourceType == webscan.AppFingerprintResourceTypeWebapplication {
+		for _, module := range modules {
+			moduleName, err := webscan.NewWebApplicationModuleFromString(strings.ToUpper(module))
+			if err != nil {
+				return nil, err
+			}
+			moduleEnum := webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(moduleName)
 			moduleEnums = append(moduleEnums, moduleEnum)
 		}
 	}

--- a/docs/docs/app.md
+++ b/docs/docs/app.md
@@ -39,11 +39,11 @@ Usage:
 
 Flags:
   -h, --help                  help for fingerprint
-      --modules strings       Modules to run (APIApplication: FASTAPI, GRAPHQL, GRPC, SWAGGER, K8S; CloudBucket: AWSS3, AZUREBLOB)
-      --resourcetype string   Resource type to fingerprint (APIAPPLICATION, CLOUDBUCKET)
+      --modules strings       Modules to run (APIApplication: FASTAPI, GRAPHQL, GRPC, SWAGGER, K8S, WORDPRESS; CloudBucket: AWSS3, AZUREBLOB; WebApplication: APACHE, NGINX)
+      --resourcetype string   Resource type to fingerprint (APIAPPLICATION, CLOUDBUCKET, WEBAPPLICATION)
       --successfulonly        Only show successful attempts
       --targets strings       URL target to perform fingerprint against
-      --timeout int           Timeout per request (seconds) (default 5)
+      --timeout int           Timeout per request (seconds) (default 30)
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")

--- a/fern/definition/app/fingerprint.yml
+++ b/fern/definition/app/fingerprint.yml
@@ -14,14 +14,20 @@ types:
     enum:
       - AWSS3
       - AZUREBLOB
+  WebApplicationModule:
+    enum:
+      - APACHE
+      - NGINX
   AppFingerprintResourceModule:
     union:
       ApiApplicationModule: ApiApplicationModule
       CloudBucketModule: CloudBucketModule
+      WebApplicationModule: WebApplicationModule
   AppFingerprintResourceType:
     enum:
       - APIAPPLICATION
       - CLOUDBUCKET
+      - WEBAPPLICATION
   # Config Struct
   AppFingerprintConfig:
     properties:

--- a/generated/go/app/types.go
+++ b/generated/go/app/types.go
@@ -178,6 +178,7 @@ type AppFingerprintResourceModule struct {
 	Type                 string
 	ApiApplicationModule ApiApplicationModule
 	CloudBucketModule    CloudBucketModule
+	WebApplicationModule WebApplicationModule
 }
 
 func NewAppFingerprintResourceModuleFromApiApplicationModule(value ApiApplicationModule) *AppFingerprintResourceModule {
@@ -186,6 +187,10 @@ func NewAppFingerprintResourceModuleFromApiApplicationModule(value ApiApplicatio
 
 func NewAppFingerprintResourceModuleFromCloudBucketModule(value CloudBucketModule) *AppFingerprintResourceModule {
 	return &AppFingerprintResourceModule{Type: "CloudBucketModule", CloudBucketModule: value}
+}
+
+func NewAppFingerprintResourceModuleFromWebApplicationModule(value WebApplicationModule) *AppFingerprintResourceModule {
+	return &AppFingerprintResourceModule{Type: "WebApplicationModule", WebApplicationModule: value}
 }
 
 func (a *AppFingerprintResourceModule) UnmarshalJSON(data []byte) error {
@@ -216,6 +221,14 @@ func (a *AppFingerprintResourceModule) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		a.CloudBucketModule = valueUnmarshaler.CloudBucketModule
+	case "WebApplicationModule":
+		var valueUnmarshaler struct {
+			WebApplicationModule WebApplicationModule `json:"value"`
+		}
+		if err := json.Unmarshal(data, &valueUnmarshaler); err != nil {
+			return err
+		}
+		a.WebApplicationModule = valueUnmarshaler.WebApplicationModule
 	}
 	return nil
 }
@@ -242,12 +255,22 @@ func (a AppFingerprintResourceModule) MarshalJSON() ([]byte, error) {
 			CloudBucketModule: a.CloudBucketModule,
 		}
 		return json.Marshal(marshaler)
+	case "WebApplicationModule":
+		var marshaler = struct {
+			Type                 string               `json:"type"`
+			WebApplicationModule WebApplicationModule `json:"value"`
+		}{
+			Type:                 "WebApplicationModule",
+			WebApplicationModule: a.WebApplicationModule,
+		}
+		return json.Marshal(marshaler)
 	}
 }
 
 type AppFingerprintResourceModuleVisitor interface {
 	VisitApiApplicationModule(ApiApplicationModule) error
 	VisitCloudBucketModule(CloudBucketModule) error
+	VisitWebApplicationModule(WebApplicationModule) error
 }
 
 func (a *AppFingerprintResourceModule) Accept(visitor AppFingerprintResourceModuleVisitor) error {
@@ -258,6 +281,8 @@ func (a *AppFingerprintResourceModule) Accept(visitor AppFingerprintResourceModu
 		return visitor.VisitApiApplicationModule(a.ApiApplicationModule)
 	case "CloudBucketModule":
 		return visitor.VisitCloudBucketModule(a.CloudBucketModule)
+	case "WebApplicationModule":
+		return visitor.VisitWebApplicationModule(a.WebApplicationModule)
 	}
 }
 
@@ -266,6 +291,7 @@ type AppFingerprintResourceType string
 const (
 	AppFingerprintResourceTypeApiapplication AppFingerprintResourceType = "APIAPPLICATION"
 	AppFingerprintResourceTypeCloudbucket    AppFingerprintResourceType = "CLOUDBUCKET"
+	AppFingerprintResourceTypeWebapplication AppFingerprintResourceType = "WEBAPPLICATION"
 )
 
 func NewAppFingerprintResourceTypeFromString(s string) (AppFingerprintResourceType, error) {
@@ -274,6 +300,8 @@ func NewAppFingerprintResourceTypeFromString(s string) (AppFingerprintResourceTy
 		return AppFingerprintResourceTypeApiapplication, nil
 	case "CLOUDBUCKET":
 		return AppFingerprintResourceTypeCloudbucket, nil
+	case "WEBAPPLICATION":
+		return AppFingerprintResourceTypeWebapplication, nil
 	}
 	var t AppFingerprintResourceType
 	return "", fmt.Errorf("%s is not a valid %T", s, t)
@@ -345,4 +373,26 @@ func NewCloudBucketModuleFromString(s string) (CloudBucketModule, error) {
 
 func (c CloudBucketModule) Ptr() *CloudBucketModule {
 	return &c
+}
+
+type WebApplicationModule string
+
+const (
+	WebApplicationModuleApache WebApplicationModule = "APACHE"
+	WebApplicationModuleNginx  WebApplicationModule = "NGINX"
+)
+
+func NewWebApplicationModuleFromString(s string) (WebApplicationModule, error) {
+	switch s {
+	case "APACHE":
+		return WebApplicationModuleApache, nil
+	case "NGINX":
+		return WebApplicationModuleNginx, nil
+	}
+	var t WebApplicationModule
+	return "", fmt.Errorf("%s is not a valid %T", s, t)
+}
+
+func (w WebApplicationModule) Ptr() *WebApplicationModule {
+	return &w
 }

--- a/internal/app/fingerprint/engine.go
+++ b/internal/app/fingerprint/engine.go
@@ -9,6 +9,7 @@ import (
 	common "github.com/Method-Security/webscan/generated/go/common"
 	apiapplication "github.com/Method-Security/webscan/internal/app/fingerprint/modules/apiapplication"
 	cloudbucket "github.com/Method-Security/webscan/internal/app/fingerprint/modules/cloudbucket"
+	"github.com/Method-Security/webscan/internal/app/fingerprint/modules/webapplication"
 )
 
 type Module interface {
@@ -38,6 +39,10 @@ func NewEngine(config *webscan.AppFingerprintConfig) *Engine {
 				*webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(webscan.CloudBucketModuleAzureblob): &cloudbucket.AzureBlobLibrary{},
 				*webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(webscan.CloudBucketModuleAwss3):     &cloudbucket.AwsS3Library{},
 			},
+			webscan.AppFingerprintResourceTypeWebapplication: {
+				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleApache): &webapplication.ApacheLibrary{},
+				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleNginx):  &webapplication.NginxLibrary{},
+			},
 		},
 	}
 }
@@ -64,8 +69,10 @@ func (e *Engine) GetModules() ([]Module, error) {
 		appendModules(e.Modules[webscan.AppFingerprintResourceTypeApiapplication])
 	case webscan.AppFingerprintResourceTypeCloudbucket:
 		appendModules(e.Modules[webscan.AppFingerprintResourceTypeCloudbucket])
+	case webscan.AppFingerprintResourceTypeWebapplication:
+		appendModules(e.Modules[webscan.AppFingerprintResourceTypeWebapplication])
 	default:
-		return nil, fmt.Errorf("unsupported server type: %s", e.Config.ResourceType)
+		return nil, fmt.Errorf("unsupported module type: %s", e.Config.ResourceType)
 	}
 
 	return moduleLibs, nil

--- a/internal/app/fingerprint/modules/webapplication/apache.go
+++ b/internal/app/fingerprint/modules/webapplication/apache.go
@@ -49,7 +49,7 @@ func (apLib *ApacheLibrary) ModuleRun(target string, config *webscan.AppFingerpr
 }
 
 func (apLib *ApacheLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseBody == nil || response.ResponseHeaders == nil {
+	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
 		return false
 	}
 
@@ -63,6 +63,10 @@ func (apLib *ApacheLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
 				return true
 			}
 		}
+	}
+
+	if response.ResponseBody == nil {
+		return false
 	}
 
 	// Check body for Apache indicators

--- a/internal/app/fingerprint/modules/webapplication/apache.go
+++ b/internal/app/fingerprint/modules/webapplication/apache.go
@@ -1,0 +1,87 @@
+package webapplication
+
+import (
+	"strings"
+
+	webscan "github.com/Method-Security/webscan/generated/go/app"
+	common "github.com/Method-Security/webscan/generated/go/common"
+	"github.com/Method-Security/webscan/utils"
+)
+
+type ApacheLibrary struct{}
+
+var apachePaths = []string{
+	"", // Root
+	"/server-status",
+	"/icons/",
+	"/manual/",
+	"/cgi-bin/",
+	"/.htaccess",
+}
+
+func (apLib *ApacheLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
+	attempt := webscan.AppFingerprintAttemptInfo{
+		Name:    webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleApache),
+		Finding: false,
+	}
+	errors := []string{}
+
+	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &attempt, errors
+	}
+
+	requests := []*common.RequestInfo{}
+
+	for _, path := range apachePaths {
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+		errors = append(errors, request.Errors...)
+
+		requests = append(requests, &request)
+		if apLib.AnalyzeResponse(&request) {
+			attempt.Finding = true
+		}
+	}
+
+	attempt.Requests = requests
+	return &attempt, errors
+}
+
+func (apLib *ApacheLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
+	if response == nil || response.StatusCode == nil || response.ResponseBody == nil || response.ResponseHeaders == nil {
+		return false
+	}
+
+	// We're interested in responses even if they're not 200 OK
+	// Apache often reveals itself in error pages too
+
+	// Check headers for Apache indicators
+	for _, headerKey := range []string{"Server", "server", "X-Powered-By", "x-powered-by"} {
+		if serverHeader, ok := response.ResponseHeaders[headerKey]; ok {
+			if strings.Contains(strings.ToLower(serverHeader), "apache") {
+				return true
+			}
+		}
+	}
+
+	// Check body for Apache indicators
+	apacheBodyIndicators := []string{
+		"<address>apache",
+		"apache server at",
+		"powered by apache",
+		"apache/",
+		"<title>apache http server",
+		"<title>apache status</title>",
+		"apache tomcat",
+	}
+
+	body := strings.ToLower(*response.ResponseBody)
+	for _, indicator := range apacheBodyIndicators {
+		if strings.Contains(body, strings.ToLower(indicator)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/app/fingerprint/modules/webapplication/nginx.go
+++ b/internal/app/fingerprint/modules/webapplication/nginx.go
@@ -1,0 +1,89 @@
+package webapplication
+
+import (
+	"strings"
+
+	webscan "github.com/Method-Security/webscan/generated/go/app"
+	common "github.com/Method-Security/webscan/generated/go/common"
+	"github.com/Method-Security/webscan/utils"
+)
+
+type NginxLibrary struct{}
+
+var nginxPaths = []string{
+	"", // Root
+	"/nginx_status",
+	"/status",
+	"/.nginx-debian.html",
+	"/50x.html",
+	"/404.html",
+}
+
+func (ngLib *NginxLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
+	attempt := webscan.AppFingerprintAttemptInfo{
+		Name:    webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleNginx),
+		Finding: false,
+	}
+	errors := []string{}
+
+	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &attempt, errors
+	}
+
+	requests := []*common.RequestInfo{}
+
+	for _, path := range nginxPaths {
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+		errors = append(errors, request.Errors...)
+
+		requests = append(requests, &request)
+		if ngLib.AnalyzeResponse(&request) {
+			attempt.Finding = true
+		}
+	}
+
+	attempt.Requests = requests
+	return &attempt, errors
+}
+
+func (ngLib *NginxLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
+	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
+		return false
+	}
+
+	// Check for "Server" or "server" headers
+	for _, headerKey := range []string{"Server", "server", "X-Powered-By", "x-powered-by"} {
+		if serverHeader, ok := response.ResponseHeaders[headerKey]; ok {
+			if strings.Contains(strings.ToLower(serverHeader), "nginx") {
+				return true
+			}
+		}
+	}
+
+	// If no body is present, we already checked headers
+	if response.ResponseBody == nil {
+		return false
+	}
+
+	// Check body for Nginx indicators
+	nginxBodyIndicators := []string{
+		"<title>welcome to nginx</title>",
+		"<title>nginx error</title>",
+		"<title>test page for nginx</title>",
+		"<h1>welcome to nginx!</h1>",
+		"<center>nginx</center>",
+		"<hr><center>nginx/",
+		"powered by nginx",
+	}
+
+	body := strings.ToLower(*response.ResponseBody)
+	for _, indicator := range nginxBodyIndicators {
+		if strings.Contains(body, indicator) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## New Modules

- Created fingerprint modules for Apache and Nginx web servers

## Why

- This will enable Layer 7 detect if Apache and Nginx and enable use of Web Server specific tools when `bannergrab` is not used/when `bannergrab` doesn't detect the server


## Example Commands

```
% app fingerprint --resourcetype WEBAPPLICATION --modules APACHE --targets https://httpd.apache.org
% app fingerprint --resourcetype WEBAPPLICATION --modules NGINX --targets https://nginx.org
```


