### PR TITLE
Refactor application fingerprinting to handle multiple resource types

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -97,7 +97,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, modules, filteredFingerprints, successfulOnly, verifyTLS, timeout)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, modules, successfulOnly, verifyTLS, timeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -510,7 +510,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums []string, fingerprints *discover.ApplicationResource, successfulOnly bool, verifyTLS bool, timeout int) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums []string, successfulOnly bool, verifyTLS bool, timeout int) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -40,7 +40,7 @@ types:
       name: string
       requests: optional<list<http.HttpRequestResponse>>
       finding: boolean
-      fingerprints: optional<list<ApplicationFingerprints>>
+      fingerprints: optional<list<ApplicationResource>>
   ApplicationFingerprintTarget:
     properties:
       target: string

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -85,13 +85,21 @@ func Run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 
 			if AnalyzeResponse(request, module) {
 				attempt.Finding = true
-				attempt.Fingerprints = []*discover.ApplicationResource{resourceType}
+				attempt.Fingerprints = []*discover.ApplicationResource{
+					{
+						Name:    resourceType.Name,
+						Modules: []*discover.ApplicationFingerprintModule{module},
+					},
+				}
 				attempts = append(attempts, attempt)
 				break
 			}
 		}
 
 		attempt.Requests = requests
+		if !attempt.Finding {
+			attempts = append(attempts, attempt)
+		}
 	}
 	return attempts, errors
 }

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -158,16 +158,20 @@ func AnalyzeResponse(httpRequestResponse *common.HttpRequestResponse, module *di
 }
 
 // LaunchFingerprintEngine runs the fingerprinting engine for all targets in the config and returns a report.
