### PR TITLE
HTTP Request Fern v2

### DIFF
--- a/fern/definition/common/requests.yml
+++ b/fern/definition/common/requests.yml
@@ -12,45 +12,47 @@ types:
       - CONNECT
       - TRACE
 
-  # Body Kind Enum
-  BodyKind:
-  enum:
-    - json # parses to structured object
-    - form # application/x-www-form-urlencoded
-    - multipart # multipart/form-data
-    - text # any text/* that is NOT form-urlencoded
-    - binary # everything else (images, pdf, video, etc.)
+  # Leaf payload types
+  JsonBody:
+    properties:
+      data: unknown # any JSON structure
+      mimeType: optional<string>
 
-  Part:
+  FormBody:
+    properties:
+      fields: map<string, string>
+      mimeType: optional<string>
+
+  BinaryBody:
+    properties:
+      base64: base64
+      mimeType: optional<string>
+
+  MultipartPart:
     properties:
       headers: optional<map<string, string>>
-      body: Body # recursive reuse
+      content: BinaryBody
 
-  # Body Union
+  MultipartBody:
+    properties:
+      parts: list<MultipartPart>
+      mimeType: optional<string>
+
+  TextBody:
+    properties:
+      value: string
+      mimeType: optional<string>
+      encoding: optional<string>
+
+  # Discriminated Union
   Body:
-    discriminated: kind
+    discriminant: kind
     union:
-      json:
-        properties:
-          data: unknown # parsed JSON
-          mimeType: optional<string> # default application/json
-      form:
-        properties:
-          fields: map<string, string> # key-value pairs
-          mimeType: optional<string> # default application/x-www-form-urlencoded
-      multipart:
-        properties:
-          parts: list<Part>
-          mimeType: optional<string> # default multipart/form-data
-      text:
-        properties:
-          value: string # UTF-8 by convention
-          mimeType: optional<string> # text/plain, text/html, text/csv, …
-          encoding: optional<string> # fallback if not UTF-8
-      binary:
-        properties:
-          base64: string # opaque bytes
-          mimeType: optional<string> # image/png, video/mp4, application/pdf, …
+      json: JsonBody
+      form: FormBody
+      multipart: MultipartBody
+      text: TextBody
+      binary: BinaryBody
 
   # Request Structure
   RequestInfo:

--- a/fern/definition/common/requests.yml
+++ b/fern/definition/common/requests.yml
@@ -68,7 +68,7 @@ types:
       statusCode: optional<integer>
       responseBody: optional<Body>
       responseHeaders: optional<map<string, list<string>>>
-      receivedAt: datetime
+      receivedAt: optional<datetime>
       sizeBytes: optional<integer>
       errors: optional<list<string>>
       timestamp: datetime

--- a/fern/definition/common/requests.yml
+++ b/fern/definition/common/requests.yml
@@ -54,16 +54,24 @@ types:
       text: TextBody
       binary: BinaryBody
 
+  # Request Params
+  RequestParams:
+    properties:
+      pathParams: optional<map<string, string>>
+      queryParams: optional<map<string, string>>
+      headerParams: optional<map<string, list<string>>>
+      body: optional<Body>
+
   # Request Structure
   RequestInfo:
     properties:
       baseUrl: string
       path: string
       method: HttpMethod
-      pathParams: optional<map<string, string>>
-      queryParams: optional<map<string, string>>
-      headers: optional<map<string, list<string>>>
+      baseHeaders: optional<map<string, list<string>>>
+      parameters: optional<RequestParams>
       body: optional<Body>
+      timestamp: datetime
       redirectChain: optional<list<string>>
       statusCode: optional<integer>
       responseBody: optional<Body>
@@ -71,12 +79,3 @@ types:
       receivedAt: optional<datetime>
       sizeBytes: optional<integer>
       errors: optional<list<string>>
-      timestamp: datetime
-
-  # Request Params
-  RequestParams:
-    properties:
-      pathParams: optional<map<string, string>>
-      queryParams: optional<map<string, string>>
-      headers: optional<map<string, list<string>>>
-      body: optional<Body>

--- a/fern/definition/common/requests.yml
+++ b/fern/definition/common/requests.yml
@@ -11,6 +11,47 @@ types:
       - HEAD
       - CONNECT
       - TRACE
+
+  # Body Kind Enum
+  BodyKind:
+  enum:
+    - json # parses to structured object
+    - form # application/x-www-form-urlencoded
+    - multipart # multipart/form-data
+    - text # any text/* that is NOT form-urlencoded
+    - binary # everything else (images, pdf, video, etc.)
+
+  Part:
+    properties:
+      headers: optional<map<string, string>>
+      body: Body # recursive reuse
+
+  # Body Union
+  Body:
+    discriminated: kind
+    union:
+      json:
+        properties:
+          data: unknown # parsed JSON
+          mimeType: optional<string> # default application/json
+      form:
+        properties:
+          fields: map<string, string> # key-value pairs
+          mimeType: optional<string> # default application/x-www-form-urlencoded
+      multipart:
+        properties:
+          parts: list<Part>
+          mimeType: optional<string> # default multipart/form-data
+      text:
+        properties:
+          value: string # UTF-8 by convention
+          mimeType: optional<string> # text/plain, text/html, text/csv, …
+          encoding: optional<string> # fallback if not UTF-8
+      binary:
+        properties:
+          base64: string # opaque bytes
+          mimeType: optional<string> # image/png, video/mp4, application/pdf, …
+
   # Request Structure
   RequestInfo:
     properties:
@@ -19,22 +60,21 @@ types:
       method: HttpMethod
       pathParams: optional<map<string, string>>
       queryParams: optional<map<string, string>>
