### PR TITLE
Add IIS fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ webscan vuln --severity INFO --tags swagger --tags fastapi --tags api --target e
 
 6. OR run command without shell example: `docker run webscan:local app enumerate graphql --target https://countries.trevorblades.com/ -o json`
 
+### Fern
+If updating the fern yaml configuration you need to [install](https://buildwithfern.com/learn/cli-reference/overview) Fern CLI. After installation you can execute `fern generate` to generate the updates.
 
 ### Note:
 This tool runs on a headless-shell base image to support chrome/chromium browser automation. The dockerfile uses debian-based install tools. 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -112,6 +112,7 @@ for the specified resource type.`,
 	webApplicationModules := strings.Join([]string{
 		string(webscan.WebApplicationModuleApache),
 		string(webscan.WebApplicationModuleNginx),
+                string(webscan.WebApplicationModuleIis),
 	}, ", ")
 
 	fingerprintCmd.Flags().StringSlice("targets", []string{}, "URL target to perform fingerprint against")

--- a/docs/docs/app.md
+++ b/docs/docs/app.md
@@ -39,7 +39,7 @@ Usage:
 
 Flags:
   -h, --help                  help for fingerprint
-      --modules strings       Modules to run (APIApplication: FASTAPI, GRAPHQL, GRPC, SWAGGER, K8S, WORDPRESS; CloudBucket: AWSS3, AZUREBLOB; WebApplication: APACHE, NGINX)
+      --modules strings       Modules to run (APIApplication: FASTAPI, GRAPHQL, GRPC, SWAGGER, K8S, WORDPRESS; CloudBucket: AWSS3, AZUREBLOB; WebApplication: APACHE, NGINX, IIS)
       --resourcetype string   Resource type to fingerprint (APIAPPLICATION, CLOUDBUCKET, WEBAPPLICATION)
       --successfulonly        Only show successful attempts
       --targets strings       URL target to perform fingerprint against

--- a/fern/definition/app/fingerprint.yml
+++ b/fern/definition/app/fingerprint.yml
@@ -26,6 +26,7 @@ types:
     enum:
       - APACHE
       - NGINX
+      - IIS
   AppFingerprintResourceModule:
     union:
       ApiApplicationModule: ApiApplicationModule

--- a/generated/go/app/types.go
+++ b/generated/go/app/types.go
@@ -480,6 +480,7 @@ type WebApplicationModule string
 const (
 	WebApplicationModuleApache WebApplicationModule = "APACHE"
 	WebApplicationModuleNginx  WebApplicationModule = "NGINX"
+	WebApplicationModuleIis    WebApplicationModule = "IIS"
 )
 
 func NewWebApplicationModuleFromString(s string) (WebApplicationModule, error) {
@@ -488,6 +489,8 @@ func NewWebApplicationModuleFromString(s string) (WebApplicationModule, error) {
 		return WebApplicationModuleApache, nil
 	case "NGINX":
 		return WebApplicationModuleNginx, nil
+	case "IIS":
+		return WebApplicationModuleIis, nil
 	}
 	var t WebApplicationModule
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/internal/app/fingerprint/engine.go
+++ b/internal/app/fingerprint/engine.go
@@ -56,6 +56,7 @@ func NewEngine(config *webscan.AppFingerprintConfig) *Engine {
 			webscan.AppFingerprintResourceTypeWebapplication: {
 				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleApache): &webapplication.ApacheLibrary{},
 				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleNginx):  &webapplication.NginxLibrary{},
+				*webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleIis):    &webapplication.IISLibrary{},
 			},
 		},
 	}

--- a/internal/app/fingerprint/modules/webapplication/iis.go
+++ b/internal/app/fingerprint/modules/webapplication/iis.go
@@ -1,0 +1,42 @@
+package webapplication
+
+import (
+	webscan "github.com/Method-Security/webscan/generated/go/app"
+	common "github.com/Method-Security/webscan/generated/go/common"
+)
+
+type IISLibrary struct{}
+
+func (iisLib *IISLibrary) Name() *webscan.AppFingerprintResourceModule {
+	return webscan.NewAppFingerprintResourceModuleFromWebApplicationModule(webscan.WebApplicationModuleIis)
+}
+
+func (iisLib *IISLibrary) Paths() []string {
+	paths := []string{
+		"", // Root
+		"/aspnet_client",
+		"/asp-stuff",
+		"/iisstart.htm",
+		"/iishelp",
+		"/iisadmpwd",
+		"/webadmin",
+		"/Scripts",
+		"/localstart.asp",
+	}
+	return paths
+}
+
+func (iisLib *IISLibrary) RequestParams() (common.HttpMethod, common.RequestParams) {
+	return common.HttpMethodGet, common.RequestParams{}
+}
+
+func (iisLib *IISLibrary) HeaderIndicators() map[string][]string {
+	return map[string][]string{
+		"server":       {"Microsoft-IIS"},
+		"x-powered-by": {"ASP.NET"},
+	}
+}
+
+func (iisLib *IISLibrary) BodyIndicators() []string {
+	return []string{}
+}


### PR DESCRIPTION
This add a new WEBAPPLICATION fingerprint for Microsoft Internet Information Services (IIS).

This builds on the existing framework used for NGINX and Apache and simply looks for different headers.