### PR TITLE
Webscan: Dont follow redirect for Fingerprint Tools

### DIFF
--- a/internal/app/enumerate/k8s.go
+++ b/internal/app/enumerate/k8s.go
@@ -24,7 +24,7 @@ func PerformAppEnumerateK8s(ctx context.Context, target string, timeout int) *we
 	attempts := []*webscan.AppEnumerateK8SAttemptInfo{}
 	for _, path := range commonK8spaths {
 		attempt := webscan.AppEnumerateK8SAttemptInfo{Path: path}
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, timeout)
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath+path, common.HttpMethodGet, common.RequestParams{}, timeout, false)
 
 		if request.Errors != nil {
 			errors = append(errors, request.Errors...)

--- a/internal/app/fingerprint/engine.go
+++ b/internal/app/fingerprint/engine.go
@@ -158,7 +158,7 @@ func (e *Engine) Run(ctx context.Context, target string, timeout int) (*webscan.
 		method, params := e.Library.RequestParams()
 
 		// Perform Request
-		request := utils.PerformRequestScan(baseURL, fullPath, method, params, timeout)
+		request := utils.PerformRequestScan(baseURL, fullPath, method, params, timeout, false)
 		errors = append(errors, request.Errors...)
 
 		requests = append(requests, &request)

--- a/internal/webserver/headergrab.go
+++ b/internal/webserver/headergrab.go
@@ -22,7 +22,7 @@ func PerformWebserverHeadergrab(ctx context.Context, config *webscan.WebserverHe
 			continue
 		}
 
-		request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+		request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodGet, common.RequestParams{}, config.Timeout, false)
 
 		if request.Errors != nil {
 			errors = append(errors, request.Errors...)

--- a/internal/webserver/ratelimit.go
+++ b/internal/webserver/ratelimit.go
@@ -32,7 +32,7 @@ func PerformWebserverRatelimit(ctx context.Context, config *webscan.WebserverRat
 		// Track if a 200 OK response was previously detected for this target
 		var hasSeen200 bool
 		for requestNumber := 1; requestNumber <= config.MaxRequests; requestNumber++ {
-			request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodGet, common.RequestParams{}, config.Timeout)
+			request := utils.PerformRequestScan(baseURL, parsedTargetPath, common.HttpMethodGet, common.RequestParams{}, config.Timeout, true)
 
 			if rateLimitDetected(&request, hasSeen200) {
 				targetInfo.DetectedRequest = &webscan.WebserverRateLimitAttemptInfo{

--- a/utils/request.go
+++ b/utils/request.go
@@ -16,7 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-func PerformRequestScan(baseURL, path string, method common.HttpMethod, params common.RequestParams, timeout int) common.RequestInfo {
+func PerformRequestScan(baseURL, path string, method common.HttpMethod, params common.RequestParams, timeout int, followRedirects bool) common.RequestInfo {
 	normalizedPath := strings.TrimRight(path, "/")
 	if normalizedPath == "" {
 		normalizedPath = "/"
@@ -61,7 +61,7 @@ func PerformRequestScan(baseURL, path string, method common.HttpMethod, params c
 	responseHeader := make(map[string]string)
 	// Create and send the request based on the presence of escape characters
 	if !hasEscapeChars {
-		resp, err := sendRequest(method, fullURL.String(), reqBody, contentType, params.HeaderParams, timeout)
+		resp, err := sendRequest(method, fullURL.String(), reqBody, contentType, params.HeaderParams, timeout, followRedirects)
 		if err != nil {
 			request.Errors = append(request.Errors, err.Error())
 			return request
@@ -87,7 +87,7 @@ func PerformRequestScan(baseURL, path string, method common.HttpMethod, params c
 		}
 	} else {
 		// Use sendFastHTTPRequest if escape characters are present
-		resp, err := sendFastHTTPRequest(string(method), fullURL.String(), responseBody, contentType, params.HeaderParams)
+		resp, err := sendFastHTTPRequest(string(method), fullURL.String(), responseBody, contentType, params.HeaderParams, followRedirects)
 		if err != nil {
 			request.Errors = append(request.Errors, err.Error())
 			return request
@@ -162,7 +162,7 @@ func prepareRequestBody(params common.RequestParams) (io.Reader, string, error) 
 	return nil, "", nil
 }
 
-func sendRequest(method common.HttpMethod, url string, body io.Reader, contentType string, headers map[string]string, timeout int) (*http.Response, error) {
+func sendRequest(method common.HttpMethod, url string, body io.Reader, contentType string, headers map[string]string, timeout int, followRedirects bool) (*http.Response, error) {
 	req, err := http.NewRequest(string(method), url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
@@ -180,6 +180,12 @@ func sendRequest(method common.HttpMethod, url string, body io.Reader, contentTy
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !followRedirects {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -189,7 +195,7 @@ func sendRequest(method common.HttpMethod, url string, body io.Reader, contentTy
 	return resp, nil
 }
 
-func sendFastHTTPRequest(method, url string, body string, contentType string, headers map[string]string) (*fasthttp.Response, error) {
+func sendFastHTTPRequest(method, url string, body string, contentType string, headers map[string]string, followRedirects bool) (*fasthttp.Response, error) {
 	// Prepare the fasthttp request and response objects
 	req := fasthttp.AcquireRequest()
 	defer fasthttp.ReleaseRequest(req)
@@ -208,7 +214,12 @@ func sendFastHTTPRequest(method, url string, body string, contentType string, he
 		req.Header.Set(key, value)
 	}
 
-	err := fasthttp.Do(req, resp)
+	var err error
+	if followRedirects {
+		err = fasthttp.DoRedirects(req, resp, 10) // Follow up to 10 redirects
+	} else {
+		err = fasthttp.Do(req, resp)
+	}
 	if err != nil {
 		fasthttp.ReleaseResponse(resp)
 		return nil, fmt.Errorf("failed to perform request: %v", err)


### PR DESCRIPTION
## Problem
We were encountering false positives when testing routes because our system was automatically following HTTP redirects. This caused our tests to receive 200 status codes instead of the expected 302 redirect status codes, masking the actual redirect behavior

## Update
Modified the request configuration to disable automatic redirect following by setting the redirect parameter to false. This ensures our tests correctly capture the 302 status code.