### PR TITLE
Remote Access Services Layer 7 Fingerprint Tools

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -105,10 +105,14 @@ for the specified resource type.`,
 		string(webscan.WebApplicationModuleApache),
 		string(webscan.WebApplicationModuleNginx),
 	}, ", ")
-
+	remoteAccessModules := strings.Join([]string{
+		string(webscan.RemoteAccessModuleCitrixgateway),
+		string(webscan.RemoteAccessModuleWindowsrdp),
+		string(webscan.RemoteAccessModuleVmwarehorizon),
+	}, ", ")
 	fingerprintCmd.Flags().StringSlice("targets", []string{}, "URL target to perform fingerprint against")
 	fingerprintCmd.Flags().String("resourcetype", "", fmt.Sprintf("Resource type to fingerprint (%s)", resourceTypes))
-	fingerprintCmd.Flags().StringSlice("modules", []string{}, fmt.Sprintf("Modules to run (APIApplication: %s; CloudBucket: %s; WebApplication: %s)", apiApplicationModules, cloudBucketModules, webApplicationModules))
+	fingerprintCmd.Flags().StringSlice("modules", []string{}, fmt.Sprintf("Modules to run (APIApplication: %s; CloudBucket: %s; WebApplication: %s; RemoteAccess: %s)", apiApplicationModules, cloudBucketModules, webApplicationModules, remoteAccessModules))
 	fingerprintCmd.Flags().Int("timeout", 30, "Timeout per request (seconds)")
 	fingerprintCmd.Flags().Bool("successfulonly", false, "Only show successful attempts")
 
@@ -309,6 +313,15 @@ func validateFingerprintResourseModuleSelection(resourceType webscan.AppFingerpr
 				return nil, err
 			}
 			moduleEnum := webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(moduleName)
+			moduleEnums = append(moduleEnums, moduleEnum)
+		}
+	} else if resourceType == webscan.AppFingerprintResourceTypeRemoteaccess {
+		for _, module := range modules {
+			moduleName, err := webscan.NewRemoteAccessModuleFromString(strings.ToUpper(module))
+			if err != nil {
+				return nil, err
+			}
+			moduleEnum := webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(moduleName)
 			moduleEnums = append(moduleEnums, moduleEnum)
 		}
 	}

--- a/fern/definition/app/fingerprint.yml
+++ b/fern/definition/app/fingerprint.yml
@@ -18,16 +18,23 @@ types:
     enum:
       - APACHE
       - NGINX
+  RemoteAccessModule:
+    enum:
+      - CITRIXGATEWAY
+      - WINDOWSRDP
+      - VMWAREHORIZON
   AppFingerprintResourceModule:
     union:
       ApiApplicationModule: ApiApplicationModule
       CloudBucketModule: CloudBucketModule
       WebApplicationModule: WebApplicationModule
+      RemoteAccessModule: RemoteAccessModule
   AppFingerprintResourceType:
     enum:
       - APIAPPLICATION
       - CLOUDBUCKET
       - WEBAPPLICATION
+      - REMOTEACCESS
   # Config Struct
   AppFingerprintConfig:
     properties:

--- a/generated/go/app/types.go
+++ b/generated/go/app/types.go
@@ -179,6 +179,7 @@ type AppFingerprintResourceModule struct {
 	ApiApplicationModule ApiApplicationModule
 	CloudBucketModule    CloudBucketModule
 	WebApplicationModule WebApplicationModule
+	RemoteAccessModule   RemoteAccessModule
 }
 
 func NewAppFingerprintResourceModuleFromApiApplicationModule(value ApiApplicationModule) *AppFingerprintResourceModule {
@@ -191,6 +192,10 @@ func NewAppFingerprintResourceModuleFromCloudBucketModule(value CloudBucketModul
 
 func NewAppFingerprintResourceModuleFromWebApplicationModule(value WebApplicationModule) *AppFingerprintResourceModule {
 	return &AppFingerprintResourceModule{Type: "WebApplicationModule", WebApplicationModule: value}
+}
+
+func NewAppFingerprintResourceModuleFromRemoteAccessModule(value RemoteAccessModule) *AppFingerprintResourceModule {
+	return &AppFingerprintResourceModule{Type: "RemoteAccessModule", RemoteAccessModule: value}
 }
 
 func (a *AppFingerprintResourceModule) UnmarshalJSON(data []byte) error {
@@ -229,6 +234,14 @@ func (a *AppFingerprintResourceModule) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		a.WebApplicationModule = valueUnmarshaler.WebApplicationModule
+	case "RemoteAccessModule":
+		var valueUnmarshaler struct {
+			RemoteAccessModule RemoteAccessModule `json:"value"`
+		}
+		if err := json.Unmarshal(data, &valueUnmarshaler); err != nil {
+			return err
+		}
+		a.RemoteAccessModule = valueUnmarshaler.RemoteAccessModule
 	}
 	return nil
 }
@@ -264,6 +277,15 @@ func (a AppFingerprintResourceModule) MarshalJSON() ([]byte, error) {
 			WebApplicationModule: a.WebApplicationModule,
 		}
 		return json.Marshal(marshaler)
+	case "RemoteAccessModule":
+		var marshaler = struct {
+			Type               string             `json:"type"`
+			RemoteAccessModule RemoteAccessModule `json:"value"`
+		}{
+			Type:               "RemoteAccessModule",
+			RemoteAccessModule: a.RemoteAccessModule,
+		}
+		return json.Marshal(marshaler)
 	}
 }
 
@@ -271,6 +293,7 @@ type AppFingerprintResourceModuleVisitor interface {
 	VisitApiApplicationModule(ApiApplicationModule) error
 	VisitCloudBucketModule(CloudBucketModule) error
 	VisitWebApplicationModule(WebApplicationModule) error
+	VisitRemoteAccessModule(RemoteAccessModule) error
 }
 
 func (a *AppFingerprintResourceModule) Accept(visitor AppFingerprintResourceModuleVisitor) error {
@@ -283,6 +306,8 @@ func (a *AppFingerprintResourceModule) Accept(visitor AppFingerprintResourceModu
 		return visitor.VisitCloudBucketModule(a.CloudBucketModule)
 	case "WebApplicationModule":
 		return visitor.VisitWebApplicationModule(a.WebApplicationModule)
+	case "RemoteAccessModule":
+		return visitor.VisitRemoteAccessModule(a.RemoteAccessModule)
 	}
 }
 
@@ -292,6 +317,7 @@ const (
 	AppFingerprintResourceTypeApiapplication AppFingerprintResourceType = "APIAPPLICATION"
 	AppFingerprintResourceTypeCloudbucket    AppFingerprintResourceType = "CLOUDBUCKET"
 	AppFingerprintResourceTypeWebapplication AppFingerprintResourceType = "WEBAPPLICATION"
+	AppFingerprintResourceTypeRemoteaccess   AppFingerprintResourceType = "REMOTEACCESS"
 )
 
 func NewAppFingerprintResourceTypeFromString(s string) (AppFingerprintResourceType, error) {
@@ -302,6 +328,8 @@ func NewAppFingerprintResourceTypeFromString(s string) (AppFingerprintResourceTy
 		return AppFingerprintResourceTypeCloudbucket, nil
 	case "WEBAPPLICATION":
 		return AppFingerprintResourceTypeWebapplication, nil
+	case "REMOTEACCESS":
+		return AppFingerprintResourceTypeRemoteaccess, nil
 	}
 	var t AppFingerprintResourceType
 	return "", fmt.Errorf("%s is not a valid %T", s, t)
@@ -373,6 +401,31 @@ func NewCloudBucketModuleFromString(s string) (CloudBucketModule, error) {
 
 func (c CloudBucketModule) Ptr() *CloudBucketModule {
 	return &c
+}
+
+type RemoteAccessModule string
+
+const (
+	RemoteAccessModuleCitrixgateway RemoteAccessModule = "CITRIXGATEWAY"
+	RemoteAccessModuleWindowsrdp    RemoteAccessModule = "WINDOWSRDP"
+	RemoteAccessModuleVmwarehorizon RemoteAccessModule = "VMWAREHORIZON"
+)
+
+func NewRemoteAccessModuleFromString(s string) (RemoteAccessModule, error) {
+	switch s {
+	case "CITRIXGATEWAY":
+		return RemoteAccessModuleCitrixgateway, nil
+	case "WINDOWSRDP":
+		return RemoteAccessModuleWindowsrdp, nil
+	case "VMWAREHORIZON":
+		return RemoteAccessModuleVmwarehorizon, nil
+	}
+	var t RemoteAccessModule
+	return "", fmt.Errorf("%s is not a valid %T", s, t)
+}
+
+func (r RemoteAccessModule) Ptr() *RemoteAccessModule {
+	return &r
 }
 
 type WebApplicationModule string

--- a/internal/app/fingerprint/engine.go
+++ b/internal/app/fingerprint/engine.go
@@ -11,11 +11,15 @@ import (
 	cloudbucket "github.com/Method-Security/webscan/internal/app/fingerprint/modules/cloudbucket"
 	"github.com/Method-Security/webscan/internal/app/fingerprint/modules/remoteaccess"
 	"github.com/Method-Security/webscan/internal/app/fingerprint/modules/webapplication"
+	"github.com/Method-Security/webscan/utils"
 )
 
 type Module interface {
-	ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string)
-	AnalyzeResponse(request *common.RequestInfo) bool
+	Name() *webscan.AppFingerprintResourceModule
+	Paths() []string
+	RequestParams() (common.HttpMethod, common.RequestParams)
+	BodyIndicators() []string
+	HeaderIndicators() map[string][]string
 }
 
 type Engine struct {
@@ -46,6 +50,8 @@ func NewEngine(config *webscan.AppFingerprintConfig) *Engine {
 			},
 			webscan.AppFingerprintResourceTypeRemoteaccess: {
 				*webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleCitrixgateway): &remoteaccess.CitrixGatewayLibrary{},
+				*webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleWindowsrdp):    &remoteaccess.WindowsRDPLibrary{},
+				*webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleVmwarehorizon): &remoteaccess.VMwareHorizonLibrary{},
 			},
 		},
 	}
@@ -53,7 +59,6 @@ func NewEngine(config *webscan.AppFingerprintConfig) *Engine {
 
 func (e *Engine) GetModules() ([]Module, error) {
 	var moduleLibs []Module
-
 	appendModules := func(resourceModules map[webscan.AppFingerprintResourceModule]Module) {
 		if len(e.Config.Modules) == 0 {
 			for _, module := range resourceModules {
@@ -84,9 +89,80 @@ func (e *Engine) GetModules() ([]Module, error) {
 	return moduleLibs, nil
 }
 
-func (e *Engine) Run(ctx context.Context, target string) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt, errs := e.Library.ModuleRun(target, e.Config)
-	return attempt, errs
+func (e *Engine) AnalyzeResponse(response *common.RequestInfo) bool {
+	if response == nil || response.StatusCode == nil {
+		return false
+	}
+
+	// Anaylsis Response Headers
+	if response.ResponseHeaders == nil {
+		return false
+	}
+	headerIndicators := e.Library.HeaderIndicators()
+	// Loop through response headers
+	for responseHeader, responseHeaderValue := range response.ResponseHeaders {
+		// Loop through header indicators
+		for headerIndicator, headerIndicatorValues := range headerIndicators {
+			if strings.EqualFold(responseHeader, headerIndicator) {
+				if len(headerIndicatorValues) == 0 {
+					return true // If empty array, the header presence alone is an indicator
+				}
+				// Loop through header values
+				for _, headerIndicatorValue := range headerIndicatorValues {
+					if strings.Contains(strings.ToLower(responseHeaderValue), strings.ToLower(headerIndicatorValue)) {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	// Anaylsis Response Body
+	if response.ResponseBody == nil {
+		return false
+	}
+	bodyIndicators := e.Library.BodyIndicators()
+	lowerBody := strings.ToLower(*response.ResponseBody)
+	for _, indicator := range bodyIndicators {
+		if strings.Contains(lowerBody, indicator) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (e *Engine) Run(ctx context.Context, target string, timeout int) (*webscan.AppFingerprintAttemptInfo, []string) {
+	attempt := webscan.AppFingerprintAttemptInfo{
+		Name:    e.Library.Name(),
+		Finding: false,
+	}
+	errors := []string{}
+
+	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &attempt, errors
+	}
+
+	requests := []*common.RequestInfo{}
+	for _, path := range e.Library.Paths() {
+		// Request Configuration
+		fullPath := parsedTargetPath + path
+		method, params := e.Library.RequestParams()
+
+		// Perform Request
+		request := utils.PerformRequestScan(baseURL, fullPath, method, params, timeout)
+		errors = append(errors, request.Errors...)
+
+		requests = append(requests, &request)
+		if e.AnalyzeResponse(&request) {
+			attempt.Finding = true
+		}
+	}
+
+	attempt.Requests = requests
+	return &attempt, errors
 }
 
 func (e *Engine) Launch(ctx context.Context) (*webscan.AppFingerprintReport, error) {
@@ -111,12 +187,12 @@ func (e *Engine) Launch(ctx context.Context) (*webscan.AppFingerprintReport, err
 				schemes := []string{"http://", "https://"}
 				for _, scheme := range schemes {
 					schemeTarget := scheme + target
-					attempt, errs := e.Run(ctx, schemeTarget)
+					attempt, errs := e.Run(ctx, schemeTarget, e.Config.Timeout)
 					attempts = append(attempts, attempt)
 					errors = append(errors, errs...)
 				}
 			} else {
-				attempt, errs := e.Run(ctx, target)
+				attempt, errs := e.Run(ctx, target, e.Config.Timeout)
 				attempts = append(attempts, attempt)
 				errors = append(errors, errs...)
 			}

--- a/internal/app/fingerprint/engine.go
+++ b/internal/app/fingerprint/engine.go
@@ -9,6 +9,7 @@ import (
 	common "github.com/Method-Security/webscan/generated/go/common"
 	apiapplication "github.com/Method-Security/webscan/internal/app/fingerprint/modules/apiapplication"
 	cloudbucket "github.com/Method-Security/webscan/internal/app/fingerprint/modules/cloudbucket"
+	"github.com/Method-Security/webscan/internal/app/fingerprint/modules/remoteaccess"
 	"github.com/Method-Security/webscan/internal/app/fingerprint/modules/webapplication"
 )
 
@@ -43,6 +44,9 @@ func NewEngine(config *webscan.AppFingerprintConfig) *Engine {
 				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleApache): &webapplication.ApacheLibrary{},
 				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleNginx):  &webapplication.NginxLibrary{},
 			},
+			webscan.AppFingerprintResourceTypeRemoteaccess: {
+				*webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleCitrixgateway): &remoteaccess.CitrixGatewayLibrary{},
+			},
 		},
 	}
 }
@@ -71,6 +75,8 @@ func (e *Engine) GetModules() ([]Module, error) {
 		appendModules(e.Modules[webscan.AppFingerprintResourceTypeCloudbucket])
 	case webscan.AppFingerprintResourceTypeWebapplication:
 		appendModules(e.Modules[webscan.AppFingerprintResourceTypeWebapplication])
+	case webscan.AppFingerprintResourceTypeRemoteaccess:
+		appendModules(e.Modules[webscan.AppFingerprintResourceTypeRemoteaccess])
 	default:
 		return nil, fmt.Errorf("unsupported module type: %s", e.Config.ResourceType)
 	}

--- a/internal/app/fingerprint/modules/apiapplication/fastapi.go
+++ b/internal/app/fingerprint/modules/apiapplication/fastapi.go
@@ -1,83 +1,39 @@
 package apiapplication
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type FastAPILibrary struct{}
 
-var fastapiPaths = []string{
-	"/docs",
-	"/redoc",
-	"/openapi.json",
+func (fastapiLib *FastAPILibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleFastapi)
 }
 
-func (fastapiLib *FastAPILibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleFastapi),
-		Finding: false,
+func (fastapiLib *FastAPILibrary) Paths() []string {
+	paths := []string{
+		"/docs",
+		"/redoc",
+		"/openapi.json",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-	for _, path := range fastapiPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if fastapiLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (fastapiLib *FastAPILibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	// Ensure the response and its body are valid
-	if response == nil || response.ResponseBody == nil || response.ResponseHeaders == nil {
-		return false
-	}
+func (fastapiLib *FastAPILibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	// Indicators to identify FastAPI responses in the body
-	bodyIndicators := []string{
-		"FastAPI - Swagger UI",
-		"FastAPI - ReDoc",
+func (fastapiLib *FastAPILibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server": {"fastapi"},
+	}
+}
+
+func (fastapiLib *FastAPILibrary) BodyIndicators() []string {
+	return []string{
+		"fastapi - swagger ui",
+		"fastapi - redoc",
 		"fastapi.tiangolo.com",
 	}
-
-	// Headers that may indicate a FastAPI response
-	headerIndicators := map[string]string{
-		"x-process-time": "", // FastAPI default header
-	}
-
-	// Check body for FastAPI-specific indicators
-	body := *response.ResponseBody
-	for _, indicator := range bodyIndicators {
-		if strings.Contains(body, indicator) {
-			return true
-		}
-	}
-
-	// Check headers for FastAPI-specific indicators
-	for key, expectedValue := range headerIndicators {
-		if value, exists := response.ResponseHeaders[key]; exists {
-			if expectedValue == "" || strings.Contains(value, expectedValue) {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/apiapplication/graphql.go
+++ b/internal/app/fingerprint/modules/apiapplication/graphql.go
@@ -2,37 +2,30 @@ package apiapplication
 
 import (
 	"encoding/json"
-	"strings"
 
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type GraphQLLibrary struct{}
 
-var graphqlPaths = []string{
-	"/graphql",
-	"/api/graphql",
-	"/v1/graphql",
-	"/graphql/v1",
-	"/query",
-	"/api",
+func (graphqlLib *GraphQLLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleGraphql)
 }
 
-func (graphqlLib *GraphQLLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleGraphql),
-		Finding: false,
+func (graphqlLib *GraphQLLibrary) Paths() []string {
+	paths := []string{
+		"/graphql",
+		"/api/graphql",
+		"/v1/graphql",
+		"/graphql/v1",
+		"/query",
+		"/api",
 	}
-	errors := []string{}
+	return paths
+}
 
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
+func (graphqlLib *GraphQLLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
 	// GraphQL introspection query
 	introspectionBodyQuery := map[string]string{
 		"query": "{ __schema { queryType { name } } }",
@@ -40,43 +33,16 @@ func (graphqlLib *GraphQLLibrary) ModuleRun(target string, config *webscan.AppFi
 	jsonQuery, _ := json.Marshal(introspectionBodyQuery)
 	bodyStr := string(jsonQuery)
 
-	requests := []*common.RequestInfo{}
-	for _, path := range graphqlPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodPost, common.RequestParams{BodyParams: bodyStr}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		finding := graphqlLib.AnalyzeResponse(&request)
-		if finding {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return common.HttpMethodPost, common.RequestParams{BodyParams: bodyStr}
 }
 
-func (graphqlLib *GraphQLLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil {
-		return false
+func (graphqlLib *GraphQLLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{}
+}
+
+func (graphqlLib *GraphQLLibrary) BodyIndicators() []string {
+	return []string{
+		"__schema",
+		"queryType",
 	}
-
-	if response.ResponseBody != nil {
-		graphqlIndicators := []string{
-			"__schema",
-			"queryType",
-		}
-
-		var jsonResponse map[string]interface{}
-		if err := json.Unmarshal([]byte(*response.ResponseBody), &jsonResponse); err == nil {
-			// Check for GraphQL-specific fields in the JSON response
-			for _, indicator := range graphqlIndicators {
-				if strings.Contains(*response.ResponseBody, indicator) {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/apiapplication/grpc.go
+++ b/internal/app/fingerprint/modules/apiapplication/grpc.go
@@ -1,78 +1,45 @@
 package apiapplication
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type GrpcLibrary struct{}
 
-var grpcPaths = []string{
-	"/grpc.health.v1.Health/Check",
-	"/grpc.health.v1alpha.Health/Check",
-	"/grpc.health.v1beta.Health/Check",
-	"/grpc.reflection.v1alpha.ServerReflectionInfo",
-	"/grpc.reflection.v1.ServerReflectionInfo",
-	"/grpc.reflection.v1beta.ServerReflectionInfo",
-	"/auth.Authentication/Login",
-	"/user.UserService/GetUser",
+func (grpcLib *GrpcLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleGrpc)
 }
 
-var grpcHeaders = map[string]string{
-	"Content-Type": "application/grpc",
+func (grpcLib *GrpcLibrary) Paths() []string {
+	paths := []string{
+		"/grpc.health.v1.Health/Check",
+		"/grpc.health.v1alpha.Health/Check",
+		"/grpc.health.v1beta.Health/Check",
+		"/grpc.reflection.v1alpha.ServerReflectionInfo",
+		"/grpc.reflection.v1.ServerReflectionInfo",
+		"/grpc.reflection.v1beta.ServerReflectionInfo",
+		"/auth.Authentication/Login",
+		"/user.UserService/GetUser",
+	}
+	return paths
 }
 
-func (grpcLib *GrpcLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleGrpc),
-		Finding: false,
+func (grpcLib *GrpcLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	headers := map[string]string{
+		"Content-Type": "application/grpc",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-	for _, path := range grpcPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodPost, common.RequestParams{HeaderParams: grpcHeaders, BodyParams: ""}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if grpcLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return common.HttpMethodPost, common.RequestParams{HeaderParams: headers}
 }
 
-func (grpcLib *GrpcLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.ResponseHeaders == nil {
-		return false
+func (grpcLib *GrpcLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"grpc-status":  {""},
+		"grpc-message": {""},
+		"content-type": {"application/grpc"},
 	}
+}
 
-	// Check for gRPC-specific headers
-	for key, value := range response.ResponseHeaders {
-		keyLower := strings.ToLower(key)
-		valueLower := strings.ToLower(value)
-
-		// Content-Type must indicate gRPC
-		if keyLower == "content-type" && strings.Contains(valueLower, "application/grpc") {
-			return true
-		}
-
-		// Look for gRPC-specific headers
-		if keyLower == "grpc-status" || keyLower == "grpc-message" {
-			return true
-		}
-	}
-
-	return false
+func (grpcLib *GrpcLibrary) BodyIndicators() []string {
+	return []string{}
 }

--- a/internal/app/fingerprint/modules/apiapplication/k8s.go
+++ b/internal/app/fingerprint/modules/apiapplication/k8s.go
@@ -3,48 +3,32 @@ package apiapplication
 import (
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type K8sLibrary struct{}
 
-func (k8sLib *K8sLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleK8S),
-		Finding: false,
-	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodPost, common.RequestParams{}, config.Timeout)
-	errors = append(errors, request.Errors...)
-
-	finding := k8sLib.AnalyzeResponse(&request)
-	if finding {
-		attempt.Finding = true
-	}
-
-	attempt.Requests = []*common.RequestInfo{&request}
-	return &attempt, errors
+func (k8sLib *K8sLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleK8S)
 }
 
-func (k8sLib *K8sLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.ResponseHeaders == nil {
-		return false
+func (k8sLib *K8sLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
 	}
+	return paths
+}
 
-	k8sHeaders := []string{"X-Kubernetes-Pf-Flowschema-Uid", "X-Kubernetes-Pf-Prioritylevel-Uid"}
+func (k8sLib *K8sLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	for _, header := range k8sHeaders {
-		if _, exists := response.ResponseHeaders[header]; exists {
-			return true
-		}
+func (k8sLib *K8sLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"x-kubernetes-pf-flowschema-uid":    {""},
+		"x-kubernetes-pf-prioritylevel-uid": {""},
 	}
+}
 
-	return false
+func (k8sLib *K8sLibrary) BodyIndicators() []string {
+	return []string{}
 }

--- a/internal/app/fingerprint/modules/apiapplication/swagger.go
+++ b/internal/app/fingerprint/modules/apiapplication/swagger.go
@@ -1,86 +1,53 @@
 package apiapplication
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type SwaggerLibrary struct{}
 
-var swaggerPaths = []string{
-	"/swagger-ui-bundle.js",
-	"/swagger-ui.html",
-	"/swagger/index.html",
-	"/swagger",
-	"/api-docs",
-	"/v2/api-docs",
-	"/swagger/v1/swagger.json",
-	"/api/swagger",
-	"/swagger.json",
-	"/swagger.yaml",
+func (swaggerLib *SwaggerLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleSwagger)
 }
 
-func (swaggerLib *SwaggerLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleSwagger),
-		Finding: false,
+func (swaggerLib *SwaggerLibrary) Paths() []string {
+	paths := []string{
+		"/swagger-ui-bundle.js",
+		"/swagger-ui.html",
+		"/swagger/index.html",
+		"/swagger",
+		"/api-docs",
+		"/v2/api-docs",
+		"/swagger/v1/swagger.json",
+		"/api/swagger",
+		"/swagger.json",
+		"/swagger.yaml",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-	for _, path := range swaggerPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if swaggerLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (swaggerLib *SwaggerLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseBody == nil || response.ResponseHeaders == nil {
-		return false
-	}
+func (swaggerLib *SwaggerLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	if *response.StatusCode != 200 {
-		return false
+func (swaggerLib *SwaggerLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"x-swagger-router-basepath":   {""},
+		"x-swagger-router-controller": {""},
 	}
+}
 
-	swaggerIndicators := []string{
-		"swagger:", "<div id=\"swagger-ui\">", "\"openapi\":",
-		"\"paths\":", "\"components\":", "\"info\": {\"title\":",
-		"Swagger UI", "loadSwaggerUI", "\"swagger\":",
+func (swaggerLib *SwaggerLibrary) BodyIndicators() []string {
+	return []string{
+		"swagger:",
+		"<div id=\"swagger-ui\">",
+		"\"openapi\":",
+		"\"paths\":",
+		"\"components\":",
+		"\"info\": {\"title\":",
+		"swagger ui",
+		"loadswaggerui",
+		"\"swagger\":",
 	}
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range swaggerIndicators {
-		if strings.Contains(body, strings.ToLower(indicator)) {
-			return true
-		}
-	}
-
-	swaggerHeaders := []string{"x-swagger-router-basepath", "x-swagger-router-controller"}
-	for header := range response.ResponseHeaders {
-		headerLower := strings.ToLower(header)
-		for _, swaggerHeader := range swaggerHeaders {
-			if headerLower == strings.ToLower(swaggerHeader) {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/apiapplication/wordpress.go
+++ b/internal/app/fingerprint/modules/apiapplication/wordpress.go
@@ -1,87 +1,43 @@
 package apiapplication
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type WordPressLibrary struct{}
 
-var wordpressPaths = []string{
-	"", // Root
-	"/wp-login.php",
-	"/wp-admin/",
-	"/xmlrpc.php",
-	"/wp-content/",
-	"/wp-includes/",
+func (wpLib *WordPressLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleWordpress)
 }
 
-func (wpLib *WordPressLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromApiApplicationModule(webscan.ApiApplicationModuleWordpress),
-		Finding: false,
+func (wpLib *WordPressLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
+		"/wp-login.php",
+		"/wp-admin",
+		"/xmlrpc.php",
+		"/wp-content",
+		"/wp-includes",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-
-	for _, path := range wordpressPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if wpLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (wpLib *WordPressLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseBody == nil || response.ResponseHeaders == nil {
-		return false
-	}
+func (wpLib *WordPressLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	if *response.StatusCode != 200 && *response.StatusCode != 403 {
-		return false
+func (wpLib *WordPressLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"x-pingback":   {"wp-json", "wp engine", "wordpress"},
+		"link":         {"wp-json", "wp engine", "wordpress"},
+		"x-powered-by": {"wp-json", "wp engine", "wordpress"},
+		"server":       {"wordpress", "wordpress/nginx"},
 	}
+}
 
-	// Check body for indicators
-	wordpressBodyIndicators := []string{
+func (wpLib *WordPressLibrary) BodyIndicators() []string {
+	return []string{
 		"wp-content/", "wp-includes/", "<meta name=\"generator\" content=\"WordPress", "/wp-json", "/wp-admin/admin-ajax.php",
 	}
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range wordpressBodyIndicators {
-		if strings.Contains(body, strings.ToLower(indicator)) {
-			return true
-		}
-	}
-
-	// Check headers for indicators
-	wordpressHeadersIndicators := []string{"x-pingback", "link", "x-powered-by"}
-	for header, values := range response.ResponseHeaders {
-		headerLower := strings.ToLower(header)
-		for _, wpHeader := range wordpressHeadersIndicators {
-			if headerLower == strings.ToLower(wpHeader) {
-				for _, value := range values {
-					if strings.Contains(strings.ToLower(string(value)), "wp-json") || strings.Contains(strings.ToLower(string(value)), "wp engine") || strings.Contains(strings.ToLower(string(value)), "wordpress") {
-						return true
-					}
-				}
-			}
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/cloudbucket/awss3.go
+++ b/internal/app/fingerprint/modules/cloudbucket/awss3.go
@@ -1,57 +1,34 @@
 package cloudbucket
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type AwsS3Library struct{}
 
-func (awsLib *AwsS3Library) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(webscan.CloudBucketModuleAwss3),
-		Finding: false,
-	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-	errors = append(errors, request.Errors...)
-
-	attempt.Finding = awsLib.AnalyzeResponse(&request)
-
-	attempt.Requests = []*common.RequestInfo{&request}
-	return &attempt, errors
+func (awsLib *AwsS3Library) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(webscan.CloudBucketModuleAwss3)
 }
 
-func (awsLib *AwsS3Library) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
-		return false
+func (awsLib *AwsS3Library) Paths() []string {
+	paths := []string{
+		"", // Root
 	}
+	return paths
+}
 
-	if *response.StatusCode != 200 && *response.StatusCode != 403 {
-		return false
+func (awsLib *AwsS3Library) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
+
+func (awsLib *AwsS3Library) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":              {"amazons3"},
+		"x-amz-bucket-region": {""},
 	}
+}
 
-	// Check for Amazon S3 server header
-	for key, headerValue := range response.ResponseHeaders {
-		if strings.EqualFold(key, "Server") {
-			if strings.Contains(strings.ToLower(strings.TrimSpace(headerValue)), "amazons3") {
-				return true
-			}
-		}
-	}
-
-	// Check for AWS bucket region header
-	_, hasRegionHeader := response.ResponseHeaders["x-amz-bucket-region"]
-
-	return hasRegionHeader
+func (awsLib *AwsS3Library) BodyIndicators() []string {
+	return []string{}
 }

--- a/internal/app/fingerprint/modules/cloudbucket/azureblob.go
+++ b/internal/app/fingerprint/modules/cloudbucket/azureblob.go
@@ -1,56 +1,34 @@
 package cloudbucket
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type AzureBlobLibrary struct{}
 
-func (azureLib *AzureBlobLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(webscan.CloudBucketModuleAzureblob),
-		Finding: false,
-	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-	errors = append(errors, request.Errors...)
-
-	attempt.Finding = azureLib.AnalyzeResponse(&request)
-
-	attempt.Requests = []*common.RequestInfo{&request}
-	return &attempt, errors
+func (azureLib *AzureBlobLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromCloudBucketModule(webscan.CloudBucketModuleAzureblob)
 }
 
-func (azureLib *AzureBlobLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil {
-		return false
+func (azureLib *AzureBlobLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
 	}
+	return paths
+}
 
-	// Check for Azure Blob specific headers and server
-	if response.ResponseHeaders != nil {
-		// Check for Microsoft Azure Storage server header
-		server, exists := response.ResponseHeaders["Server"]
-		if exists && strings.Contains(strings.ToLower(server), "microsoft") &&
-			strings.Contains(strings.ToLower(server), "blob") {
-			return true
-		}
+func (azureLib *AzureBlobLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-		// Check for x-ms-blob-type header
-		if _, exists := response.ResponseHeaders["X-Ms-Blob-Type"]; exists {
-			return true
-		}
+func (azureLib *AzureBlobLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":         {"blob"},
+		"x-ms-blob-type": {""},
 	}
+}
 
-	return false
+func (azureLib *AzureBlobLibrary) BodyIndicators() []string {
+	return []string{}
 }

--- a/internal/app/fingerprint/modules/remoteaccess/citrixgateway.go
+++ b/internal/app/fingerprint/modules/remoteaccess/citrixgateway.go
@@ -1,101 +1,58 @@
 package remoteaccess
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type CitrixGatewayLibrary struct{}
 
-var citrixGatewayPaths = []string{
-	"", // Root
-	"/citrix/",
-	"/logon/logonPoint/tmindex.html",
-	"/nf/auth/login.html",
-	"/selfservice",
-	"/vpn",
-	"/vpn/index.html",
+func (citLib *CitrixGatewayLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleCitrixgateway)
 }
 
-func (citLib *CitrixGatewayLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleCitrixgateway),
-		Finding: false,
+func (citLib *CitrixGatewayLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
+		"/citrix",
+		"/logon/logonPoint/tmindex.html",
+		"/nf/auth/login.html",
+		"/selfservice",
+		"/vpn",
+		"/vpn/index.html",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-
-	for _, path := range citrixGatewayPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if citLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (citLib *CitrixGatewayLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
-		return false
-	}
+func (citLib *CitrixGatewayLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	// Check headers for Citrix indicators
-	headerIndicators := map[string][]string{
-		"Server":                          {"citrix", "netscaler"},
-		"X-Citrix":                        {""},
-		"Citrix-TransactionID":            {""},
-		"Set-Cookie":                      {"citrix_ns", "NSC_", "NSC_AAAC", "NSC_TASS", "NSC_AAA"},
-		"X-NS-Client-IP":                  {""},
-		"X-NS-Location":                   {""},
-		"X-Citrix-Gateway":                {""},
-		"X-Transcend-Version":             {""},
-		"Pragma":                          {"NS"},
-		"Cache-Control":                   {"NS"},
-		"NsCookie":                        {""},
-		"NSC_":                            {""},
-		"X-Citrix-Application":            {""},
-		"X-AAAAuth":                       {""},
-		"X-AAA-Session":                   {""},
-		"AAA-Cookie":                      {""},
-		"X-NS-AAA":                        {""},
-		"MicrosoftSharePointTeamServices": {"Citrix ShareFile"},
+func (citLib *CitrixGatewayLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":                          {"citrix", "netscaler"},
+		"x-citrix":                        {""},
+		"citrix-transactionid":            {""},
+		"set-cookie":                      {"citrix_ns", "nsc_", "nsc_aaac", "nsc_tass", "nsc_aaa"},
+		"x-ns-client-ip":                  {""},
+		"x-ns-location":                   {""},
+		"x-citrix-gateway":                {""},
+		"x-transcend-version":             {""},
+		"pragma":                          {"ns"},
+		"cache-control":                   {"ns"},
+		"nscookie":                        {""},
+		"nsc_":                            {""},
+		"x-citrix-application":            {""},
+		"x-aaaauth":                       {""},
+		"x-aaa-session":                   {""},
+		"aaa-cookie":                      {""},
+		"x-ns-aaa":                        {""},
+		"microsoftsharepointteamservices": {"citrix sharefile"},
 	}
+}
 
-	for headerKey, values := range headerIndicators {
-		if headerValue, ok := response.ResponseHeaders[headerKey]; ok {
-			headerValueLower := strings.ToLower(headerValue)
-			if len(values) == 0 { // If empty array, the header presence alone is an indicator
-				return true
-			}
-			for _, value := range values {
-				if strings.Contains(headerValueLower, strings.ToLower(value)) {
-					return true
-				}
-			}
-		}
-	}
-
-	if response.ResponseBody == nil {
-		return false
-	}
-
-	// Check body for Citrix Gateway indicators
-	citrixBodyIndicators := []string{
+func (citLib *CitrixGatewayLibrary) BodyIndicators() []string {
+	return []string{
 		"citrix gateway",
 		"netscaler gateway",
 		"citrix adc",
@@ -119,13 +76,4 @@ func (citLib *CitrixGatewayLibrary) AnalyzeResponse(response *common.RequestInfo
 		"aaacookiecheck",
 		"nsaaasession",
 	}
-
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range citrixBodyIndicators {
-		if strings.Contains(body, indicator) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/remoteaccess/citrixgateway.go
+++ b/internal/app/fingerprint/modules/remoteaccess/citrixgateway.go
@@ -1,0 +1,131 @@
+package remoteaccess
+
+import (
+	"strings"
+
+	webscan "github.com/Method-Security/webscan/generated/go/app"
+	common "github.com/Method-Security/webscan/generated/go/common"
+	"github.com/Method-Security/webscan/utils"
+)
+
+type CitrixGatewayLibrary struct{}
+
+var citrixGatewayPaths = []string{
+	"", // Root
+	"/citrix/",
+	"/logon/logonPoint/tmindex.html",
+	"/nf/auth/login.html",
+	"/selfservice",
+	"/vpn",
+	"/vpn/index.html",
+}
+
+func (citLib *CitrixGatewayLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
+	attempt := webscan.AppFingerprintAttemptInfo{
+		Name:    webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleCitrixgateway),
+		Finding: false,
+	}
+	errors := []string{}
+
+	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &attempt, errors
+	}
+
+	requests := []*common.RequestInfo{}
+
+	for _, path := range citrixGatewayPaths {
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+		errors = append(errors, request.Errors...)
+
+		requests = append(requests, &request)
+		if citLib.AnalyzeResponse(&request) {
+			attempt.Finding = true
+		}
+	}
+
+	attempt.Requests = requests
+	return &attempt, errors
+}
+
+func (citLib *CitrixGatewayLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
+	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
+		return false
+	}
+
+	// Check headers for Citrix indicators
+	headerIndicators := map[string][]string{
+		"Server":                          {"citrix", "netscaler"},
+		"X-Citrix":                        {""},
+		"Citrix-TransactionID":            {""},
+		"Set-Cookie":                      {"citrix_ns", "NSC_", "NSC_AAAC", "NSC_TASS", "NSC_AAA"},
+		"X-NS-Client-IP":                  {""},
+		"X-NS-Location":                   {""},
+		"X-Citrix-Gateway":                {""},
+		"X-Transcend-Version":             {""},
+		"Pragma":                          {"NS"},
+		"Cache-Control":                   {"NS"},
+		"NsCookie":                        {""},
+		"NSC_":                            {""},
+		"X-Citrix-Application":            {""},
+		"X-AAAAuth":                       {""},
+		"X-AAA-Session":                   {""},
+		"AAA-Cookie":                      {""},
+		"X-NS-AAA":                        {""},
+		"MicrosoftSharePointTeamServices": {"Citrix ShareFile"},
+	}
+
+	for headerKey, values := range headerIndicators {
+		if headerValue, ok := response.ResponseHeaders[headerKey]; ok {
+			headerValueLower := strings.ToLower(headerValue)
+			if len(values) == 0 { // If empty array, the header presence alone is an indicator
+				return true
+			}
+			for _, value := range values {
+				if strings.Contains(headerValueLower, strings.ToLower(value)) {
+					return true
+				}
+			}
+		}
+	}
+
+	if response.ResponseBody == nil {
+		return false
+	}
+
+	// Check body for Citrix Gateway indicators
+	citrixBodyIndicators := []string{
+		"citrix gateway",
+		"netscaler gateway",
+		"citrix adc",
+		"citrix_ns_id",
+		"nsapimgr",
+		"citrix virtual apps",
+		"citrix workspace",
+		"citrix access gateway",
+		"citrixauthentication",
+		"ctx_login_handler",
+		"name=\"citrix\"",
+		"name=\"netscaler\"",
+		"netscaler gateway plugin",
+		"netscaler aaa",
+		"netscaleraaa",
+		"aaa service",
+		"aaa authentication",
+		"aaalogin.js",
+		"aaatm.js",
+		"aaapage",
+		"aaacookiecheck",
+		"nsaaasession",
+	}
+
+	body := strings.ToLower(*response.ResponseBody)
+	for _, indicator := range citrixBodyIndicators {
+		if strings.Contains(body, indicator) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/app/fingerprint/modules/remoteaccess/vmwarehorizon.go
+++ b/internal/app/fingerprint/modules/remoteaccess/vmwarehorizon.go
@@ -1,0 +1,102 @@
+package remoteaccess
+
+import (
+	"strings"
+
+	webscan "github.com/Method-Security/webscan/generated/go/app"
+	common "github.com/Method-Security/webscan/generated/go/common"
+	"github.com/Method-Security/webscan/utils"
+)
+
+type VMwareHorizonLibrary struct{}
+
+var horizonPaths = []string{
+	"", // Root
+	"/broker/xml",
+	"/portal",
+	"/admin",
+	"/view-client",
+}
+
+func (vmwLib *VMwareHorizonLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
+	attempt := webscan.AppFingerprintAttemptInfo{
+		Name:    webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleVmwarehorizon),
+		Finding: false,
+	}
+	errors := []string{}
+
+	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &attempt, errors
+	}
+
+	requests := []*common.RequestInfo{}
+
+	for _, path := range horizonPaths {
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+		errors = append(errors, request.Errors...)
+
+		requests = append(requests, &request)
+		if vmwLib.AnalyzeResponse(&request) {
+			attempt.Finding = true
+		}
+	}
+
+	attempt.Requests = requests
+	return &attempt, errors
+}
+
+func (vmwLib *VMwareHorizonLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
+	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
+		return false
+	}
+
+	// Check headers for VMware Horizon indicators
+	headerIndicators := map[string][]string{
+		"Server":              {"vmware", "horizon"},
+		"X-VMWARE-CSRF-TOKEN": {""},
+		"X-VMWARE":            {""},
+		"Set-Cookie":          {"blastsession"},
+		"X-Blast":             {""},
+	}
+
+	for headerKey, values := range headerIndicators {
+		if headerValue, ok := response.ResponseHeaders[headerKey]; ok {
+			headerValueLower := strings.ToLower(headerValue)
+			if len(values) == 0 {
+				return true
+			}
+			for _, value := range values {
+				if strings.Contains(headerValueLower, strings.ToLower(value)) {
+					return true
+				}
+			}
+		}
+	}
+
+	if response.ResponseBody == nil {
+		return false
+	}
+
+	// Check body for VMware Horizon indicators
+	horizonBodyIndicators := []string{
+		"vmware horizon",
+		"horizon client",
+		"vmware blast",
+		"horizon connection server",
+		"vmware-view",
+		"vmware-blast",
+		"vmware horizon html access",
+		"vmware horizon view",
+	}
+
+	body := strings.ToLower(*response.ResponseBody)
+	for _, indicator := range horizonBodyIndicators {
+		if strings.Contains(body, indicator) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/app/fingerprint/modules/remoteaccess/vmwarehorizon.go
+++ b/internal/app/fingerprint/modules/remoteaccess/vmwarehorizon.go
@@ -1,86 +1,43 @@
 package remoteaccess
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type VMwareHorizonLibrary struct{}
 
-var horizonPaths = []string{
-	"", // Root
-	"/broker/xml",
-	"/portal",
-	"/admin",
-	"/view-client",
+func (vmwLib *VMwareHorizonLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleVmwarehorizon)
 }
 
-func (vmwLib *VMwareHorizonLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleVmwarehorizon),
-		Finding: false,
+func (vmwLib *VMwareHorizonLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
+		"/broker/xml",
+		"/portal",
+		"/admin",
+		"/view-client",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-
-	for _, path := range horizonPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if vmwLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (vmwLib *VMwareHorizonLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
-		return false
-	}
+func (vmwLib *VMwareHorizonLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	// Check headers for VMware Horizon indicators
-	headerIndicators := map[string][]string{
-		"Server":              {"vmware", "horizon"},
-		"X-VMWARE-CSRF-TOKEN": {""},
-		"X-VMWARE":            {""},
-		"Set-Cookie":          {"blastsession"},
-		"X-Blast":             {""},
+func (vmwLib *VMwareHorizonLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":              {"vmware", "horizon"},
+		"x-vmware-csrf-token": {""},
+		"x-vmware":            {""},
+		"set-cookie":          {"blastsession"},
+		"x-blast":             {""},
 	}
+}
 
-	for headerKey, values := range headerIndicators {
-		if headerValue, ok := response.ResponseHeaders[headerKey]; ok {
-			headerValueLower := strings.ToLower(headerValue)
-			if len(values) == 0 {
-				return true
-			}
-			for _, value := range values {
-				if strings.Contains(headerValueLower, strings.ToLower(value)) {
-					return true
-				}
-			}
-		}
-	}
-
-	if response.ResponseBody == nil {
-		return false
-	}
-
-	// Check body for VMware Horizon indicators
-	horizonBodyIndicators := []string{
+func (vmwLib *VMwareHorizonLibrary) BodyIndicators() []string {
+	return []string{
 		"vmware horizon",
 		"horizon client",
 		"vmware blast",
@@ -90,13 +47,4 @@ func (vmwLib *VMwareHorizonLibrary) AnalyzeResponse(response *common.RequestInfo
 		"vmware horizon html access",
 		"vmware horizon view",
 	}
-
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range horizonBodyIndicators {
-		if strings.Contains(body, indicator) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/remoteaccess/windowsrdp.go
+++ b/internal/app/fingerprint/modules/remoteaccess/windowsrdp.go
@@ -1,0 +1,111 @@
+package remoteaccess
+
+import (
+	"strings"
+
+	webscan "github.com/Method-Security/webscan/generated/go/app"
+	common "github.com/Method-Security/webscan/generated/go/common"
+	"github.com/Method-Security/webscan/utils"
+)
+
+type WindowsRDPLibrary struct{}
+
+var rdpPaths = []string{
+	"", // Root path
+	"/rdweb/",
+	"/rds/",
+	"/RDWeb/Pages/",
+	"/RDWeb/Pages/en-US/Default.aspx",
+	"/RDWeb/Pages/en-US/login.aspx",
+	"/Remote/logon.aspx",
+}
+
+func (rdpLib *WindowsRDPLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
+	attempt := webscan.AppFingerprintAttemptInfo{
+		Name:    webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleWindowsrdp),
+		Finding: false,
+	}
+	errors := []string{}
+
+	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &attempt, errors
+	}
+
+	requests := []*common.RequestInfo{}
+
+	for _, path := range rdpPaths {
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+		errors = append(errors, request.Errors...)
+
+		requests = append(requests, &request)
+		if rdpLib.AnalyzeResponse(&request) {
+			attempt.Finding = true
+		}
+	}
+
+	attempt.Requests = requests
+	return &attempt, errors
+}
+
+func (rdpLib *WindowsRDPLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
+	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
+		return false
+	}
+
+	// Check headers for RDP Web Access indicators
+	headerIndicators := map[string][]string{
+		"Server":           {"rdweb", "rdgateway"},
+		"X-Powered-By":     {"rdweb"},
+		"X-RDWeb-Version":  {""},
+		"X-RDS-Version":    {""},
+		"X-MS-RDP":         {""},
+		"Set-Cookie":       {"RDPCookie", "RDP_FX_", "RDWebCookie"},
+		"X-RDWebStartMode": {""},
+	}
+
+	for headerKey, values := range headerIndicators {
+		if headerValue, ok := response.ResponseHeaders[headerKey]; ok {
+			headerValueLower := strings.ToLower(headerValue)
+			if len(values) == 0 { // If empty array, the header presence alone is an indicator
+				return true
+			}
+			for _, value := range values {
+				if strings.Contains(headerValueLower, strings.ToLower(value)) {
+					return true
+				}
+			}
+		}
+	}
+
+	// Check if standard RDP port is open (this would require a TCP scan, not covered in this HTTP scanner)
+	// Here we're only checking web interfaces
+
+	if response.ResponseBody == nil {
+		return false
+	}
+
+	// Check body for RDP Gateway indicators
+	rdpBodyIndicators := []string{
+		"Remote Desktop Gateway",
+		"RD Gateway",
+		"RD Web Access",
+		"Remote Desktop Services",
+		"RDWeb/Pages",
+		"rdpclientlauncher",
+		"msrdpclient",
+		"rdp.rdp",
+		"rdpcore.js",
+		"RDS WebFeed",
+	}
+
+	body := strings.ToLower(*response.ResponseBody)
+	for _, indicator := range rdpBodyIndicators {
+		if strings.Contains(body, strings.ToLower(indicator)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/app/fingerprint/modules/remoteaccess/windowsrdp.go
+++ b/internal/app/fingerprint/modules/remoteaccess/windowsrdp.go
@@ -1,111 +1,55 @@
 package remoteaccess
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type WindowsRDPLibrary struct{}
 
-var rdpPaths = []string{
-	"", // Root path
-	"/rdweb/",
-	"/rds/",
-	"/RDWeb/Pages/",
-	"/RDWeb/Pages/en-US/Default.aspx",
-	"/RDWeb/Pages/en-US/login.aspx",
-	"/Remote/logon.aspx",
+func (rdpLib *WindowsRDPLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleWindowsrdp)
 }
 
-func (rdpLib *WindowsRDPLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromRemoteAccessModule(webscan.RemoteAccessModuleWindowsrdp),
-		Finding: false,
+func (rdpLib *WindowsRDPLibrary) Paths() []string {
+	paths := []string{
+		"", // Root path
+		"/rdweb",
+		"/rds",
+		"/rdweb/pages",
+		"/rdweb/pages/default.aspx",
+		"/rdweb/pages/login.aspx",
+		"/remote/logon.aspx",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-
-	for _, path := range rdpPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if rdpLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (rdpLib *WindowsRDPLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
-		return false
+func (rdpLib *WindowsRDPLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
+
+func (rdpLib *WindowsRDPLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":           {"rdweb", "rdgateway"},
+		"x-powered-by":     {"rdweb"},
+		"x-rdweb-version":  {""},
+		"x-rds-version":    {""},
+		"x-ms-rdp":         {""},
+		"set-cookie":       {"rdpcookie", "rdp_fx_", "rdweb"},
+		"x-rdwebstartmode": {""},
 	}
+}
 
-	// Check headers for RDP Web Access indicators
-	headerIndicators := map[string][]string{
-		"Server":           {"rdweb", "rdgateway"},
-		"X-Powered-By":     {"rdweb"},
-		"X-RDWeb-Version":  {""},
-		"X-RDS-Version":    {""},
-		"X-MS-RDP":         {""},
-		"Set-Cookie":       {"RDPCookie", "RDP_FX_", "RDWebCookie"},
-		"X-RDWebStartMode": {""},
-	}
-
-	for headerKey, values := range headerIndicators {
-		if headerValue, ok := response.ResponseHeaders[headerKey]; ok {
-			headerValueLower := strings.ToLower(headerValue)
-			if len(values) == 0 { // If empty array, the header presence alone is an indicator
-				return true
-			}
-			for _, value := range values {
-				if strings.Contains(headerValueLower, strings.ToLower(value)) {
-					return true
-				}
-			}
-		}
-	}
-
-	// Check if standard RDP port is open (this would require a TCP scan, not covered in this HTTP scanner)
-	// Here we're only checking web interfaces
-
-	if response.ResponseBody == nil {
-		return false
-	}
-
-	// Check body for RDP Gateway indicators
-	rdpBodyIndicators := []string{
-		"Remote Desktop Gateway",
-		"RD Gateway",
-		"RD Web Access",
-		"Remote Desktop Services",
-		"RDWeb/Pages",
+func (rdpLib *WindowsRDPLibrary) BodyIndicators() []string {
+	return []string{
+		"remote desktop gateway",
+		"rd gateway",
+		"rd web access",
+		"remote desktop services",
 		"rdpclientlauncher",
 		"msrdpclient",
 		"rdp.rdp",
 		"rdpcore.js",
-		"RDS WebFeed",
+		"rds webfeed",
 	}
-
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range rdpBodyIndicators {
-		if strings.Contains(body, strings.ToLower(indicator)) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/webapplication/apache.go
+++ b/internal/app/fingerprint/modules/webapplication/apache.go
@@ -1,76 +1,41 @@
 package webapplication
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type ApacheLibrary struct{}
 
-var apachePaths = []string{
-	"", // Root
-	"/server-status",
-	"/icons/",
-	"/manual/",
-	"/cgi-bin/",
-	"/.htaccess",
+func (apLib *ApacheLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleApache)
 }
 
-func (apLib *ApacheLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleApache),
-		Finding: false,
+func (apLib *ApacheLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
+		"/server-status",
+		"/icons",
+		"/manual",
+		"/cgi-bin",
+		"/.htaccess",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-
-	for _, path := range apachePaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if apLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (apLib *ApacheLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
-		return false
+func (apLib *ApacheLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
+
+func (apLib *ApacheLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":       {"apache"},
+		"x-powered-by": {""},
 	}
+}
 
-	// We're interested in responses even if they're not 200 OK
-	// Apache often reveals itself in error pages too
-
-	// Check headers for Apache indicators
-	for _, headerKey := range []string{"Server", "server", "X-Powered-By", "x-powered-by"} {
-		if serverHeader, ok := response.ResponseHeaders[headerKey]; ok {
-			if strings.Contains(strings.ToLower(serverHeader), "apache") {
-				return true
-			}
-		}
-	}
-
-	if response.ResponseBody == nil {
-		return false
-	}
-
-	// Check body for Apache indicators
-	apacheBodyIndicators := []string{
+func (apLib *ApacheLibrary) BodyIndicators() []string {
+	return []string{
 		"<address>apache",
 		"apache server at",
 		"powered by apache",
@@ -79,13 +44,4 @@ func (apLib *ApacheLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
 		"<title>apache status</title>",
 		"apache tomcat",
 	}
-
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range apacheBodyIndicators {
-		if strings.Contains(body, strings.ToLower(indicator)) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/app/fingerprint/modules/webapplication/nginx.go
+++ b/internal/app/fingerprint/modules/webapplication/nginx.go
@@ -1,74 +1,41 @@
 package webapplication
 
 import (
-	"strings"
-
 	webscan "github.com/Method-Security/webscan/generated/go/app"
 	common "github.com/Method-Security/webscan/generated/go/common"
-	"github.com/Method-Security/webscan/utils"
 )
 
 type NginxLibrary struct{}
 
-var nginxPaths = []string{
-	"", // Root
-	"/nginx_status",
-	"/status",
-	"/.nginx-debian.html",
-	"/50x.html",
-	"/404.html",
+func (ngLib *NginxLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleNginx)
 }
 
-func (ngLib *NginxLibrary) ModuleRun(target string, config *webscan.AppFingerprintConfig) (*webscan.AppFingerprintAttemptInfo, []string) {
-	attempt := webscan.AppFingerprintAttemptInfo{
-		Name:    webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleNginx),
-		Finding: false,
+func (ngLib *NginxLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
+		"/nginx_status",
+		"/status",
+		"/.nginx-debian.html",
+		"/50x.html",
+		"/404.html",
 	}
-	errors := []string{}
-
-	baseURL, parsedTargetPath, err := utils.SplitTarget(target)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return &attempt, errors
-	}
-
-	requests := []*common.RequestInfo{}
-
-	for _, path := range nginxPaths {
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
-		errors = append(errors, request.Errors...)
-
-		requests = append(requests, &request)
-		if ngLib.AnalyzeResponse(&request) {
-			attempt.Finding = true
-		}
-	}
-
-	attempt.Requests = requests
-	return &attempt, errors
+	return paths
 }
 
-func (ngLib *NginxLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
-	if response == nil || response.StatusCode == nil || response.ResponseHeaders == nil {
-		return false
-	}
+func (ngLib *NginxLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
 
-	// Check for "Server" or "server" headers
-	for _, headerKey := range []string{"Server", "server", "X-Powered-By", "x-powered-by"} {
-		if serverHeader, ok := response.ResponseHeaders[headerKey]; ok {
-			if strings.Contains(strings.ToLower(serverHeader), "nginx") {
-				return true
-			}
-		}
+func (ngLib *NginxLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":       {"nginx"},
+		"x-powered-by": {"nginx"},
 	}
+}
 
-	// If no body is present, we already checked headers
-	if response.ResponseBody == nil {
-		return false
-	}
-
-	// Check body for Nginx indicators
-	nginxBodyIndicators := []string{
+func (ngLib *NginxLibrary) BodyIndicators() []string {
+	return []string{
 		"<title>welcome to nginx</title>",
 		"<title>nginx error</title>",
 		"<title>test page for nginx</title>",
@@ -77,13 +44,4 @@ func (ngLib *NginxLibrary) AnalyzeResponse(response *common.RequestInfo) bool {
 		"<hr><center>nginx/",
 		"powered by nginx",
 	}
-
-	body := strings.ToLower(*response.ResponseBody)
-	for _, indicator := range nginxBodyIndicators {
-		if strings.Contains(body, indicator) {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
## New Modules: Layer 7 Fingerprint Detection of Remote Access Services
Added modules for 3 common remote access services

1. Citrix Gateway/NetScaler AAA
2. VMware Horizon
3. Windows RDS

## Why
Our banner grab tool, which finds the Layer 7 protocol and specific app that runs on that protocol, is insufficient for fingerprinting specific remote access applications. This is a specialized tool for fingerprinting those applications

## Code Clean Up
Common code was pulled out of the modules into the engine so that the modules just define paths, request configurations, Header Indicators and Body Indicators. This will increase code maintainability and speed at which new modules can be created


