### PR TITLE
Fix gRPC enumerate

### DIFF
--- a/internal/app/enumerate/grpc.go
+++ b/internal/app/enumerate/grpc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	webscan "github.com/Method-Security/webscan/generated/go/app/enumerate"
@@ -18,6 +19,9 @@ import (
 // PerformAppEnumerateGrpc performs a gRPC scan against a target URL and returns the report.
 func PerformAppEnumerateGrpc(ctx context.Context, target string) webscan.RoutesReport {
 	report := webscan.RoutesReport{Target: target, BaseEndpointUrl: target, AppType: webscan.ApiTypeGrpc}
+
+	// Strip scheme if present
+	target = strings.TrimPrefix(strings.TrimPrefix(target, "http://"), "https://")
 
 	conn, err := connectToGRPCServer(target)
 	if err != nil {


### PR DESCRIPTION
### TL;DR

Strip HTTP/HTTPS scheme from gRPC target URLs before connection

### What changed?

Added logic to strip `http://` and `https://` prefixes from the target URL in the `PerformAppEnumerateGrpc` function before attempting to connect to the gRPC server. This ensures that the connection is made to the hostname directly without the scheme.

### How to test?

1. Run the application with a gRPC target that includes a scheme (e.g., `https://example.com`)
2. Verify that the connection is successful and the scheme is properly removed
3. Test with both HTTP and HTTPS schemes to ensure both are handled correctly

### Why make this change?

gRPC connections typically don't use HTTP/HTTPS schemes in the connection string. This change prevents connection failures when users provide URLs with schemes, making the API more forgiving and user-friendly by automatically handling this common input format.