-      headerParams: optional<map<string, string>>
-      bodyParams: optional<string>
-      formParams: optional<map<string, string>>  
-      multipartParams: optional<map<string, string>>
+      headers: optional<map<string, list<string>>>
+      body: optional<Body>
       redirectChain: optional<list<string>>
       statusCode: optional<integer>
-      responseBody: optional<string>
-      responseHeaders: optional<map<string, string>>
+      responseBody: optional<Body>
+      responseHeaders: optional<map<string, list<string>>>
+      receivedAt: datetime
+      sizeBytes: optional<integer>
       errors: optional<list<string>>
       timestamp: datetime
+
   # Request Params
   RequestParams:
     properties:
       pathParams: optional<map<string, string>>
       queryParams: optional<map<string, string>>
-      headerParams: optional<map<string, string>>
-      bodyParams: optional<string>
-      formParams: optional<map<string, string>>
-      multipartParams: optional<map<string, string>>
+      headers: optional<map<string, list<string>>>
+      body: optional<Body>

--- a/fern/definition/spider/spider.yml
+++ b/fern/definition/spider/spider.yml
@@ -1,0 +1,15 @@
+imports:
+  requests: ../common/requests.yml
+types:
+  WebRoute:
+    properties:
+      url: string
+      path: optional<string>
+      method: optional<requests.HttpMethod>
+      requestParams: optional<list<requests.RequestParams>>
+  WebSpiderReport:
+    properties:
+      target: string
+      routes: optional<list<WebRoute>>
+      urls: optional<list<string>>
+      errors: optional<list<string>>

--- a/internal/app/enumerate/swagger.go
+++ b/internal/app/enumerate/swagger.go
@@ -81,13 +81,13 @@ func PerformAppEnumerateSwagger(ctx context.Context, target string, timeout int)
 		}
 
 		var docType map[string]interface{}
-		if err := json.Unmarshal([]byte(*resp.ResponseBody), &docType); err != nil {
+		if err := json.Unmarshal([]byte(resp.ResponseBody.GetText().GetValue()), &docType); err != nil {
 			continue
 		}
 
 		if _, ok := docType["swagger"]; ok || docType["openapi"] != nil {
 			swaggerURL = target + path // full URL for the report
-			bodyBytes = []byte(*resp.ResponseBody)
+			bodyBytes = []byte(resp.ResponseBody.GetText().GetValue())
 			foundSpec = true
 			break
 		}

--- a/internal/app/enumerate/webserver/iis.go
+++ b/internal/app/enumerate/webserver/iis.go
@@ -117,8 +117,8 @@ func enumerateSite(target string, timeout int) (*enumerateWebserverFern.IisSite,
 			FollowRedirects: FollowRedirects,
 			Insecure:        true,
 		})
