### PR TITLE
Comments + Renames + CI Improvement

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -16,19 +16,52 @@ env:
   GO_VERSION: "1.24"
 
 jobs:
-  prepare-linux:
-    name: Prepare Linux
+  prepare-linux-arm:
+    name: Prepare Linux (arm64)
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Generate Fern Go Code
+        run: |
+          npm install -g fern-api
+          fern generate --group local
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: >-
+            build --single-target --clean --snapshot --timeout 60m
+            -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GOOS: linux
+          GOARCH: arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64-dist
+          path: dist/
+          retention-days: 7
+
+  prepare-linux-amd64:
+    name: Prepare Linux (amd64)
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
@@ -40,33 +73,25 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-
-      - name: Build ARM64 Builder Image
-        shell: bash
-        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
-
       - name: Build AMD64 Builder Image
-        shell: bash
         run: docker buildx build . --platform linux/amd64 --load --tag amdbuilder -f Dockerfile.builder
-
-      - name: Build ARM64 Image
-        shell: bash
-        run: docker run -v .:/app/webscan -e GOARCH=arm64 -e GOOS=linux -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} --rm armbuilder goreleaser build --single-target -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options}}
-
       - name: Build AMD64 Image
-        shell: bash
-        run: docker run -v .:/app/webscan -e GOARCH=amd64 -e GOOS=linux -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} --rm amdbuilder goreleaser build --single-target -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options}}
-
+        run: |
+          docker run -v $PWD:/app/webscan \
+            -e GOARCH=amd64 -e GOOS=linux \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
+            --rm amdbuilder goreleaser build --single-target \
+            -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-dist
+          name: linux-amd64-dist
           path: dist/
           retention-days: 7
 
@@ -87,16 +112,13 @@ jobs:
           brew install libpcap docker
           echo "LD_LIBRARY_PATH=$(brew --prefix)/Cellar/libpcap/*/lib" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest'
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         if: matrix.os == 'ubuntu-latest'
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         if: matrix.os == 'ubuntu-latest'
-
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
@@ -109,20 +131,17 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
@@ -131,7 +150,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-dist
@@ -142,7 +160,8 @@ jobs:
     name: Build
     needs:
       - prepare
-      - prepare-linux
+      - prepare-linux-arm
+      - prepare-linux-amd64
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -150,38 +169,30 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
           remove-haskell: "true"
-
       - name: Install Dependences
         run: sudo apt install libpcap-dev
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Show available Docker Buildx platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
-
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
-
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
-
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Login to docker.io registry
         uses: docker/login-action@v3
         with:
