### PR TITLE
GraphQL Fern Update

### DIFF
--- a/fern/definition/app/enumerate/graphql.yml
+++ b/fern/definition/app/enumerate/graphql.yml
@@ -20,4 +20,4 @@ types:
   GraphQLQuery:
     properties:
       type: string
-      fields: list<string>
+      fields: optional<list<string>>

--- a/internal/app/enumerate/graphql.go
+++ b/internal/app/enumerate/graphql.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	webscan "github.com/Method-Security/webscan/generated/go/app/enumerate"
@@ -19,7 +20,7 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) webscan.Rout
 	report := webscan.RoutesReport{Target: target, AppType: webscan.ApiTypeGraphQl}
 
 	basePath, baseEndpointURL := extractBasePathAndEndpoint(target)
-	report.BaseEndpointUrl = baseEndpointURL
+	report.BaseEndpointUrl = baseEndpointURL + basePath
 
 	addTopLevelRoute(&report, basePath)
 
@@ -46,13 +47,16 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) webscan.Rout
 }
 
 func extractBasePathAndEndpoint(target string) (string, string) {
-	urlParts := strings.Split(target, "/")
-	basePath := "/"
-	if len(urlParts) > 3 {
-		basePath = "/" + strings.Join(urlParts[3:], "/")
-		return basePath, strings.Join(urlParts[:3], "/")
+	u, err := url.Parse(target)
+	if err != nil {
+		return "/", target // fallback if parsing fails
 	}
-	return basePath, strings.Join(urlParts, "/")
+	baseEndpoint := u.Scheme + "://" + u.Host
+	basePath := u.Path
+	if basePath == "" {
+		basePath = "/"
+	}
+	return basePath, baseEndpoint
 }
 
 func addTopLevelRoute(report *webscan.RoutesReport, basePath string) {

--- a/internal/app/enumerate/graphql.go
+++ b/internal/app/enumerate/graphql.go
@@ -20,7 +20,7 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) webscan.Rout
 	report := webscan.RoutesReport{Target: target, AppType: webscan.ApiTypeGraphQl}
 
 	basePath, baseEndpointURL := extractBasePathAndEndpoint(target)
-	report.BaseEndpointUrl = baseEndpointURL + basePath
+	report.BaseEndpointUrl = baseEndpointURL
 
 	addTopLevelRoute(&report, basePath)
 


### PR DESCRIPTION
# Fix GraphQL URL extraction and update Fern definition

- Updated the `GraphQLQuery` type in Fern definition to make `fields` property optional
- Improved the `extractBasePathAndEndpoint` function to properly parse URLs using Go's `url.Parse` instead of string splitting
- Fixed base path extraction to correctly handle various URL formats