-		if nf.ResponseBody != nil {
-			if v := parseIisVersionFromBody(*nf.ResponseBody); v != "" {
+		if nf.ResponseBody != nil && nf.ResponseBody.GetText() != nil {
+			if v := parseIisVersionFromBody(nf.ResponseBody.GetText().GetValue()); v != "" {
 				site.Server = &enumerateWebserverFern.WebServerInfo{Name: "Microsoft-IIS", Version: &v}
 			}
 		}

--- a/internal/app/enumerate/wordpress/plugins.go
+++ b/internal/app/enumerate/wordpress/plugins.go
@@ -125,9 +125,9 @@ func scanTarget(url string, plugins []string, timeout int) (enumerateWordpressFe
 		errors = append(errors, errs...)
 	}
 	// Base response body detection methods
-	htmlPlugins := checkHTMLForPlugins(accessRequest.ResponseBody)
-	registeredPlugins := checkRegisteredPlugins(accessRequest.ResponseBody)
-	cssPlugins := checkCSSReferences(accessRequest.ResponseBody)
+	htmlPlugins := checkHTMLForPlugins(accessRequest.ResponseBody.GetText())
+	registeredPlugins := checkRegisteredPlugins(accessRequest.ResponseBody.GetText())
+	cssPlugins := checkCSSReferences(accessRequest.ResponseBody.GetText())
 
 	// Combine results with proper deduplication
 	pluginsMap := make(map[string]*enumerateWordpressFern.WordpressPlugin)
@@ -217,7 +217,7 @@ func checkWordPressAPI(url string, plugins []string, timeout int) ([]*enumerateW
 	}
 
 	var apiResponse WordPressAPIResponse
-	if err := json.Unmarshal([]byte(*apiRequest.ResponseBody), &apiResponse); err == nil {
+	if err := json.Unmarshal([]byte(apiRequest.ResponseBody.GetText().GetValue()), &apiResponse); err == nil {
 		// Look for plugin namespaces (they often start with plugin-specific prefixes)
 		for _, namespace := range apiResponse.Namespaces {
 			// Plugins typically register their REST API namespaces in the format 'plugin-name/v1' or 'plugin-name/version-number',
@@ -282,7 +282,7 @@ func fetchPluginsFromAPI(baseURL string, path string, timeout int) []*enumerateW
 
 	// Try to parse as JSON array of plugins
 	var pluginList []map[string]interface{}
-	if err := json.Unmarshal([]byte(*apiRequest.ResponseBody), &pluginList); err == nil {
+	if err := json.Unmarshal([]byte(apiRequest.ResponseBody.GetText().GetValue()), &pluginList); err == nil {
 		for _, pluginData := range pluginList {
 			name, _ := pluginData["name"].(string)
 			version, _ := pluginData["version"].(string)
@@ -301,7 +301,7 @@ func fetchPluginsFromAPI(baseURL string, path string, timeout int) []*enumerateW
 }
 
 // checkHTMLForPlugins scans the HTML for common plugin paths
-func checkHTMLForPlugins(baseResponseBody *string) []*enumerateWordpressFern.WordpressPlugin {
+func checkHTMLForPlugins(baseResponseBody *common.TextBody) []*enumerateWordpressFern.WordpressPlugin {
 	plugins := []*enumerateWordpressFern.WordpressPlugin{}
 
 	// Different regex patterns to find plugin references
@@ -327,7 +327,7 @@ func checkHTMLForPlugins(baseResponseBody *string) []*enumerateWordpressFern.Wor
 	// match[1] = plugin name
 	// match[2] = version
 	for _, pattern := range patterns {
-		matches := pattern.regex.FindAllStringSubmatch(*baseResponseBody, -1)
+		matches := pattern.regex.FindAllStringSubmatch(baseResponseBody.GetValue(), -1)
 		for _, match := range matches {
 			if len(match) > pattern.nameGroup {
 				// Extract plugin name
@@ -386,13 +386,13 @@ func checkReadmeFiles(url string, plugins []string, timeout int) ([]*enumerateWo
 		}
 
 		// If readme.txt is empty, it's not a real plugin
-		if readmeRequest.ResponseBody == nil || *readmeRequest.ResponseBody == "" {
+		if readmeRequest.ResponseBody == nil || readmeRequest.ResponseBody.GetText() == nil || readmeRequest.ResponseBody.GetText().GetValue() == "" {
 			continue
 		}
 
 		// Try to extract version from readme.txt
 		versionRegex := regexp.MustCompile(`(?i)stable tag:\s*([0-9.]+)`)
-		versionMatch := versionRegex.FindStringSubmatch(*readmeRequest.ResponseBody)
+		versionMatch := versionRegex.FindStringSubmatch(readmeRequest.ResponseBody.GetText().GetValue())
 		var version *string
 
 		// Regex Info:
@@ -404,8 +404,9 @@ func checkReadmeFiles(url string, plugins []string, timeout int) ([]*enumerateWo
 
 		// Extract description if available
 		var description *string
-		if readmeRequest.ResponseBody != nil && *readmeRequest.ResponseBody != "" {
-			description = readmeRequest.ResponseBody
+		if readmeRequest.ResponseBody != nil && readmeRequest.ResponseBody.GetText() != nil {
+			desc := readmeRequest.ResponseBody.GetText().GetValue()
+			description = &desc
 		}
 
 		// Add plugin to list
@@ -421,12 +422,12 @@ func checkReadmeFiles(url string, plugins []string, timeout int) ([]*enumerateWo
 }
 
 // checkRegisteredPlugins checks for plugin registration in the page source
-func checkRegisteredPlugins(baseResponseBody *string) []*enumerateWordpressFern.WordpressPlugin {
+func checkRegisteredPlugins(baseResponseBody *common.TextBody) []*enumerateWordpressFern.WordpressPlugin {
 	plugins := []*enumerateWordpressFern.WordpressPlugin{}
 
 	// Look for wp_register_script, wp_enqueue_script, etc. with plugin names
 	regex := regexp.MustCompile(`/wp-content/plugins/([^/'"]+)/`)
-	matches := regex.FindAllStringSubmatch(*baseResponseBody, -1)
+	matches := regex.FindAllStringSubmatch(baseResponseBody.GetValue(), -1)
 
 	// Regex Info:
 	// match[0] = full match
@@ -444,12 +445,12 @@ func checkRegisteredPlugins(baseResponseBody *string) []*enumerateWordpressFern.
 }
 
 // checkCSSReferences looks for plugin-specific CSS files
-func checkCSSReferences(baseResponseBody *string) []*enumerateWordpressFern.WordpressPlugin {
+func checkCSSReferences(baseResponseBody *common.TextBody) []*enumerateWordpressFern.WordpressPlugin {
 	plugins := []*enumerateWordpressFern.WordpressPlugin{}
 
 	// Look for CSS links with plugin references
 	regex := regexp.MustCompile(`href=['"]([^'"]*wp-content/plugins/([^/'"]+)/[^'"]*\.css[^'"]*?)['"]`)
-	matches := regex.FindAllStringSubmatch(*baseResponseBody, -1)
+	matches := regex.FindAllStringSubmatch(baseResponseBody.GetValue(), -1)
 
 	// Regex Info:
 	// match[0] = full match

--- a/internal/app/fingerprint/engine.go
+++ b/internal/app/fingerprint/engine.go
@@ -92,8 +92,10 @@ func AnalyzeResponse(response *common.RequestInfo, module *webscan.AppResourceMo
 					}
 					// Loop through header values
 					for _, headerIndicatorValue := range headerIndicatorValues {
-						if strings.Contains(strings.ToLower(responseHeaderValue), strings.ToLower(headerIndicatorValue)) {
-							return true
+						for _, headerValue := range responseHeaderValue {
+							if strings.Contains(strings.ToLower(headerValue), strings.ToLower(headerIndicatorValue)) {
+								return true
+							}
 						}
 					}
 				}
@@ -104,7 +106,7 @@ func AnalyzeResponse(response *common.RequestInfo, module *webscan.AppResourceMo
 	// Analysis Response Body
 	bodyIndicators := module.BodyIndicators
 	if response.ResponseBody != nil && bodyIndicators != nil {
-		lowerBody := strings.ToLower(*response.ResponseBody)
+		lowerBody := strings.ToLower(response.ResponseBody.GetText().GetValue())
 		for _, indicator := range bodyIndicators {
 			if strings.Contains(lowerBody, indicator) {
 				return true

--- a/internal/routecapture/routecapture.go
+++ b/internal/routecapture/routecapture.go
@@ -24,7 +24,7 @@ func extractRoutes(ctx context.Context, target string, htmlContent string, baseU
 	errors := []string{}
 
 	log.Info("Parsing HTML content using goquery")
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent.GetText().GetValue()))
 	if err != nil {
 		log.Error("Failed to parse HTML content", svc1log.SafeParam("error", err))
 		errors = append(errors, err.Error())
@@ -114,7 +114,7 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod commo
 		}
 		log.Info("Page capture successful")
 		// Extract the routes and urls
-		routes, urls, errors = extractRoutes(ctx, target, *requestInfo.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodRequest, nil)
+		routes, urls, errors = extractRoutes(ctx, target, requestInfo.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodRequest, nil)
 
 	case common.CaptureMethodBrowser:
 		log.Info("Initiating page capture with browser method", svc1log.SafeParam("target", target))
@@ -127,7 +127,7 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod commo
 		log.Info("Page capture successful")
 
 		// Extract the routes and urls
-		routes, urls, errors = extractRoutes(ctx, target, *result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowser, capturer)
+		routes, urls, errors = extractRoutes(ctx, target, result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowser, capturer)
 
 		_ = capturer.Close(ctx)
 
@@ -143,7 +143,7 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod commo
 		log.Info("Page capture successful")
 
 		// Extract the routes and urls
-		routes, urls, errors = extractRoutes(ctx, target, *result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowserbase, capturer.Capturer)
+		routes, urls, errors = extractRoutes(ctx, target, result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowserbase, capturer.Capturer)
 
 		_ = capturer.Close(ctx)
 

--- a/internal/routecapture/routecapture.go
+++ b/internal/routecapture/routecapture.go
@@ -17,7 +17,7 @@ import (
 
 var FollowRedirects = true
 
-func extractRoutes(ctx context.Context, target string, htmlContent string, baseURLsOnly bool, captureStaticAssets bool, timeout int, captureMethod common.CaptureMethod, browserCapturer *headless.BrowserPageCapturer) ([]*routecapturefern.WebRoute, []string, []string) {
+func extractRoutes(ctx context.Context, target string, htmlContent common.Body, baseURLsOnly bool, captureStaticAssets bool, timeout int, captureMethod common.CaptureMethod, browserCapturer *headless.BrowserPageCapturer) ([]*routecapturefern.WebRoute, []string, []string) {
 	log := svc1log.FromContext(ctx)
 	routes := []*routecapturefern.WebRoute{}
 	urls := make(map[string]struct{})
@@ -114,7 +114,7 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod commo
 		}
 		log.Info("Page capture successful")
 		// Extract the routes and urls
-		routes, urls, errors = extractRoutes(ctx, target, requestInfo.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodRequest, nil)
+		routes, urls, errors = extractRoutes(ctx, target, *requestInfo.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodRequest, nil)
 
 	case common.CaptureMethodBrowser:
 		log.Info("Initiating page capture with browser method", svc1log.SafeParam("target", target))
@@ -127,7 +127,7 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod commo
 		log.Info("Page capture successful")
 
 		// Extract the routes and urls
-		routes, urls, errors = extractRoutes(ctx, target, result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowser, capturer)
+		routes, urls, errors = extractRoutes(ctx, target, *result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowser, capturer)
 
 		_ = capturer.Close(ctx)
 
@@ -143,7 +143,7 @@ func PerformRouteCapture(ctx context.Context, target string, captureMethod commo
 		log.Info("Page capture successful")
 
 		// Extract the routes and urls
-		routes, urls, errors = extractRoutes(ctx, target, result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowserbase, capturer.Capturer)
+		routes, urls, errors = extractRoutes(ctx, target, *result.ResponseBody, baseURLsOnly, captureStaticAssets, timeout, common.CaptureMethodBrowserbase, capturer.Capturer)
 
 		_ = capturer.Close(ctx)
 

--- a/internal/routecapture/staticassest/takeover.go
+++ b/internal/routecapture/staticassest/takeover.go
@@ -125,7 +125,7 @@ func isStaticAssetTakeOver(request *common.RequestInfo, fingerprints []routecapt
 		for _, responseBody := range fingerprint.ResponseBody {
 			// Convert the response body to lowercase to make the comparison case insensitive
 			lowerBody := strings.ToLower(responseBody)
-			lowerRequestBody := strings.ToLower(*request.ResponseBody)
+			lowerRequestBody := strings.ToLower(request.ResponseBody.GetText().GetValue())
 			if *request.StatusCode == fingerprint.StatusCode && strings.Contains(lowerRequestBody, lowerBody) {
 				successfulFingerprint = true
 				instance.Vulnerable = true

--- a/internal/webserver/ratelimit.go
+++ b/internal/webserver/ratelimit.go
@@ -76,7 +76,9 @@ func rateLimitDetected(request *common.RequestInfo, hasSeen200 bool) bool {
 	if request.StatusCode != nil && *request.StatusCode == http.StatusTooManyRequests {
 		return true
 	}
-	if request.ResponseHeaders != nil && request.ResponseHeaders["X-Retry-After"] != "" || request.ResponseHeaders["X-RateLimit-Remaining"] == "0" {
+	if request.ResponseHeaders != nil &&
+		((len(request.ResponseHeaders["X-Retry-After"]) > 0 && request.ResponseHeaders["X-Retry-After"][0] != "") ||
+			(len(request.ResponseHeaders["X-RateLimit-Remaining"]) > 0 && request.ResponseHeaders["X-RateLimit-Remaining"][0] == "0")) {
 		return true
 	}
 

--- a/utils/headless/browser.go
+++ b/utils/headless/browser.go
@@ -77,6 +77,9 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 	var statusCode int
 	var headers = map[string]string{}
 	redirectIntercepted := false
+	var timestamp time.Time
+	var receivedAt time.Time
+	var sizeBytes int
 
 	err = rod.Try(func() {
 		page := b.Browser.MustPage().Context(pageCtx)
@@ -132,6 +135,8 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 			page.MustEvalOnNewDocument(script)
 		}
 
+		timestamp = time.Now()
+
 		err = page.Navigate(url)
 		if err != nil {
 			if strings.Contains(err.Error(), "net::ERR_ABORTED") && redirectIntercepted {
@@ -178,12 +183,17 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 					log.Error("Failed to get HTML content", svc1log.SafeParam("error", err))
 					requestInfo.Errors = append(requestInfo.Errors, err.Error())
 				} else {
+					receivedAt = time.Now()
+					sizeBytes = len(htmlContent)
 					requestInfo.ResponseBody = &common.Body{
 						Kind: "text",
 						Text: &common.TextBody{
 							Value: htmlContent,
 						},
 					}
+					requestInfo.Timestamp = timestamp
+					requestInfo.ReceivedAt = &receivedAt
+					requestInfo.SizeBytes = &sizeBytes
 				}
 			}
 		}
@@ -198,7 +208,7 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 	if parsedURL, err := urlutil.Parse(url); err == nil {
 		requestInfo.Path = parsedURL.Path
 		parsedURL.Query().Iterate(func(key string, value []string) bool {
-			requestInfo.QueryParams[key] = value[0]
+			requestInfo.Parameters.QueryParams[key] = value[0]
 			return true
 		})
 	}

--- a/utils/headless/browser.go
+++ b/utils/headless/browser.go
@@ -180,6 +180,9 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 		requestInfo.Errors = append(requestInfo.Errors, err.Error())
 	}
 
+	requestInfo.ResponseBody = &htmlContent
+
+	log.Info("Parsing URL to get path and query parameters")
 	if parsedURL, err := urlutil.Parse(url); err == nil {
 		requestInfo.Path = parsedURL.Path
 		parsedURL.Query().Iterate(func(key string, value []string) bool {

--- a/utils/headless/browser.go
+++ b/utils/headless/browser.go
@@ -137,7 +137,16 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 			if strings.Contains(err.Error(), "net::ERR_ABORTED") && redirectIntercepted {
 				log.Info("Navigation aborted due to blocked redirect", svc1log.SafeParam("url", url))
 				requestInfo.StatusCode = &statusCode
-				requestInfo.ResponseHeaders = headers
+				// Convert headers (map[string]string) to map[string][]string, splitting on commas
+				headerMap := make(map[string][]string, len(headers))
+				for k, v := range headers {
+					parts := strings.Split(v, ",")
+					for i := range parts {
+						parts[i] = strings.TrimSpace(parts[i])
+					}
+					headerMap[k] = parts
+				}
+				requestInfo.ResponseHeaders = headerMap
 				requestInfo.RedirectChain = redirectChain
 				return
 			}
@@ -169,7 +178,12 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 					log.Error("Failed to get HTML content", svc1log.SafeParam("error", err))
 					requestInfo.Errors = append(requestInfo.Errors, err.Error())
 				} else {
-					requestInfo.ResponseBody = &htmlContent
+					requestInfo.ResponseBody = &common.Body{
+						Kind: "text",
+						Text: &common.TextBody{
+							Value: htmlContent,
+						},
+					}
 				}
 			}
 		}
@@ -179,8 +193,6 @@ func (b *BrowserPageCapturer) Capture(ctx context.Context, url string, options *
 		log.Error("Failed during headless capture", svc1log.SafeParam("url", url), svc1log.SafeParam("error", err))
 		requestInfo.Errors = append(requestInfo.Errors, err.Error())
 	}
-
-	requestInfo.ResponseBody = &htmlContent
 
 	log.Info("Parsing URL to get path and query parameters")
 	if parsedURL, err := urlutil.Parse(url); err == nil {

--- a/utils/request.go
+++ b/utils/request.go
@@ -20,6 +20,7 @@ type RequestOptions struct {
 	BaseURL         string
 	Path            string
 	Method          common.HttpMethod
+	BaseHeaders     map[string][]string
 	Params          common.RequestParams
 	FollowRedirects bool
 	Insecure        bool
@@ -28,10 +29,10 @@ type RequestOptions struct {
 
 func PerformRequestScan(options RequestOptions) common.RequestInfo {
 	request := common.RequestInfo{
-		BaseUrl:   options.BaseURL,
-		Path:      options.Path,
-		Method:    options.Method,
-		Timestamp: time.Now(),
+		BaseUrl:     options.BaseURL,
+		Path:        options.Path,
+		Method:      options.Method,
+		BaseHeaders: options.BaseHeaders,
 	}
 
 	// Construct the URL
@@ -50,7 +51,7 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 
 	// Check for escape characters in headers
 	hasEscapeChars := false
-	for key, values := range options.Params.Headers {
+	for key, values := range options.Params.HeaderParams {
 		if strings.Contains(key, "\r") || strings.Contains(key, "\n") || strings.Contains(key, "\\") || strings.Contains(key, "\u0000") {
 			hasEscapeChars = true
 			break
@@ -68,10 +69,14 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 
 	var statusCode int
 	var responseBody string
-	responseHeader := make(map[string][]string)
+	var timestamp = time.Now()
+	var receivedAt time.Time
+	var sizeBytes int
+	responseHeaders := make(map[string][]string)
 	// Create and send the request based on the presence of escape characters
 	if !hasEscapeChars {
-		resp, redirectChain, err := sendRequest(options.Method, fullURL.String(), reqBody, contentType, options.Params.Headers, options.Timeout, options.FollowRedirects, options.Insecure)
+		resp, redirectChain, err := sendRequest(options.Method, fullURL.String(), reqBody, contentType, options.Params.HeaderParams, options.Timeout, options.FollowRedirects, options.Insecure)
+		receivedAt = time.Now()
 		if err != nil {
 			request.Errors = append(request.Errors, err.Error())
 			return request
@@ -90,25 +95,28 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 		}
 		statusCode = resp.StatusCode
 		responseBody = string(body)
-		responseHeader = resp.Header
+		sizeBytes = int(len(body))
+		responseHeaders = resp.Header
 
 		// Populate report
-		populateReport(&request, statusCode, responseHeader, responseBody, options.Params, redirectChain)
+		populateReport(&request, statusCode, responseHeaders, responseBody, options.Params, redirectChain, timestamp, receivedAt, &sizeBytes)
 	} else {
 		// Use sendFastHTTPRequest if escape characters are present
-		resp, redirectChain, err := sendFastHTTPRequest(string(options.Method), fullURL.String(), responseBody, contentType, options.Params.Headers, options.FollowRedirects)
+		resp, redirectChain, err := sendFastHTTPRequest(string(options.Method), fullURL.String(), responseBody, contentType, options.Params.HeaderParams, options.FollowRedirects)
+		receivedAt = time.Now()
 		if err != nil {
 			request.Errors = append(request.Errors, err.Error())
 			return request
 		}
 		statusCode = resp.StatusCode()
 		responseBody = string(resp.Body())
+		sizeBytes = int(len(resp.Body()))
 		resp.Header.VisitAll(func(key, value []byte) {
-			responseHeader[string(key)] = append(responseHeader[string(key)], string(value))
+			responseHeaders[string(key)] = append(responseHeaders[string(key)], string(value))
 		})
 		fasthttp.ReleaseResponse(resp)
 		// Populate report
-		populateReport(&request, statusCode, responseHeader, responseBody, options.Params, redirectChain)
+		populateReport(&request, statusCode, responseHeaders, responseBody, options.Params, redirectChain, timestamp, receivedAt, &sizeBytes)
 	}
 
 	return request
@@ -274,7 +282,41 @@ func sendFastHTTPRequest(method, url string, body string, contentType string, he
 	return resp, redirectChain, nil
 }
 
-func populateReport(report *common.RequestInfo, statusCode int, headers map[string][]string, body string, params common.RequestParams, redirectChain []string) {
+// parseResponseBody parses the response body based on the Content-Type header and returns a *common.Body
+func parseResponseBody(body string, contentType string) *common.Body {
+	switch {
+	case strings.Contains(contentType, "application/json"):
+		var jsonData interface{}
+		if err := json.Unmarshal([]byte(body), &jsonData); err == nil {
+			return common.NewBodyFromJson(&common.JsonBody{Data: jsonData})
+		}
+		return common.NewBodyFromText(&common.TextBody{Value: body})
+	case strings.Contains(contentType, "application/x-www-form-urlencoded"):
+		formVals, err := url.ParseQuery(body)
+		if err == nil {
+			fields := make(map[string]string)
+			for k, v := range formVals {
+				if len(v) > 0 {
+					fields[k] = v[0]
+				}
+			}
+			return common.NewBodyFromForm(&common.FormBody{Fields: fields})
+		}
+		return common.NewBodyFromText(&common.TextBody{Value: body})
+	case strings.Contains(contentType, "text/"):
+		return common.NewBodyFromText(&common.TextBody{Value: body})
+	case strings.Contains(contentType, "multipart/"):
+		// For now, just store as text. Parsing multipart is complex and not always needed.
+		return common.NewBodyFromText(&common.TextBody{Value: body})
+	case strings.Contains(contentType, "application/octet-stream"):
+		// Could handle binary, but for now, just store as text
+		return common.NewBodyFromText(&common.TextBody{Value: body})
+	default:
+		return common.NewBodyFromText(&common.TextBody{Value: body})
+	}
+}
+
+func populateReport(report *common.RequestInfo, statusCode int, headers map[string][]string, body string, params common.RequestParams, redirectChain []string, timestamp time.Time, receivedAt time.Time, sizeBytes *int) {
 	if headers != nil {
 		report.ResponseHeaders = make(map[string][]string)
 		for key, values := range headers {
@@ -282,15 +324,26 @@ func populateReport(report *common.RequestInfo, statusCode int, headers map[stri
 		}
 	}
 
-	report.ResponseBody = common.NewBodyFromText(&common.TextBody{Value: body})
+	// Determine Content-Type
+	contentType := ""
+	if headers != nil {
+		if ctVals, ok := headers["Content-Type"]; ok && len(ctVals) > 0 {
+			contentType = ctVals[0]
+		}
+	}
+
+	report.ResponseBody = parseResponseBody(body, contentType)
 	report.StatusCode = &statusCode
 	report.RedirectChain = redirectChain
+	report.Timestamp = timestamp
+	report.ReceivedAt = &receivedAt
+	report.SizeBytes = sizeBytes
 
 	if len(params.PathParams) > 0 {
-		report.PathParams = params.PathParams
+		report.Parameters.PathParams = params.PathParams
 	}
 	if len(params.QueryParams) > 0 {
-		report.QueryParams = params.QueryParams
+		report.Parameters.QueryParams = params.QueryParams
 	}
 }
 

--- a/utils/request.go
+++ b/utils/request.go
@@ -42,7 +42,7 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 	}
 
 	// Prepare request body and content type
-	reqBody, contentType, err := prepareRequestBody(options.Params)
+	reqBody, contentType, err := prepareRequestBody(options.Params.Body)
 	if err != nil {
 		request.Errors = append(request.Errors, err.Error())
 		return request
@@ -50,23 +50,28 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 
 	// Check for escape characters in headers
 	hasEscapeChars := false
-	for key, value := range options.Params.HeaderParams {
+	for key, values := range options.Params.Headers {
 		if strings.Contains(key, "\r") || strings.Contains(key, "\n") || strings.Contains(key, "\\") || strings.Contains(key, "\u0000") {
 			hasEscapeChars = true
 			break
 		}
-		if strings.Contains(value, "\r") || strings.Contains(value, "\n") || strings.Contains(value, "\\") || strings.Contains(value, "\u0000") {
-			hasEscapeChars = true
+		for _, value := range values {
+			if strings.Contains(value, "\r") || strings.Contains(value, "\n") || strings.Contains(value, "\\") || strings.Contains(value, "\u0000") {
+				hasEscapeChars = true
+				break
+			}
+		}
+		if hasEscapeChars {
 			break
 		}
 	}
 
 	var statusCode int
 	var responseBody string
-	responseHeader := make(map[string]string)
+	responseHeader := make(map[string][]string)
 	// Create and send the request based on the presence of escape characters
 	if !hasEscapeChars {
-		resp, redirectChain, err := sendRequest(options.Method, fullURL.String(), reqBody, contentType, options.Params.HeaderParams, options.Timeout, options.FollowRedirects, options.Insecure)
+		resp, redirectChain, err := sendRequest(options.Method, fullURL.String(), reqBody, contentType, options.Params.Headers, options.Timeout, options.FollowRedirects, options.Insecure)
 		if err != nil {
 			request.Errors = append(request.Errors, err.Error())
 			return request
@@ -85,16 +90,13 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 		}
 		statusCode = resp.StatusCode
 		responseBody = string(body)
-		for key, values := range resp.Header {
-			if len(values) > 0 {
-				responseHeader[key] = values[0]
-			}
-		}
+		responseHeader = resp.Header
+
 		// Populate report
 		populateReport(&request, statusCode, responseHeader, responseBody, options.Params, redirectChain)
 	} else {
 		// Use sendFastHTTPRequest if escape characters are present
-		resp, redirectChain, err := sendFastHTTPRequest(string(options.Method), fullURL.String(), responseBody, contentType, options.Params.HeaderParams, options.FollowRedirects)
+		resp, redirectChain, err := sendFastHTTPRequest(string(options.Method), fullURL.String(), responseBody, contentType, options.Params.Headers, options.FollowRedirects)
 		if err != nil {
 			request.Errors = append(request.Errors, err.Error())
 			return request
@@ -102,7 +104,7 @@ func PerformRequestScan(options RequestOptions) common.RequestInfo {
 		statusCode = resp.StatusCode()
 		responseBody = string(resp.Body())
 		resp.Header.VisitAll(func(key, value []byte) {
-			responseHeader[string(key)] = string(value)
+			responseHeader[string(key)] = append(responseHeader[string(key)], string(value))
 		})
 		fasthttp.ReleaseResponse(resp)
 		// Populate report
@@ -135,50 +137,74 @@ func constructURL(baseURL, path string, pathParams, queryParams map[string]strin
 	return fullURL, nil
 }
 
-func prepareRequestBody(params common.RequestParams) (io.Reader, string, error) {
-	if params.BodyParams != nil && *params.BodyParams != "" {
-		if json.Valid([]byte(*params.BodyParams)) {
-			return strings.NewReader(*params.BodyParams), "application/json", nil
-		}
-		return bytes.NewReader([]byte(*params.BodyParams)), "text/plain", nil
+func prepareRequestBody(body *common.Body) (io.Reader, string, error) {
+	if body == nil {
+		return nil, "", nil
 	}
 
-	if len(params.FormParams) > 0 {
-		formValues := url.Values{}
-		for key, value := range params.FormParams {
-			formValues.Set(key, value)
+	switch body.GetKind() {
+	case "text":
+		if body.GetText() != nil {
+			return strings.NewReader(body.GetText().GetValue()), "text/plain", nil
 		}
-
-		encodedForm := formValues.Encode()
-		return strings.NewReader(encodedForm), "application/x-www-form-urlencoded", nil
-	}
-
-	if len(params.MultipartParams) > 0 {
-		body := &bytes.Buffer{}
-		writer := multipart.NewWriter(body)
-		for key, value := range params.MultipartParams {
-			if err := writer.WriteField(key, value); err != nil {
-				return nil, "", fmt.Errorf("failed to write multipart field: %v", err)
+	case "json":
+		if body.GetJson() != nil {
+			jsonBytes, err := json.Marshal(body.GetJson().GetData())
+			if err != nil {
+				return nil, "", err
 			}
+			return bytes.NewReader(jsonBytes), "application/json", nil
 		}
-		if err := writer.Close(); err != nil {
-			return nil, "", fmt.Errorf("failed to close multipart writer: %v", err)
+	case "form":
+		if body.GetForm() != nil {
+			formValues := url.Values{}
+			for key, value := range body.GetForm().GetFields() {
+				formValues.Set(key, value)
+			}
+			encodedForm := formValues.Encode()
+			return strings.NewReader(encodedForm), "application/x-www-form-urlencoded", nil
 		}
-		return body, writer.FormDataContentType(), nil
+	case "multipart":
+		if body.GetMultipart() != nil {
+			buf := &bytes.Buffer{}
+			writer := multipart.NewWriter(buf)
+			for _, part := range body.GetMultipart().GetParts() {
+				if part.GetContent() != nil {
+					// Assume each part is a file for simplicity
+					formFile, err := writer.CreateFormFile("file", "file.bin")
+					if err != nil {
+						return nil, "", err
+					}
+					_, err = formFile.Write(part.GetContent().GetBase64())
+					if err != nil {
+						return nil, "", err
+					}
+				}
+				for key, value := range part.GetHeaders() {
+					writer.WriteField(key, value)
+				}
+			}
+			if err := writer.Close(); err != nil {
+				return nil, "", err
+			}
+			return buf, writer.FormDataContentType(), nil
+		}
+	case "binary":
+		if body.GetBinary() != nil {
+			return bytes.NewReader(body.GetBinary().GetBase64()), "application/octet-stream", nil
+		}
 	}
-
 	return nil, "", nil
 }
 
-func sendRequest(method common.HttpMethod, url string, body io.Reader, contentType string, headers map[string]string, timeout int, followRedirects bool, insecure bool) (*http.Response, []string, error) {
+func sendRequest(method common.HttpMethod, url string, body io.Reader, contentType string, headers map[string][]string, timeout int, followRedirects bool, insecure bool) (*http.Response, []string, error) {
 	req, err := http.NewRequest(string(method), url, body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
-	for key, value := range headers {
-		req.Header.Add(key, value)
-	}
+	req.Header = headers
+
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
@@ -205,7 +231,7 @@ func sendRequest(method common.HttpMethod, url string, body io.Reader, contentTy
 	return resp, redirectChain, nil
 }
 
-func sendFastHTTPRequest(method, url string, body string, contentType string, headers map[string]string, followRedirects bool) (*fasthttp.Response, []string, error) {
+func sendFastHTTPRequest(method, url string, body string, contentType string, headers map[string][]string, followRedirects bool) (*fasthttp.Response, []string, error) {
 	// Prepare the fasthttp request and response objects
 	req := fasthttp.AcquireRequest()
 	defer fasthttp.ReleaseRequest(req)
@@ -220,8 +246,10 @@ func sendFastHTTPRequest(method, url string, body string, contentType string, he
 		req.Header.Set("Content-Type", contentType)
 	}
 
-	for key, value := range headers {
-		req.Header.Set(key, value)
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
 	}
 
 	redirectChain := []string{url}
@@ -246,15 +274,15 @@ func sendFastHTTPRequest(method, url string, body string, contentType string, he
 	return resp, redirectChain, nil
 }
 
-func populateReport(report *common.RequestInfo, statusCode int, headers map[string]string, body string, params common.RequestParams, redirectChain []string) {
+func populateReport(report *common.RequestInfo, statusCode int, headers map[string][]string, body string, params common.RequestParams, redirectChain []string) {
 	if headers != nil {
-		report.ResponseHeaders = make(map[string]string)
+		report.ResponseHeaders = make(map[string][]string)
 		for key, values := range headers {
 			report.ResponseHeaders[key] = values
 		}
 	}
 
-	report.ResponseBody = &body
+	report.ResponseBody = common.NewBodyFromText(&common.TextBody{Value: body})
 	report.StatusCode = &statusCode
 	report.RedirectChain = redirectChain
 
@@ -264,18 +292,6 @@ func populateReport(report *common.RequestInfo, statusCode int, headers map[stri
 	if len(params.QueryParams) > 0 {
 		report.QueryParams = params.QueryParams
 	}
-	if len(params.HeaderParams) > 0 {
-		report.HeaderParams = params.HeaderParams
-	}
-	if params.BodyParams != nil && *params.BodyParams != "" {
-		report.BodyParams = params.BodyParams
-	}
-	if len(params.FormParams) > 0 {
-		report.FormParams = params.FormParams
-	}
-	if len(params.MultipartParams) > 0 {
-		report.MultipartParams = params.MultipartParams
-	}
 }
 
 // GetHeader is a generic header helper (case‑insensitive)
@@ -283,12 +299,12 @@ func GetHeader(r *common.RequestInfo, name string) string {
 	if r.ResponseHeaders == nil {
 		return ""
 	}
-	if v, ok := r.ResponseHeaders[name]; ok {
-		return v
+	if v, ok := r.ResponseHeaders[name]; ok && len(v) > 0 {
+		return v[0]
 	}
 	for hn, hv := range r.ResponseHeaders {
-		if strings.EqualFold(hn, name) {
-			return hv
+		if strings.EqualFold(hn, name) && len(hv) > 0 {
+			return hv[0]
 		}
 	}
 	return ""


### PR DESCRIPTION
# Enhanced Request Structure with Improved Body Handling

This PR refactors the request/response structure to provide better support for different content types:

- Adds a discriminated union `Body` type with specialized subtypes for different content formats:
  - `JsonBody` for JSON data
  - `FormBody` for form data
  - `MultipartBody` for multipart content
  - `TextBody` for plain text
  - `BinaryBody` for binary data

- Updates header handling to support multiple values per header (map<string, list<string>>)

- Adds additional metadata fields to RequestInfo:
  - `receivedAt` timestamp
  - `sizeBytes` for response size tracking

- Updates all code that interacts with request/response bodies to use the new type system
- TODO: Need to ensure all modules are calculating `receivedAt` and `sizeBytes` and populating value.

This change improves type safety and provides better structure for handling different content types throughout the application.