-func LaunchFingerprintEngine(ctx context.Context, config *discover.DiscoverApplicationConfig, filteredFingerprints *discover.ApplicationResource) (*discover.DiscoverApplicationReport, error) {
+func LaunchFingerprintEngine(ctx context.Context, config *discover.DiscoverApplicationConfig, filteredFingerprints *discover.ApplicationFingerprints) (*discover.DiscoverApplicationReport, error) {
 	report := discover.DiscoverApplicationReport{Config: config}
 	errors := []string{}
 
 	var targets []*discover.ApplicationFingerprintTarget
 	for _, target := range config.Targets {
 		var attempts []*discover.ApplicationFingerprintAttempt
-		attempt, errs := Run(ctx, target, config, filteredFingerprints)
-		attempts = append(attempts, attempt...)
-		errors = append(errors, errs...)
+
+		// Process each resource type separately
+		for _, resourceType := range filteredFingerprints.Fingerprints {
+			attempt, errs := Run(ctx, target, config, resourceType)
+			attempts = append(attempts, attempt...)
+			errors = append(errors, errs...)
+		}
 
 		filteredAttempts := []*discover.ApplicationFingerprintAttempt{}
 		for _, attempt := range attempts {

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -85,16 +85,7 @@ func Run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 
 			if AnalyzeResponse(request, module) {
 				attempt.Finding = true
-				attempt.Fingerprints = []*discover.ApplicationFingerprints{
-					{
-						Fingerprints: []*discover.ApplicationResource{
-							{
-								Name:    resourceType.Name,
-								Modules: []*discover.ApplicationFingerprintModule{module},
-							},
-						},
-					},
-				}
+				attempt.Fingerprints = []*discover.ApplicationResource{resourceType}
 				attempts = append(attempts, attempt)
 				break
 			}

--- a/internal/discover/application/helpers.go
+++ b/internal/discover/application/helpers.go
@@ -28,38 +28,47 @@ func LoadFingerprints(filePath string) (*discover.ApplicationFingerprints, error
 
 // FilterFingerprints filters the fingerprints based on resource types and modules
 // Returns error if resource type or module doesn't exist
-// If resourceType is 'ALL', it returns all resource types combined into a single resource
-func FilterFingerprints(fingerprints *discover.ApplicationFingerprints, resourceConfigType *discover.ApplicationResourceConfigType, modules []string) (*discover.ApplicationResource, error) {
-	// Handle 'ALL' resource type - combine all resource types
+// If resourceType is 'ALL', it returns all resource types as separate resources
+func FilterFingerprints(fingerprints *discover.ApplicationFingerprints, resourceConfigType *discover.ApplicationResourceConfigType, modules []string) (*discover.ApplicationFingerprints, error) {
+	// Handle 'ALL' resource type - return all resource types with their modules
 	if resourceConfigType.GetApplicationResourceTypeAll() == discover.ApplicationResourceTypeAllAll {
-		allModules := []*discover.ApplicationFingerprintModule{}
+		var filteredResources []*discover.ApplicationResource
 
-		// Collect all modules from all resource types
+		// Collect all resource types with their modules
 		for _, rt := range fingerprints.Fingerprints {
+			var filteredModules []*discover.ApplicationFingerprintModule
+
 			// If specific modules are requested, filter them
 			if len(modules) > 0 {
 				for _, m := range rt.Modules {
 					if slices.Contains(modules, m.Name) {
-						allModules = append(allModules, m)
+						filteredModules = append(filteredModules, m)
 					}
 				}
 			} else {
 				// No specific modules requested, add all modules from this resource type
-				allModules = append(allModules, rt.Modules...)
+				filteredModules = append(filteredModules, rt.Modules...)
+			}
+
+			// Only add the resource type if it has matching modules
+			if len(filteredModules) > 0 {
+				filteredResources = append(filteredResources, &discover.ApplicationResource{
+					Name:    rt.Name,
+					Modules: filteredModules,
+				})
 			}
 		}
 
-		if len(allModules) == 0 {
+		if len(filteredResources) == 0 {
 			if len(modules) > 0 {
 				return nil, fmt.Errorf("none of the specified modules %v were found", modules)
 			}
 			return nil, fmt.Errorf("no modules found for resource type ALL")
 		}
 
-		// Return a combined resource with all modules
-		return &discover.ApplicationResource{
-			Name:    resourceConfigType,
-			Modules: allModules,
+		// Return all resource types as separate resources
+		return &discover.ApplicationFingerprints{
+			Fingerprints: filteredResources,
 		}, nil
 	}
 
@@ -82,7 +91,9 @@ func FilterFingerprints(fingerprints *discover.ApplicationFingerprints, resource
 
 	// If no module specified, return all modules for this type
 	if len(modules) == 0 {
-		return foundResourceType, nil
+		return &discover.ApplicationFingerprints{
+			Fingerprints: []*discover.ApplicationResource{foundResourceType},
+		}, nil
 	}
 
 	// Find the specific modules
@@ -97,9 +108,13 @@ func FilterFingerprints(fingerprints *discover.ApplicationFingerprints, resource
 	}
 
 	// Return filtered config with just the requested modules
-	return &discover.ApplicationResource{
-		Name:    foundResourceType.Name,
-		Modules: foundModules,
+	return &discover.ApplicationFingerprints{
+		Fingerprints: []*discover.ApplicationResource{
+			{
+				Name:    foundResourceType.Name,
+				Modules: foundModules,
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
### TL;DR

Refactored application fingerprinting to handle multiple resource types separately instead of combining them.

### What changed?

- Modified `FilterFingerprints` to return multiple resource types as separate resources instead of combining them into a single resource
- Updated `LaunchFingerprintEngine` to process each resource type separately
- Removed the `filteredFingerprints` parameter from `getDiscoverApplicationConfig` function signature
- Changed the return type of `FilterFingerprints` from `*discover.ApplicationResource` to `*discover.ApplicationFingerprints`

### How to test?

1. Run the discover command with different resource types and modules
2. Test with the 'ALL' resource type to ensure it correctly processes all resource types separately
3. Verify that fingerprinting works correctly with specific modules and resource types

### Why make this change?

This change improves the architecture of the fingerprinting system by maintaining separation between different resource types during processing. Instead of merging all resource types into a single combined resource, each type is now processed independently, which provides better organization and more accurate results when analyzing responses.