@@ -192,28 +203,23 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-
       - name: View Artifacts
         run: ls -al artifacts artifacts/*
-
       - name: Arrange Artifacts
         run: |
           mkdir -p output/build-linux_arm64/
@@ -221,16 +227,14 @@ jobs:
           mkdir -p output/build-darwin_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-dist/linux_arm64/build-linux_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
 
       - name: View Output
         run: ls -al output output/*
-
-      # release
       - uses: goreleaser/goreleaser-action@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
@@ -240,4 +244,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          COSIGN_EXPERIMENTAL: "true" 
+          COSIGN_EXPERIMENTAL: "true"

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -78,7 +78,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -90,7 +90,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationFingerprintConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, insecure, timeout)
+			config, err := getDiscoverApplicationFingerprintConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, verifyTLS, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -111,7 +111,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().String("resource-type", "", "Type of resource to fingerprint (e.g., web, api, cms)")
 	discoverApplicationCmd.Flags().StringSlice("modules", []string{}, "Specific fingerprinting modules to run")
 	discoverApplicationCmd.Flags().Bool("successful-only", false, "Only show successful fingerprint matches")
-	discoverApplicationCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	discoverApplicationCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	discoverApplicationCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 
 	// Mark Required Flags
@@ -141,7 +141,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -172,7 +172,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPageConfig(target, maxRedirects, insecure, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverPageConfig(target, maxRedirects, verifyTLS, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverpage.PerformPageCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -184,7 +184,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Config Flags
 	discoverPageCmd.Flags().Bool("screenshot", false, "Capture a screenshot of the page")
 	discoverPageCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
-	discoverPageCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	discoverPageCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	discoverPageCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	// Request Method Flags for all capture subcommands
 	discoverPageCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
@@ -226,7 +226,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -245,7 +245,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverProbeConfig(targets, maxRedirects, HTTPSOnly, insecure, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverProbeConfig(targets, maxRedirects, HTTPSOnly, verifyTLS, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate report
 			report, err := discoverprobe.PerformWebProbe(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -261,7 +261,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Config Flags
 	discoverProbeCmd.Flags().Bool("https-only", true, "Only probe HTTPS URLs")
 	discoverProbeCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
-	discoverProbeCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	discoverProbeCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	discoverProbeCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	// Request Method Flags
 	discoverProbeCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
@@ -313,7 +313,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -337,7 +337,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, insecure, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -351,7 +351,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverRouteCmd.Flags().Bool("ignore-static-assets", true, "Exclude static assets from route discovery")
 	discoverRouteCmd.Flags().Int("spider-depth", 1, "Maximum depth for route spidering")
 	discoverRouteCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
-	discoverRouteCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	discoverRouteCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	discoverRouteCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverRouteCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 
@@ -456,7 +456,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -482,7 +482,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get the config
-			config := getDiscoverSaasActiveConfig(orgs, *filteredSaasFingerprints, *filteredSsoFingerprints, saasCompanies, ssoCompanies, maxRedirects, successfulOnly, httpsOnly, insecure, timeout, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverSaasActiveConfig(orgs, *filteredSaasFingerprints, *filteredSsoFingerprints, saasCompanies, ssoCompanies, maxRedirects, successfulOnly, httpsOnly, verifyTLS, timeout, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate the report
 			report, err := discoversaasactive.LaunchDiscoverSaasActive(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -502,7 +502,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	saasActiveCmd.Flags().Bool("successful-only", false, "Only show successful attempts")
 	saasActiveCmd.Flags().Bool("https-only", true, "Only show successful attempts over HTTPS")
 	saasActiveCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
-	saasActiveCmd.Flags().Bool("insecure", false, "Allow insecure connections")
+	saasActiveCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	saasActiveCmd.Flags().Int("timeout", 30, "Timeout in seconds for the capture")
 	// Request Method Flags for all capture subcommands
 	saasActiveCmd.Flags().String("request-method", "HEADLESS", "Request method (headless, browserbase)")
@@ -526,7 +526,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationFingerprintConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, insecure bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
+func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, verifyTLS bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
 	resourceEnum, err := discover.NewApplicationFingerprintResourceTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -537,18 +537,18 @@ func getDiscoverApplicationFingerprintConfig(targets []string, resource string, 
 		Modules:        moduleEnums,
 		Fingerprints:   fingerprints,
 		SuccessfulOnly: successfulOnly,
-		Insecure:       insecure,
+		VerifyTls:      verifyTLS,
 		Timeout:        max(timeout, 0),
 	}
 	return config, nil
 }
 
 // getDiscoverPageConfig builds the config for page capture and analysis.
-func getDiscoverPageConfig(target string, maxRedirects int, insecure bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
+func getDiscoverPageConfig(target string, maxRedirects int, verifyTLS bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
 	config := discover.DiscoverPageConfig{
 		Target:            target,
 		MaxRedirects:      maxRedirects,
-		Insecure:          insecure,
+		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		TakeScreenshot:    takeScreenshot,
 		RequestMethod:     requestMethod,
@@ -559,12 +559,12 @@ func getDiscoverPageConfig(target string, maxRedirects int, insecure bool, timeo
 }
 
 // getDiscoverProbeConfig builds the config for probe discovery.
-func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, insecure bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
+func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
 		Targets:           targets,
 		MaxRedirects:      maxRedirects,
 		HttpsOnly:         HTTPSOnly,
-		Insecure:          insecure,
+		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,
@@ -575,14 +575,14 @@ func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, 
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, insecure bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
 		IgnoreStaticAssets:  ignoreStaticAssets,
 		RequireBaseUrlMatch: requiredBaseURLMatch,
 		SpiderDepth:         spiderDepth,
 		MaxRedirects:        maxRedirects,
-		Insecure:            insecure,
+		VerifyTls:           verifyTLS,
 		Timeout:             max(timeout, 0),
 		Threads:             max(threads, 0),
 		RequestMethod:       requestMethod,
@@ -593,7 +593,7 @@ func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStat
 }
 
 // getDiscoverSaasActiveConfig builds the config for SaaS active discovery.
-func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, insecure bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
+func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
 	config := discoversaasfern.DiscoverSaasActiveConfig{
 		Orgs:              orgs,
 		SaasFingerprints:  &saasFingerprints,
@@ -603,7 +603,7 @@ func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfer
 		MaxRedirects:      maxRedirects,
 		SuccessfulOnly:    successfulOnly,
 		HttpsOnly:         httpsOnly,
-		Insecure:          insecure,
+		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -25,6 +25,7 @@ import (
 	cobra "github.com/spf13/cobra"
 )
 
+// InitDiscoverCommand initializes the 'discover' command and its subcommands for the CLI.
 func (a *WebScan) InitDiscoverCommand() {
 	discoverCmd := &cobra.Command{
 		Use:   "discover",
@@ -524,6 +525,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	a.RootCmd.AddCommand(discoverCmd)
 }
 
+// getDiscoverApplicationFingerprintConfig builds the config for application fingerprinting discovery.
 func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, insecure bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
 	resourceEnum, err := discover.NewApplicationFingerprintResourceTypeFromString(resource)
 	if err != nil {
@@ -541,6 +543,7 @@ func getDiscoverApplicationFingerprintConfig(targets []string, resource string, 
 	return config, nil
 }
 
+// getDiscoverPageConfig builds the config for page capture and analysis.
 func getDiscoverPageConfig(target string, maxRedirects int, insecure bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
 	config := discover.DiscoverPageConfig{
 		Target:            target,
@@ -555,6 +558,7 @@ func getDiscoverPageConfig(target string, maxRedirects int, insecure bool, timeo
 	return config
 }
 
+// getDiscoverProbeConfig builds the config for probe discovery.
 func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, insecure bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
 		Targets:           targets,
@@ -570,6 +574,7 @@ func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, 
 	return config
 }
 
+// getDiscoverRouteConfig builds the config for route discovery.
 func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, insecure bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
@@ -587,6 +592,7 @@ func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStat
 	return config
 }
 
+// getDiscoverSaasActiveConfig builds the config for SaaS active discovery.
 func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, insecure bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
 	config := discoversaasfern.DiscoverSaasActiveConfig{
 		Orgs:              orgs,

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -20,7 +20,6 @@ import (
 
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
-
 	// External
 	cobra "github.com/spf13/cobra"
 )
@@ -78,7 +77,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -90,7 +89,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationFingerprintConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, verifyTls, timeout)
+			config, err := getDiscoverApplicationFingerprintConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, verifyTLS, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -141,7 +140,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -172,7 +171,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPageConfig(target, maxRedirects, verifyTls, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverPageConfig(target, maxRedirects, verifyTLS, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverpage.PerformPageCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -226,7 +225,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -245,7 +244,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverProbeConfig(targets, maxRedirects, HTTPSOnly, verifyTls, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverProbeConfig(targets, maxRedirects, HTTPSOnly, verifyTLS, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate report
 			report, err := discoverprobe.PerformWebProbe(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -313,7 +312,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -337,7 +336,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, verifyTls, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -456,7 +455,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -482,7 +481,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get the config
-			config := getDiscoverSaasActiveConfig(orgs, *filteredSaasFingerprints, *filteredSsoFingerprints, saasCompanies, ssoCompanies, maxRedirects, successfulOnly, httpsOnly, verifyTls, timeout, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverSaasActiveConfig(orgs, *filteredSaasFingerprints, *filteredSsoFingerprints, saasCompanies, ssoCompanies, maxRedirects, successfulOnly, httpsOnly, verifyTLS, timeout, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate the report
 			report, err := discoversaasactive.LaunchDiscoverSaasActive(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -526,7 +525,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationFingerprintConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, verifyTls bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
+func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, verifyTLS bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
 	resourceEnum, err := discover.NewApplicationFingerprintResourceTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -537,18 +536,18 @@ func getDiscoverApplicationFingerprintConfig(targets []string, resource string, 
 		Modules:        moduleEnums,
 		Fingerprints:   fingerprints,
 		SuccessfulOnly: successfulOnly,
-		VerifyTls:      verifyTls,
+		VerifyTls:      verifyTLS,
 		Timeout:        max(timeout, 0),
 	}
 	return config, nil
 }
 
 // getDiscoverPageConfig builds the config for page capture and analysis.
-func getDiscoverPageConfig(target string, maxRedirects int, verifyTls bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
+func getDiscoverPageConfig(target string, maxRedirects int, verifyTLS bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
 	config := discover.DiscoverPageConfig{
 		Target:            target,
 		MaxRedirects:      maxRedirects,
-		VerifyTls:         verifyTls,
+		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		TakeScreenshot:    takeScreenshot,
 		RequestMethod:     requestMethod,
@@ -559,12 +558,12 @@ func getDiscoverPageConfig(target string, maxRedirects int, verifyTls bool, time
 }
 
 // getDiscoverProbeConfig builds the config for probe discovery.
-func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, verifyTls bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
+func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
 		Targets:           targets,
 		MaxRedirects:      maxRedirects,
 		HttpsOnly:         HTTPSOnly,
-		VerifyTls:         verifyTls,
+		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,
@@ -575,14 +574,14 @@ func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, 
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, verifyTls bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
 		IgnoreStaticAssets:  ignoreStaticAssets,
 		RequireBaseUrlMatch: requiredBaseURLMatch,
 		SpiderDepth:         spiderDepth,
 		MaxRedirects:        maxRedirects,
-		VerifyTls:           verifyTls,
+		VerifyTls:           verifyTLS,
 		Timeout:             max(timeout, 0),
 		Threads:             max(threads, 0),
 		RequestMethod:       requestMethod,
@@ -593,7 +592,7 @@ func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStat
 }
 
 // getDiscoverSaasActiveConfig builds the config for SaaS active discovery.
-func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, verifyTls bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
+func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
 	config := discoversaasfern.DiscoverSaasActiveConfig{
 		Orgs:              orgs,
 		SaasFingerprints:  &saasFingerprints,
@@ -603,7 +602,7 @@ func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfer
 		MaxRedirects:      maxRedirects,
 		SuccessfulOnly:    successfulOnly,
 		HttpsOnly:         httpsOnly,
-		VerifyTls:         verifyTls,
+		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -78,7 +78,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -90,7 +90,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationFingerprintConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, verifyTLS, timeout)
+			config, err := getDiscoverApplicationFingerprintConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, verifyTls, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -141,7 +141,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -172,7 +172,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPageConfig(target, maxRedirects, verifyTLS, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverPageConfig(target, maxRedirects, verifyTls, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverpage.PerformPageCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -226,7 +226,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -245,7 +245,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverProbeConfig(targets, maxRedirects, HTTPSOnly, verifyTLS, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverProbeConfig(targets, maxRedirects, HTTPSOnly, verifyTls, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate report
 			report, err := discoverprobe.PerformWebProbe(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -313,7 +313,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -337,7 +337,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, verifyTls, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -456,7 +456,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -482,7 +482,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get the config
-			config := getDiscoverSaasActiveConfig(orgs, *filteredSaasFingerprints, *filteredSsoFingerprints, saasCompanies, ssoCompanies, maxRedirects, successfulOnly, httpsOnly, verifyTLS, timeout, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverSaasActiveConfig(orgs, *filteredSaasFingerprints, *filteredSsoFingerprints, saasCompanies, ssoCompanies, maxRedirects, successfulOnly, httpsOnly, verifyTls, timeout, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate the report
 			report, err := discoversaasactive.LaunchDiscoverSaasActive(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -526,7 +526,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationFingerprintConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, verifyTLS bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
+func getDiscoverApplicationFingerprintConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationFingerprintResource, successfulOnly bool, verifyTls bool, timeout int) (*discover.DiscoverApplicationFingerprintConfig, error) {
 	resourceEnum, err := discover.NewApplicationFingerprintResourceTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -537,18 +537,18 @@ func getDiscoverApplicationFingerprintConfig(targets []string, resource string, 
 		Modules:        moduleEnums,
 		Fingerprints:   fingerprints,
 		SuccessfulOnly: successfulOnly,
-		VerifyTls:      verifyTLS,
+		VerifyTls:      verifyTls,
 		Timeout:        max(timeout, 0),
 	}
 	return config, nil
 }
 
 // getDiscoverPageConfig builds the config for page capture and analysis.
-func getDiscoverPageConfig(target string, maxRedirects int, verifyTLS bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
+func getDiscoverPageConfig(target string, maxRedirects int, verifyTls bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
 	config := discover.DiscoverPageConfig{
 		Target:            target,
 		MaxRedirects:      maxRedirects,
-		VerifyTls:         verifyTLS,
+		VerifyTls:         verifyTls,
 		Timeout:           max(timeout, 0),
 		TakeScreenshot:    takeScreenshot,
 		RequestMethod:     requestMethod,
@@ -559,12 +559,12 @@ func getDiscoverPageConfig(target string, maxRedirects int, verifyTLS bool, time
 }
 
 // getDiscoverProbeConfig builds the config for probe discovery.
-func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
+func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, verifyTls bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
 		Targets:           targets,
 		MaxRedirects:      maxRedirects,
 		HttpsOnly:         HTTPSOnly,
-		VerifyTls:         verifyTLS,
+		VerifyTls:         verifyTls,
 		Timeout:           max(timeout, 0),
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,
@@ -575,14 +575,14 @@ func getDiscoverProbeConfig(targets []string, maxRedirects int, HTTPSOnly bool, 
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, verifyTls bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
 		IgnoreStaticAssets:  ignoreStaticAssets,
 		RequireBaseUrlMatch: requiredBaseURLMatch,
 		SpiderDepth:         spiderDepth,
 		MaxRedirects:        maxRedirects,
-		VerifyTls:           verifyTLS,
+		VerifyTls:           verifyTls,
 		Timeout:             max(timeout, 0),
 		Threads:             max(threads, 0),
 		RequestMethod:       requestMethod,
@@ -593,7 +593,7 @@ func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStat
 }
 
 // getDiscoverSaasActiveConfig builds the config for SaaS active discovery.
-func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
+func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfern.SaasFingerprintFile, ssoFingerprints discoversaasfern.SaasFingerprintFile, saasCompanies []string, ssoCompanies []string, maxRedirects int, successfulOnly bool, httpsOnly bool, verifyTls bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discoversaasfern.DiscoverSaasActiveConfig {
 	config := discoversaasfern.DiscoverSaasActiveConfig{
 		Orgs:              orgs,
 		SaasFingerprints:  &saasFingerprints,
@@ -603,7 +603,7 @@ func getDiscoverSaasActiveConfig(orgs []string, saasFingerprints discoversaasfer
 		MaxRedirects:      maxRedirects,
 		SuccessfulOnly:    successfulOnly,
 		HttpsOnly:         httpsOnly,
-		VerifyTls:         verifyTLS,
+		VerifyTls:         verifyTls,
 		Timeout:           max(timeout, 0),
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -22,6 +22,7 @@ import (
 	cobra "github.com/spf13/cobra"
 )
 
+// InitEnumerateCommand initializes the 'enumerate' command and its subcommands for the CLI.
 func (a *WebScan) InitEnumerateCommand() {
 	enumerateCmd := &cobra.Command{
 		Use:   "enumerate",
@@ -389,6 +390,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	a.RootCmd.AddCommand(enumerateCmd)
 }
 
+// getEnumerateWordpressPluginsConfig builds the config for WordPress plugin enumeration.
 func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, insecure bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
 	config := &enumeratecmswordpressfern.EnumerateWordpressPluginsConfig{
 		Targets:  targets,
@@ -400,6 +402,7 @@ func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, inse
 	return config
 }
 
+// getEnumerateKubeConfig builds the config for Kubernetes enumeration.
 func getEnumerateKubeConfig(target string, insecure bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
 	config := enumeratekubefern.EnumerateKubeConfig{
 		Target:   target,
@@ -409,6 +412,7 @@ func getEnumerateKubeConfig(target string, insecure bool, timeout int) enumerate
 	return config
 }
 
+// getEnumerateWebserverIISConfig builds the config for IIS webserver enumeration.
 func getEnumerateWebserverIISConfig(targets []string, insecure bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
 	config := enumeratewebserverfern.EnumerateWebserverIisConfig{
 		Targets:  targets,
@@ -419,6 +423,7 @@ func getEnumerateWebserverIISConfig(targets []string, insecure bool, timeout int
 	return config
 }
 
+// getEnumerateGeneralRateLimitConfig builds the config for general rate limit enumeration.
 func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, insecure bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
 	config := enumerategeneralfern.EnumerateGeneralRateLimitConfig{
 		Targets:     targets,

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -123,7 +123,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Get config flags
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -135,7 +135,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Set Config
-			config := getEnumerateKubeConfig(target, verifyTls, timeout)
+			config := getEnumerateKubeConfig(target, verifyTLS, timeout)
 
 			// Generate report
 			report := enumeratekube.PerformAppEnumerateKube(cmd.Context(), config)
@@ -206,7 +206,7 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(errors.New("no plugins provided"))
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -223,7 +223,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWordpressPluginsConfig(targets, plugins, verifyTls, timeout, threads)
+			config := getEnumerateWordpressPluginsConfig(targets, plugins, verifyTLS, timeout, threads)
 
 			// Generate report
 			report := enumeratecmswordpress.PerformAppEnumerateCMSWordpressPlugins(cmd.Context(), config)
@@ -275,7 +275,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Config flags
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -292,7 +292,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWebserverIISConfig(targets, verifyTls, timeout, threads)
+			config := getEnumerateWebserverIISConfig(targets, verifyTLS, timeout, threads)
 
 			// Generate report
 			report := enumeratewebserver.PerformAppEnumerateWebserverIIS(cmd.Context(), config)
@@ -348,7 +348,7 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -360,7 +360,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, timespan, verifyTls, timeout)
+			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, timespan, verifyTLS, timeout)
 
 			// Generate report
 			report := enumerategeneral.PerformGeneralRatelimit(cmd.Context(), config)
@@ -391,11 +391,11 @@ func (a *WebScan) InitEnumerateCommand() {
 }
 
 // getEnumerateWordpressPluginsConfig builds the config for WordPress plugin enumeration.
-func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, verifyTls bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
+func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, verifyTLS bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
 	config := &enumeratecmswordpressfern.EnumerateWordpressPluginsConfig{
 		Targets:   targets,
 		Plugins:   plugins,
-		VerifyTls: verifyTls,
+		VerifyTls: verifyTLS,
 		Timeout:   max(timeout, 0),
 		Threads:   max(threads, 0),
 	}
@@ -403,20 +403,20 @@ func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, veri
 }
 
 // getEnumerateKubeConfig builds the config for Kubernetes enumeration.
-func getEnumerateKubeConfig(target string, verifyTls bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
+func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
 	config := enumeratekubefern.EnumerateKubeConfig{
 		Target:    target,
-		VerifyTls: verifyTls,
+		VerifyTls: verifyTLS,
 		Timeout:   max(timeout, 0),
 	}
 	return config
 }
 
 // getEnumerateWebserverIISConfig builds the config for IIS webserver enumeration.
-func getEnumerateWebserverIISConfig(targets []string, verifyTls bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
+func getEnumerateWebserverIISConfig(targets []string, verifyTLS bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
 	config := enumeratewebserverfern.EnumerateWebserverIisConfig{
 		Targets:   targets,
-		VerifyTls: verifyTls,
+		VerifyTls: verifyTLS,
 		Timeout:   max(timeout, 0),
 		Threads:   max(threads, 0),
 	}
@@ -424,12 +424,12 @@ func getEnumerateWebserverIISConfig(targets []string, verifyTls bool, timeout in
 }
 
 // getEnumerateGeneralRateLimitConfig builds the config for general rate limit enumeration.
-func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, verifyTls bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
+func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, verifyTLS bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
 	config := enumerategeneralfern.EnumerateGeneralRateLimitConfig{
 		Targets:     targets,
 		MaxRequests: maxRequests,
 		Timespan:    max(timespan, 0),
-		VerifyTls:   verifyTls,
+		VerifyTls:   verifyTLS,
 		Timeout:     max(timeout, 0),
 	}
 	return config

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -123,7 +123,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Get config flags
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -135,7 +135,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Set Config
-			config := getEnumerateKubeConfig(target, insecure, timeout)
+			config := getEnumerateKubeConfig(target, verifyTLS, timeout)
 
 			// Generate report
 			report := enumeratekube.PerformAppEnumerateKube(cmd.Context(), config)
@@ -148,7 +148,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Target Flags
 	enumerateKubeCmd.Flags().String("target", "", "URL target to perform Kubernetes enumeration against")
 	// Config Flags
-	enumerateKubeCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	enumerateKubeCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	enumerateKubeCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 
 	// Mark required flags
@@ -206,7 +206,7 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(errors.New("no plugins provided"))
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -223,7 +223,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWordpressPluginsConfig(targets, plugins, insecure, timeout, threads)
+			config := getEnumerateWordpressPluginsConfig(targets, plugins, verifyTLS, timeout, threads)
 
 			// Generate report
 			report := enumeratecmswordpress.PerformAppEnumerateCMSWordpressPlugins(cmd.Context(), config)
@@ -238,7 +238,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateCMSWordpressPluginsCmd.Flags().StringSlice("plugins", []string{}, "Specific WordPress plugins to check for")
 	enumerateCMSWordpressPluginsCmd.Flags().StringSlice("plugins-file-paths", []string{"configs/enumerate/cms/wordpress/plugins_small.txt"}, "Paths to files containing WordPress plugin lists")
-	enumerateCMSWordpressPluginsCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	enumerateCMSWordpressPluginsCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 
@@ -275,7 +275,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Config flags
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -292,7 +292,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWebserverIISConfig(targets, insecure, timeout, threads)
+			config := getEnumerateWebserverIISConfig(targets, verifyTLS, timeout, threads)
 
 			// Generate report
 			report := enumeratewebserver.PerformAppEnumerateWebserverIIS(cmd.Context(), config)
@@ -305,7 +305,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Target Flags
 	enumerateWebserverIISCmd.Flags().StringSlice("targets", []string{}, "URL targets to perform IIS enumeration against")
 	// Config Flags
-	enumerateWebserverIISCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	enumerateWebserverIISCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	enumerateWebserverIISCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	enumerateWebserverIISCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 
@@ -348,7 +348,7 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -360,7 +360,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, timespan, insecure, timeout)
+			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, timespan, verifyTLS, timeout)
 
 			// Generate report
 			report := enumerategeneral.PerformGeneralRatelimit(cmd.Context(), config)
@@ -375,7 +375,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateGeneralRatelimitCmd.Flags().Int("max-requests", 10, "Maximum number of requests to send")
 	enumerateGeneralRatelimitCmd.Flags().Int("timespan", 10, "Time window for rate limit testing in seconds")
-	enumerateGeneralRatelimitCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	enumerateGeneralRatelimitCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	enumerateGeneralRatelimitCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 
 	_ = enumerateGeneralRatelimitCmd.MarkFlagRequired("targets")
@@ -391,45 +391,45 @@ func (a *WebScan) InitEnumerateCommand() {
 }
 
 // getEnumerateWordpressPluginsConfig builds the config for WordPress plugin enumeration.
-func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, insecure bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
+func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, verifyTLS bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
 	config := &enumeratecmswordpressfern.EnumerateWordpressPluginsConfig{
-		Targets:  targets,
-		Plugins:  plugins,
-		Insecure: insecure,
-		Timeout:  max(timeout, 0),
-		Threads:  max(threads, 0),
+		Targets:   targets,
+		Plugins:   plugins,
+		VerifyTls: verifyTLS,
+		Timeout:   max(timeout, 0),
+		Threads:   max(threads, 0),
 	}
 	return config
 }
 
 // getEnumerateKubeConfig builds the config for Kubernetes enumeration.
-func getEnumerateKubeConfig(target string, insecure bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
+func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
 	config := enumeratekubefern.EnumerateKubeConfig{
-		Target:   target,
-		Insecure: insecure,
-		Timeout:  max(timeout, 0),
+		Target:    target,
+		VerifyTls: verifyTLS,
+		Timeout:   max(timeout, 0),
 	}
 	return config
 }
 
 // getEnumerateWebserverIISConfig builds the config for IIS webserver enumeration.
-func getEnumerateWebserverIISConfig(targets []string, insecure bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
+func getEnumerateWebserverIISConfig(targets []string, verifyTLS bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
 	config := enumeratewebserverfern.EnumerateWebserverIisConfig{
-		Targets:  targets,
-		Insecure: insecure,
-		Timeout:  max(timeout, 0),
-		Threads:  max(threads, 0),
+		Targets:   targets,
+		VerifyTls: verifyTLS,
+		Timeout:   max(timeout, 0),
+		Threads:   max(threads, 0),
 	}
 	return config
 }
 
 // getEnumerateGeneralRateLimitConfig builds the config for general rate limit enumeration.
-func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, insecure bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
+func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, verifyTLS bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
 	config := enumerategeneralfern.EnumerateGeneralRateLimitConfig{
 		Targets:     targets,
 		MaxRequests: maxRequests,
 		Timespan:    max(timespan, 0),
-		Insecure:    insecure,
+		VerifyTls:   verifyTLS,
 		Timeout:     max(timeout, 0),
 	}
 	return config

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -123,7 +123,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Get config flags
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -135,7 +135,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Set Config
-			config := getEnumerateKubeConfig(target, verifyTLS, timeout)
+			config := getEnumerateKubeConfig(target, verifyTls, timeout)
 
 			// Generate report
 			report := enumeratekube.PerformAppEnumerateKube(cmd.Context(), config)
@@ -206,7 +206,7 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(errors.New("no plugins provided"))
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -223,7 +223,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWordpressPluginsConfig(targets, plugins, verifyTLS, timeout, threads)
+			config := getEnumerateWordpressPluginsConfig(targets, plugins, verifyTls, timeout, threads)
 
 			// Generate report
 			report := enumeratecmswordpress.PerformAppEnumerateCMSWordpressPlugins(cmd.Context(), config)
@@ -275,7 +275,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Config flags
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -292,7 +292,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWebserverIISConfig(targets, verifyTLS, timeout, threads)
+			config := getEnumerateWebserverIISConfig(targets, verifyTls, timeout, threads)
 
 			// Generate report
 			report := enumeratewebserver.PerformAppEnumerateWebserverIIS(cmd.Context(), config)
@@ -348,7 +348,7 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -360,7 +360,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, timespan, verifyTLS, timeout)
+			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, timespan, verifyTls, timeout)
 
 			// Generate report
 			report := enumerategeneral.PerformGeneralRatelimit(cmd.Context(), config)
@@ -391,11 +391,11 @@ func (a *WebScan) InitEnumerateCommand() {
 }
 
 // getEnumerateWordpressPluginsConfig builds the config for WordPress plugin enumeration.
-func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, verifyTLS bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
+func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, verifyTls bool, timeout int, threads int) *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
 	config := &enumeratecmswordpressfern.EnumerateWordpressPluginsConfig{
 		Targets:   targets,
 		Plugins:   plugins,
-		VerifyTls: verifyTLS,
+		VerifyTls: verifyTls,
 		Timeout:   max(timeout, 0),
 		Threads:   max(threads, 0),
 	}
@@ -403,20 +403,20 @@ func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, veri
 }
 
 // getEnumerateKubeConfig builds the config for Kubernetes enumeration.
-func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
+func getEnumerateKubeConfig(target string, verifyTls bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
 	config := enumeratekubefern.EnumerateKubeConfig{
 		Target:    target,
-		VerifyTls: verifyTLS,
+		VerifyTls: verifyTls,
 		Timeout:   max(timeout, 0),
 	}
 	return config
 }
 
 // getEnumerateWebserverIISConfig builds the config for IIS webserver enumeration.
-func getEnumerateWebserverIISConfig(targets []string, verifyTLS bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
+func getEnumerateWebserverIISConfig(targets []string, verifyTls bool, timeout int, threads int) enumeratewebserverfern.EnumerateWebserverIisConfig {
 	config := enumeratewebserverfern.EnumerateWebserverIisConfig{
 		Targets:   targets,
-		VerifyTls: verifyTLS,
+		VerifyTls: verifyTls,
 		Timeout:   max(timeout, 0),
 		Threads:   max(threads, 0),
 	}
@@ -424,12 +424,12 @@ func getEnumerateWebserverIISConfig(targets []string, verifyTLS bool, timeout in
 }
 
 // getEnumerateGeneralRateLimitConfig builds the config for general rate limit enumeration.
-func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, verifyTLS bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
+func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, timespan int, verifyTls bool, timeout int) enumerategeneralfern.EnumerateGeneralRateLimitConfig {
 	config := enumerategeneralfern.EnumerateGeneralRateLimitConfig{
 		Targets:     targets,
 		MaxRequests: maxRequests,
 		Timespan:    max(timespan, 0),
-		VerifyTls:   verifyTLS,
+		VerifyTls:   verifyTls,
 		Timeout:     max(timeout, 0),
 	}
 	return config

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -70,7 +70,7 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			insecure, err := cmd.Flags().GetBool("insecure")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -94,7 +94,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, insecure, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -109,7 +109,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestWebpageStaticAssetTakeoverCmd.Flags().Bool("require-base-url-match", false, "Only scan assets sharing the target's base URL")
 	pentestWebpageStaticAssetTakeoverCmd.Flags().Bool("successful-only", false, "Only show successful takeover attempts")
 	pentestWebpageStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
-	pentestWebpageStaticAssetTakeoverCmd.Flags().Bool("insecure", false, "Allow insecure SSL/TLS connections")
+	pentestWebpageStaticAssetTakeoverCmd.Flags().Bool("verify-tls", true, "Verify TLS certificates when making HTTPS requests")
 	pentestWebpageStaticAssetTakeoverCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestWebpageStaticAssetTakeoverCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 	// Request Method Flags for all capture subcommands
@@ -133,14 +133,14 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, insecure bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
 		IgnoreStaticAssets:  false,
 		RequireBaseUrlMatch: requireBaseURLMatch,
 		SpiderDepth:         1,
-		Insecure:            insecure,
+		VerifyTls:           verifyTLS,
 		Timeout:             max(timeout, 0),
 		Threads:             max(threads, 0),
 		RequestMethod:       requestMethod,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -16,6 +16,7 @@ import (
 	cobra "github.com/spf13/cobra"
 )
 
+// InitPentestCommand initializes the 'pentest' command and its subcommands for the CLI.
 func (a *WebScan) InitPentestCommand() {
 	pentestCmd := &cobra.Command{
 		Use:   "pentest",
@@ -131,6 +132,7 @@ func (a *WebScan) InitPentestCommand() {
 
 }
 
+// getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
 func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, insecure bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -70,7 +70,7 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
+			verifyTls, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -94,7 +94,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, verifyTls, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -133,14 +133,14 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTls bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
 		IgnoreStaticAssets:  false,
 		RequireBaseUrlMatch: requireBaseURLMatch,
 		SpiderDepth:         1,
-		VerifyTls:           verifyTLS,
+		VerifyTls:           verifyTls,
 		Timeout:             max(timeout, 0),
 		Threads:             max(threads, 0),
 		RequestMethod:       requestMethod,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -70,7 +70,7 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			verifyTls, err := cmd.Flags().GetBool("verify-tls")
+			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -94,7 +94,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, verifyTls, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -133,14 +133,14 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTls bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
 		IgnoreStaticAssets:  false,
 		RequireBaseUrlMatch: requireBaseURLMatch,
 		SpiderDepth:         1,
-		VerifyTls:           verifyTls,
+		VerifyTls:           verifyTLS,
 		Timeout:             max(timeout, 0),
 		Threads:             max(threads, 0),
 		RequestMethod:       requestMethod,

--- a/fern/definition/common/configs.yml
+++ b/fern/definition/common/configs.yml
@@ -7,7 +7,7 @@ types:
     properties:
       request: http.HttpRequest
       maxRedirects: integer
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/common/configs.yml
+++ b/fern/definition/common/configs.yml
@@ -7,7 +7,7 @@ types:
     properties:
       request: http.HttpRequest
       maxRedirects: integer
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -35,7 +35,7 @@ types:
       modules: optional<list<string>>
       fingerprints: optional<ApplicationFingerprintResource>
       successfulOnly: boolean
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
   # Report Struct
   ApplicationFingerprintAttempt:

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -16,10 +16,10 @@ types:
     properties:
       name: string
       method: http.HttpMethod
-      paths : list<string>
+      paths: list<string>
       requestParams: optional<http.HttpRequestParams>
-      headerIndicators : optional<map<string, optional<list<string>>>>
-      bodyIndicators : optional<list<string>>
+      headerIndicators: optional<map<string, optional<list<string>>>>
+      bodyIndicators: optional<list<string>>
   ApplicationFingerprintResource:
     properties:
       name: ApplicationFingerprintResourceType
@@ -35,14 +35,14 @@ types:
       modules: optional<list<string>>
       fingerprints: optional<ApplicationFingerprintResource>
       successfulOnly: boolean
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
   # Report Struct
   ApplicationFingerprintAttempt:
     properties:
       name: string
       requests: optional<list<http.HttpRequestResponse>>
-      finding : boolean
+      finding: boolean
   ApplicationFingerprintTarget:
     properties:
       target: string

--- a/fern/definition/discover/page.yml
+++ b/fern/definition/discover/page.yml
@@ -8,7 +8,7 @@ types:
       target: string
       takeScreenshot: boolean
       maxRedirects: integer
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/discover/page.yml
+++ b/fern/definition/discover/page.yml
@@ -8,7 +8,7 @@ types:
       target: string
       takeScreenshot: boolean
       maxRedirects: integer
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -8,7 +8,7 @@ types:
       targets: list<string>
       maxRedirects: integer
       httpsOnly: boolean
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -8,7 +8,7 @@ types:
       targets: list<string>
       maxRedirects: integer
       httpsOnly: boolean
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -10,7 +10,7 @@ types:
       requireBaseUrlMatch: boolean
       spiderDepth: integer
       maxRedirects: integer
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       threads: integer
       requestMethod: method.RequestMethod
@@ -27,7 +27,7 @@ types:
       exampleValues: optional<list<string>>
   RouteDetails:
     properties:
-      baseURL: string 
+      baseURL: string
       path: string
       method: optional<http.HttpMethod>
       queryParams: optional<list<RouteQueryParam>>

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -10,7 +10,7 @@ types:
       requireBaseUrlMatch: boolean
       spiderDepth: integer
       maxRedirects: integer
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       threads: integer
       requestMethod: method.RequestMethod

--- a/fern/definition/discover/saas/active.yml
+++ b/fern/definition/discover/saas/active.yml
@@ -26,7 +26,7 @@ types:
       successfulOnly: boolean
       httpsOnly: boolean
       maxRedirects: integer
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/discover/saas/active.yml
+++ b/fern/definition/discover/saas/active.yml
@@ -26,7 +26,7 @@ types:
       successfulOnly: boolean
       httpsOnly: boolean
       maxRedirects: integer
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/fern/definition/enumerate/cms/wordpress/plugins.yml
+++ b/fern/definition/enumerate/cms/wordpress/plugins.yml
@@ -4,7 +4,7 @@ types:
     properties:
       targets: list<string>
       plugins: optional<list<string>>
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       threads: integer
   # Fingerprint File Struct

--- a/fern/definition/enumerate/cms/wordpress/plugins.yml
+++ b/fern/definition/enumerate/cms/wordpress/plugins.yml
@@ -4,7 +4,7 @@ types:
     properties:
       targets: list<string>
       plugins: optional<list<string>>
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       threads: integer
   # Fingerprint File Struct

--- a/fern/definition/enumerate/general/ratelimit.yml
+++ b/fern/definition/enumerate/general/ratelimit.yml
@@ -7,7 +7,7 @@ types:
       targets: list<string>
       maxRequests: integer
       timespan: integer
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
   # Report Struct
   RateLimitAttempt:

--- a/fern/definition/enumerate/general/ratelimit.yml
+++ b/fern/definition/enumerate/general/ratelimit.yml
@@ -7,7 +7,7 @@ types:
       targets: list<string>
       maxRequests: integer
       timespan: integer
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
   # Report Struct
   RateLimitAttempt:

--- a/fern/definition/enumerate/kube/kube.yml
+++ b/fern/definition/enumerate/kube/kube.yml
@@ -5,7 +5,7 @@ types:
   EnumerateKubeConfig:
     properties:
       target: string
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
   # Report Struct
   EnumerateKubeReport:

--- a/fern/definition/enumerate/kube/kube.yml
+++ b/fern/definition/enumerate/kube/kube.yml
@@ -1,11 +1,11 @@
-imports: 
+imports:
   http: ../../common/http.yml
 types:
   # Function Config Struct
   EnumerateKubeConfig:
     properties:
       target: string
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
   # Report Struct
   EnumerateKubeReport:

--- a/fern/definition/enumerate/webserver/iis.yml
+++ b/fern/definition/enumerate/webserver/iis.yml
@@ -5,7 +5,7 @@ types:
   EnumerateWebserverIisConfig:
     properties:
       targets: list<string>
-      insecure: boolean
+      verifyTLS: boolean
       timeout: integer
       threads: integer
   # Report Struct

--- a/fern/definition/enumerate/webserver/iis.yml
+++ b/fern/definition/enumerate/webserver/iis.yml
@@ -5,7 +5,7 @@ types:
   EnumerateWebserverIisConfig:
     properties:
       targets: list<string>
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
       threads: integer
   # Report Struct

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -33,6 +33,8 @@ func createSendHTTPRequestConfig(baseURL, path string, method common.HttpMethod,
 	}
 }
 
+// Run executes the fingerprinting process for a given target and configuration.
+// Returns a slice of ApplicationFingerprintAttempt and a slice of error messages.
 func Run(ctx context.Context, target string, config *discover.DiscoverApplicationFingerprintConfig) ([]*discover.ApplicationFingerprintAttempt, []string) {
 	if config == nil || config.Fingerprints == nil || len(config.Fingerprints.Modules) == 0 {
 		return []*discover.ApplicationFingerprintAttempt{}, []string{"invalid config: no resource types found"}
@@ -92,6 +94,8 @@ func Run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 	return attempts, errors
 }
 
+// AnalyzeResponse checks if the HTTP response matches the fingerprint module's indicators.
+// Returns true if a match is found, false otherwise.
 func AnalyzeResponse(httpRequestResponse *common.HttpRequestResponse, module *discover.ApplicationFingerprintModule) bool {
 	// Check if response is nil
 	if httpRequestResponse == nil || httpRequestResponse.Response == nil || httpRequestResponse.Response.StatusCode == nil {
@@ -142,6 +146,7 @@ func AnalyzeResponse(httpRequestResponse *common.HttpRequestResponse, module *di
 	return false
 }
 
+// LaunchFingerprintEngine runs the fingerprinting engine for all targets in the config and returns a report.
 func LaunchFingerprintEngine(ctx context.Context, config *discover.DiscoverApplicationFingerprintConfig) (*discover.DiscoverApplicationFingerprintReport, error) {
 	report := discover.DiscoverApplicationFingerprintReport{Config: config}
 	errors := []string{}

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -24,7 +24,7 @@ func createSendHTTPRequestConfig(baseURL, path string, method common.HttpMethod,
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/discover/page/helpers/html.go
+++ b/internal/discover/page/helpers/html.go
@@ -9,6 +9,7 @@ import (
 	request "github.com/Method-Security/webscan/utils/request"
 )
 
+// PerformHTMLPageCapture sends an HTTP request using the provided config and returns the response.
 func PerformHTMLPageCapture(ctx context.Context, config *common.SendHttpRequestConfig) (*common.HttpRequestResponse, error) {
 	// Send request
 	httpRequestResponse, err := request.SendRequest(ctx, *config)

--- a/internal/discover/page/helpers/screenshot.go
+++ b/internal/discover/page/helpers/screenshot.go
@@ -15,6 +15,7 @@ import (
 	gson "github.com/ysmood/gson"
 )
 
+// CaptureScreenshot uses a headless browser to capture a screenshot of the given URL and returns the image bytes.
 func CaptureScreenshot(ctx context.Context, requester *headless.Requester, sendHTTPRequestConfig *common.SendHttpRequestConfig) ([]byte, error) {
 	log := svc1log.FromContext(ctx)
 

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -24,7 +24,7 @@ func getHTTPRequestConfig(baseURL string, path string, config discover.DiscoverP
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       config.MaxRedirects,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      config.RequestMethod,
 		HeadlessConfig:     config.HeadlessConfig,

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -71,6 +71,7 @@ func sendRequests(ctx context.Context, target string, config *discover.DiscoverP
 	return httpRequestResponses, errors
 }
 
+// PerformWebProbe performs web probing for the given config and returns a DiscoverProbeReport.
 func PerformWebProbe(ctx context.Context, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) (*discover.DiscoverProbeReport, error) {
 	report := &discover.DiscoverProbeReport{Config: config}
 	errors := []string{}

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -24,7 +24,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config *discover.Discover
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       config.MaxRedirects,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      config.RequestMethod,
 		HeadlessConfig:     config.HeadlessConfig,

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -17,6 +17,8 @@ import (
 
 // ExtractFormRoutes extracts WebRoutes from form elements in the HTML document
 // It returns a slice of WebRoutes, a slice of URLs and a slice of errors
+// ExtractFormRoutes extracts WebRoutes from form elements in the HTML document
+// It returns a slice of WebRoutes, a slice of URLs and a slice of errors
 // WebRoutes are merged to only return unique routes
 func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
@@ -97,6 +99,8 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), []string{}
 }
 
+// ExtractAnchorRoutes extracts WebRoutes from anchor (<a>) elements in the HTML document.
+// Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
 func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
 	urls := make(map[string]struct{})
@@ -140,6 +144,8 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
 }
 
+// ExtractLinkRoutes extracts WebRoutes from link (<link>) elements in the HTML document.
+// Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
 func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
 	urls := make(map[string]struct{})

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -19,6 +19,8 @@ import (
 	parser "github.com/robertkrimen/otto/parser"
 )
 
+// ExtractScriptRoutes extracts WebRoutes from script elements in the HTML document
+// It returns a slice of RouteDetails, a slice of URLs and a slice of errors
 // extractScriptContentRoutes takes JavaScript code as a string, parses it using the Otto parser library to find all routes (including POST and GET methods with bodyParams and queryParams), and returns them.
 func extractScriptContentRoutes(scriptContent string, baseURL string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
@@ -143,7 +145,8 @@ func (v *visitor) addRoute(urlStr, method string, bodyParams []*discover.RouteBo
 	v.urls[urlStr] = struct{}{}
 }
 
-// ExtractScriptRoutes finds script elements with a src attribute, fetches the JavaScript data, converts it to a string, then calls extractScriptContentRoutes and returns the results. If onlybaseURLs is set, only request script src that are relative.
+// ExtractScriptRoutes finds script elements with a src attribute, fetches the JavaScript data, parses it, and extracts routes.
+// Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
 func ExtractScriptRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
 	urls := make(map[string]struct{})
@@ -209,7 +212,8 @@ func ExtractScriptRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
 }
 
-// ExtractInlineScriptRoutes finds inline JavaScript code within script tags, and for each, passes the string contents to extractScriptContentRoutes and returns the results.
+// ExtractInlineScriptRoutes finds inline JavaScript code within script tags, parses it, and extracts routes.
+// Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
 func ExtractInlineScriptRoutes(doc *goquery.Document, url string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
 	urls := make(map[string]struct{})

--- a/internal/discover/route/helpers/extractors/networkExtractors.go
+++ b/internal/discover/route/helpers/extractors/networkExtractors.go
@@ -19,7 +19,8 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// ExtractNetworkRoutes fetches network requests, parses them, and populates []WebRoute.
+// ExtractNetworkRoutes uses a headless browser to capture network requests and extract route details from them.
+// Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
 func ExtractNetworkRoutes(ctx context.Context, b *headless.Requester, target string, baseURLsOnly bool, captureStaticAssets bool) ([]*discover.RouteDetails, []string, []string) {
 	routes := []*discover.RouteDetails{}
 	urls := make(map[string]struct{})

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -32,7 +32,7 @@ func AddListToSetString(set map[string]struct{}, list []string) map[string]struc
 	return set
 }
 
-// MergeStaticAssets merges StaticAssets, retaining only unique static assets
+// MergeStaticAssets merges static asset URLs, retaining only unique static assets.
 func MergeStaticAssets(staticAssets []string) []string {
 	staticAssetMap := make(map[string]struct{})
 
@@ -45,8 +45,7 @@ func MergeStaticAssets(staticAssets []string) []string {
 	return SetToListString(staticAssetMap)
 }
 
-// MergeWebRoutes merges WebRoutes, retaining only unique routes
-// unique routes are defined by the combination of method and URL
+// MergeWebRoutes merges WebRoutes, retaining only unique routes (by method and URL).
 func MergeWebRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
 	routeMap := make(map[string]*discover.RouteDetails)
 
@@ -80,8 +79,7 @@ func MergeWebRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
 	return mergedRoutes
 }
 
-// MergeQueryParams Helper function to merge QueryParams only retaining those that are unique
-// When the same param name is encountered, the example values are merged
+// MergeQueryParams merges two slices of RouteQueryParam, retaining unique params and merging example values.
 func MergeQueryParams(params1 []*discover.RouteQueryParam, params2 []*discover.RouteQueryParam) []*discover.RouteQueryParam {
 	// If either is nil return the other
 	if params1 == nil && params2 == nil {
@@ -117,8 +115,7 @@ func MergeQueryParams(params1 []*discover.RouteQueryParam, params2 []*discover.R
 	return mergedParams
 }
 
-// MergeBodyParams helper function to merge BodyParams only retaining those that are unique
-// When the same param name is encountered, the example values are merged
+// MergeBodyParams merges two slices of RouteBodyParam, retaining unique params and merging example values.
 func MergeBodyParams(params1 []*discover.RouteBodyParam, params2 []*discover.RouteBodyParam) []*discover.RouteBodyParam {
 	// If either is nil return the other
 	if params1 == nil && params2 == nil {
@@ -154,7 +151,7 @@ func MergeBodyParams(params1 []*discover.RouteBodyParam, params2 []*discover.Rou
 	return mergedParams
 }
 
-// ParseQueryParams helper function to parse query parameters from the URL
+// ParseQueryParams parses query parameters from a URL into RouteQueryParam structs.
 func ParseQueryParams(reqURL *url.URL) []*discover.RouteQueryParam {
 	var queryParams []*discover.RouteQueryParam
 	for key, values := range reqURL.Query() {
@@ -166,7 +163,7 @@ func ParseQueryParams(reqURL *url.URL) []*discover.RouteQueryParam {
 	return queryParams
 }
 
-// ParseBodyParams helper function to parse body parameters
+// ParseBodyParams parses body parameters from a JSON or form-urlencoded string into RouteBodyParam structs.
 func ParseBodyParams(postData string) ([]*discover.RouteBodyParam, error) {
 	var bodyParams []*discover.RouteBodyParam
 
@@ -208,7 +205,7 @@ func ParseBodyParams(postData string) ([]*discover.RouteBodyParam, error) {
 	return bodyParams, nil
 }
 
-// ResolveURL helper function to resolve relative URLs
+// ResolveURL resolves a reference URL relative to a base URL.
 func ResolveURL(base, ref string) string {
 	baseURL, err := url.Parse(base)
 	if err != nil {
@@ -222,7 +219,7 @@ func ResolveURL(base, ref string) string {
 	return strings.TrimRight(baseURL.ResolveReference(refURL).String(), "/")
 }
 
-// URLRemoveQueryParams helper function to remove query parameters from a URL
+// URLRemoveQueryParams removes query parameters from a URL string.
 func URLRemoveQueryParams(rawURL string) (string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -232,10 +229,7 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 	return parsedURL.String(), nil
 }
 
-// IsURLAllowed helper function to check if a URL is allowed based on baseUrlsOnly and base domain and captureStaticAssets
-// This only checks the first subdomain only of the baseURL as a condition for match
-// Web routes often get redirected to www.* or other subdomains, so we only check the base domain
-// baseURL should be the original URL sent to the CLI, targetURL is the URL discovered that needs checking
+// IsURLAllowed checks if a target URL is allowed based on base URL, static asset rules, and domain matching.
 func IsURLAllowed(baseURL string, targetURL string, requireBaseURLMatch bool, ignoreStaticAssets bool) bool {
 	// First check to see if the targetURL is a static asset type
 	if !ignoreStaticAssets {
@@ -255,10 +249,7 @@ func IsURLAllowed(baseURL string, targetURL string, requireBaseURLMatch bool, ig
 	return IsSubdomain(baseDomain, targetDomain)
 }
 
-// ExtractDomain helper function to extract the domain from a URL with an optional maxDomainLevel parameter
-// maxDomainLevel specifies the number of domain levels to include in the extracted domain
-// e.g. maxDomainLevel=2 would extract "example.com" from "www.sub.example.com"
-// maxDomainLevel=0 would extract the full domain
+// ExtractDomain extracts the domain from a URL up to a specified domain level.
 func ExtractDomain(rawURL string, maxDomainLevel int) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -276,7 +267,7 @@ func ExtractDomain(rawURL string, maxDomainLevel int) string {
 	return domain
 }
 
-// IsSubdomain helper function to check if sub is a subdomain of base
+// IsSubdomain checks if 'sub' is a subdomain of 'base'.
 func IsSubdomain(base string, sub string) bool {
 	if base == "" || sub == "" {
 		return false
@@ -284,7 +275,7 @@ func IsSubdomain(base string, sub string) bool {
 	return sub == base || strings.HasSuffix(sub, "."+base)
 }
 
-// IsAbsoluteURL helper function to check if a URL is absolute
+// IsAbsoluteURL returns true if the given URL is absolute.
 func IsAbsoluteURL(u string) bool {
 	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") || strings.HasPrefix(u, "//")
 }

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -132,6 +132,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	return mergedRoutes, staticAssetsList, errors
 }
 
+// PerformRouteCapture performs route discovery and spidering for the given config, returning a DiscoverRouteReport.
 func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) discover.DiscoverRouteReport {
 	log := svc1log.FromContext(ctx)
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -37,7 +37,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config discover.DiscoverR
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       config.MaxRedirects,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      config.RequestMethod,
 		HeadlessConfig:     config.HeadlessConfig,

--- a/internal/discover/saas/active/active.go
+++ b/internal/discover/saas/active/active.go
@@ -28,7 +28,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config discoversaasfern.D
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       config.MaxRedirects,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      config.RequestMethod,
 		HeadlessConfig:     config.HeadlessConfig,

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -64,7 +64,7 @@ func createSendHTTPRequestConfig(baseURL, path string, timeout int) common.SendH
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		Insecure:           true,
+		VerifyTls:          false,
 		Timeout:            timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/enumerate/cms/wordpress/plugins.go
+++ b/internal/enumerate/cms/wordpress/plugins.go
@@ -30,7 +30,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratecmswordp
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		Insecure:           true,
+		VerifyTls:          false,
 		Timeout:            config.Timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/enumerate/cms/wordpress/plugins.go
+++ b/internal/enumerate/cms/wordpress/plugins.go
@@ -39,7 +39,8 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratecmswordp
 	}
 }
 
-// PerformAppEnumerateCMSWordpressPlugins attempts to find plugins installed on WordPress sites
+// PerformAppEnumerateCMSWordpressPlugins attempts to find plugins installed on WordPress sites.
+// It returns a report containing the results for each target and any errors encountered.
 func PerformAppEnumerateCMSWordpressPlugins(ctx context.Context, config *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig) enumeratecmswordpressfern.EnumerateWordpressPluginsReport {
 	report := enumeratecmswordpressfern.EnumerateWordpressPluginsReport{Config: config}
 

--- a/internal/enumerate/cms/wordpress/plugins.go
+++ b/internal/enumerate/cms/wordpress/plugins.go
@@ -30,7 +30,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratecmswordp
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		VerifyTls:          false,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/enumerate/general/ratelimit.go
+++ b/internal/enumerate/general/ratelimit.go
@@ -27,7 +27,7 @@ func createRateLimitRequestConfig(baseURL, path string, config enumerategeneralf
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		BrowserbaseSecrets: nil,

--- a/internal/enumerate/general/ratelimit.go
+++ b/internal/enumerate/general/ratelimit.go
@@ -36,7 +36,7 @@ func createRateLimitRequestConfig(baseURL, path string, config enumerategeneralf
 	}
 }
 
-// PerformGeneralRatelimit performs rate limit detection on target URLs within a specified timespan
+// PerformGeneralRatelimit performs rate limit detection on target URLs within a specified timespan and returns a DetectRateLimitReport.
 func PerformGeneralRatelimit(ctx context.Context, config enumerategeneralfern.EnumerateGeneralRateLimitConfig) *enumerategeneralfern.DetectRateLimitReport {
 	// Initialize report
 	report := &enumerategeneralfern.DetectRateLimitReport{Config: &config}
@@ -101,8 +101,7 @@ func PerformGeneralRatelimit(ctx context.Context, config enumerategeneralfern.En
 	return report
 }
 
-// RateLimitDetected checks if a response explicitly indicates that a request was rate-limited
-// or if a 403 response is returned after a 200 response was previously seen.
+// RateLimitDetected checks if a response explicitly indicates that a request was rate-limited or if a 403 response is returned after a 200 response was previously seen.
 func RateLimitDetected(request *common.HttpRequestResponse, hasSeen200 bool) bool {
 	if request == nil || request.Response == nil {
 		return false

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -16,7 +16,7 @@ import (
 
 var commonKubepaths = []string{"/api", "/livez", "/version"}
 
-func createSendHTTPRequestConfig(baseURL, path string, insecure bool, timeout int) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -26,7 +26,7 @@ func createSendHTTPRequestConfig(baseURL, path string, insecure bool, timeout in
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		Insecure:           insecure,
+		VerifyTls:          verifyTLS,
 		Timeout:            timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,
@@ -53,7 +53,7 @@ func PerformAppEnumerateKube(ctx context.Context, config enumeratekubefern.Enume
 	requests := []*common.HttpRequestResponse{}
 	for _, path := range commonKubepaths {
 		// Create Request Config
-		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.Insecure, config.Timeout)
+		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.VerifyTls, config.Timeout)
 
 		// Send Request
 		request, err := request.SendRequest(ctx, requestConfig)

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -16,7 +16,7 @@ import (
 
 var commonKubepaths = []string{"/api", "/livez", "/version"}
 
-func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, verifyTls bool, timeout int) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -26,7 +26,7 @@ func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout i
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		VerifyTls:          verifyTLS,
+		VerifyTls:          verifyTls,
 		Timeout:            timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -16,7 +16,7 @@ import (
 
 var commonKubepaths = []string{"/api", "/livez", "/version"}
 
-func createSendHTTPRequestConfig(baseURL, path string, verifyTls bool, timeout int) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -26,7 +26,7 @@ func createSendHTTPRequestConfig(baseURL, path string, verifyTls bool, timeout i
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		VerifyTls:          verifyTls,
+		VerifyTls:          verifyTLS,
 		Timeout:            timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -35,6 +35,7 @@ func createSendHTTPRequestConfig(baseURL, path string, insecure bool, timeout in
 	}
 }
 
+// PerformAppEnumerateKube performs enumeration of common Kubernetes endpoints and returns an EnumerateKubeReport.
 func PerformAppEnumerateKube(ctx context.Context, config enumeratekubefern.EnumerateKubeConfig) *enumeratekubefern.EnumerateKubeReport {
 	// Initialize report
 	report := &enumeratekubefern.EnumerateKubeReport{Target: config.Target, Config: &config}

--- a/internal/enumerate/webserver/iis.go
+++ b/internal/enumerate/webserver/iis.go
@@ -39,7 +39,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratewebserve
 	}
 }
 
-// PerformAppEnumerateWebserverIIS is the entry point exposed to the wider application
+// PerformAppEnumerateWebserverIIS performs enumeration of IIS webservers for the given config and returns a report.
 func PerformAppEnumerateWebserverIIS(ctx context.Context, config enumeratewebserverfern.EnumerateWebserverIisConfig) enumeratewebserverfern.EnumerateWebserverIisReport {
 	rpt := enumeratewebserverfern.EnumerateWebserverIisReport{Config: &config}
 

--- a/internal/enumerate/webserver/iis.go
+++ b/internal/enumerate/webserver/iis.go
@@ -30,7 +30,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratewebserve
 	return common.SendHttpRequestConfig{
 		Request:            &request,
 		MaxRedirects:       0,
-		Insecure:           config.Insecure,
+		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -33,7 +33,7 @@ func createSendHTTPRequestConfig(targetBaseURL, targetPath string, config pentes
 	requestConfig := common.SendHttpRequestConfig{
 		Request:            &httpRequest,
 		MaxRedirects:       config.RouteCaptureConfig.MaxRedirects,
-		Insecure:           config.RouteCaptureConfig.Insecure,
+		VerifyTls:          config.RouteCaptureConfig.VerifyTls,
 		Timeout:            config.RouteCaptureConfig.Timeout,
 		RequestMethod:      config.RouteCaptureConfig.RequestMethod,
 		HeadlessConfig:     config.RouteCaptureConfig.HeadlessConfig,

--- a/utils/request/helpers/headless/client.go
+++ b/utils/request/helpers/headless/client.go
@@ -8,6 +8,7 @@ import (
 	cdp "github.com/go-rod/rod/lib/cdp"
 )
 
+// Requester manages a headless browser instance and configuration for making requests.
 type Requester struct {
 	Browser                    *rod.Browser
 	PathToBrowser              *string
@@ -15,6 +16,7 @@ type Requester struct {
 	MinDOMStabalizeTimeSeconds int
 }
 
+// NewRequester creates a new Requester with the given timeout and headless configuration.
 func NewRequester(timeout int, config *common.HeadlessRequestConfig) *Requester {
 	return &Requester{
 		Browser:                    nil,
@@ -24,6 +26,7 @@ func NewRequester(timeout int, config *common.HeadlessRequestConfig) *Requester 
 	}
 }
 
+// NewRequesterWithClient creates a new Requester using an existing rod cdp.Client.
 func NewRequesterWithClient(client *cdp.Client, timeout int, minDOMStabalizeTime int) *Requester {
 	return &Requester{
 		Browser:                    rod.New().Client(client).MustConnect(),

--- a/utils/request/helpers/headless/headless.go
+++ b/utils/request/helpers/headless/headless.go
@@ -224,7 +224,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		log.Info("Initializing browser")
 		// Create a new browser launcher
 		launch := launcher.New().Headless(true)
-		// Set the verifyTls flag if defined
+		// Set the verifyTLS flag if defined
 		if !config.VerifyTls {
 			launch = launch.Set("ignore-certificate-errors")
 		}

--- a/utils/request/helpers/headless/headless.go
+++ b/utils/request/helpers/headless/headless.go
@@ -224,8 +224,8 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		log.Info("Initializing browser")
 		// Create a new browser launcher
 		launch := launcher.New().Headless(true)
-		// Set the insecure flag if defined
-		if config.Insecure {
+		// Set the verifyTLS flag if defined
+		if !config.VerifyTls {
 			launch = launch.Set("ignore-certificate-errors")
 		}
 		if b.PathToBrowser != nil && *b.PathToBrowser != "" {

--- a/utils/request/helpers/headless/headless.go
+++ b/utils/request/helpers/headless/headless.go
@@ -224,7 +224,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		log.Info("Initializing browser")
 		// Create a new browser launcher
 		launch := launcher.New().Headless(true)
-		// Set the verifyTLS flag if defined
+		// Set the verifyTls flag if defined
 		if !config.VerifyTls {
 			launch = launch.Set("ignore-certificate-errors")
 		}

--- a/utils/request/helpers/standard/helpers/prepare.go
+++ b/utils/request/helpers/standard/helpers/prepare.go
@@ -48,7 +48,8 @@ func ConstructURL(ctx context.Context, request *common.HttpRequest) (*string, er
 	return &urlStr, nil
 }
 
-func PrepareRequestBody(log svc1log.Logger, request *common.HttpRequest) (io.Reader, error) {
+func PrepareRequestBody(ctx context.Context, request *common.HttpRequest) (io.Reader, error) {
+	log := svc1log.FromContext(ctx)
 	if request.Params == nil || request.Params.Body == nil {
 		return nil, nil
 	}

--- a/utils/request/helpers/standard/helpers/send.go
+++ b/utils/request/helpers/standard/helpers/send.go
@@ -3,6 +3,7 @@ package standard
 import (
 	// Standard
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -15,7 +16,8 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-func SendHTTPRequest(log svc1log.Logger, url string, headers map[string]string, bodyReader io.Reader, config common.SendHttpRequestConfig) (*http.Response, []string, error) {
+func SendHTTPRequest(ctx context.Context, url string, headers map[string]string, bodyReader io.Reader, config common.SendHttpRequestConfig) (*http.Response, []string, error) {
+	log := svc1log.FromContext(ctx)
 	log.Info("Sending request", svc1log.SafeParam("url", url), svc1log.SafeParam("maxRedirects", config.MaxRedirects))
 
 	// Configure HTTP Client

--- a/utils/request/helpers/standard/helpers/send.go
+++ b/utils/request/helpers/standard/helpers/send.go
@@ -22,7 +22,7 @@ func SendHTTPRequest(log svc1log.Logger, url string, headers map[string]string, 
 	client := &http.Client{
 		Timeout: time.Duration(config.Timeout) * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Insecure},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.VerifyTls},
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/utils/request/helpers/standard/standard.go
+++ b/utils/request/helpers/standard/standard.go
@@ -13,15 +13,10 @@ import (
 	// Utils
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	standardhelpers "github.com/Method-Security/webscan/utils/request/helpers/standard/helpers"
-
-	// External
-	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // SendStandardRequest performs an HTTP request using http/net and returns detailed information including response data
 func SendStandardRequest(ctx context.Context, config common.SendHttpRequestConfig) (common.HttpRequestResponse, error) {
-	// Initialize
-	log := svc1log.FromContext(ctx)
 	// Set the request
 	request := config.Request
 	if request == nil {
@@ -33,7 +28,7 @@ func SendStandardRequest(ctx context.Context, config common.SendHttpRequestConfi
 	if err != nil {
 		return common.HttpRequestResponse{Request: request}, fmt.Errorf("URL construction failed: %v", err)
 	}
-	constructedReqReader, err := standardhelpers.PrepareRequestBody(log, request)
+	constructedReqReader, err := standardhelpers.PrepareRequestBody(ctx, request)
 	if err != nil {
 		return common.HttpRequestResponse{Request: request}, fmt.Errorf("request body preparation failed: %v", err)
 	}
@@ -49,7 +44,7 @@ func SendStandardRequest(ctx context.Context, config common.SendHttpRequestConfi
 	// Send Request
 	sentAt := time.Now()
 	request.SentAt = &sentAt
-	resp, redirectChain, err := standardhelpers.SendHTTPRequest(log, *constructedURL, constructedHeaders, constructedReqReader, config)
+	resp, redirectChain, err := standardhelpers.SendHTTPRequest(ctx, *constructedURL, constructedHeaders, constructedReqReader, config)
 	if err != nil {
 		return common.HttpRequestResponse{Request: request}, fmt.Errorf("request failed: %v", err)
 	}


### PR DESCRIPTION
# Rename `insecure` flag to `verify-tls` with inverted logic

This PR renames the `insecure` flag to `verify-tls` across all commands, inverting the logic for better security posture. The new flag defaults to `true` (verify certificates), replacing the previous `insecure: false` default.

The PR also improves the CI/CD pipeline by:
- Splitting Linux builds into separate amd64 and arm64 jobs
- Using a native ARM runner for arm64 builds instead of emulation
- Improving Docker command formatting for better readability
- Updating artifact naming for clarity

Additionally, the PR adds comprehensive documentation comments to functions throughout the codebase, particularly in the command handlers and helper functions.