### PR TITLE
Optimize application discovery request handling

### DIFF
--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -61,7 +61,7 @@ func Run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 			Finding: false,
 		}
 
-		var requests []*common.HttpRequestResponse
+		var allRequests []*common.HttpRequestResponse
 		for _, path := range module.Paths {
 			// Request Configuration
 			fullPath := parsedTargetPath + path
@@ -81,7 +81,7 @@ func Run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 				errors = append(errors, err.Error())
 				continue
 			}
-			requests = append(requests, request)
+			allRequests = append(allRequests, request)
 
 			if AnalyzeResponse(request, module) {
 				attempt.Finding = true
@@ -91,13 +91,16 @@ func Run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 						Modules: []*discover.ApplicationFingerprintModule{module},
 					},
 				}
+				// Only include the successful request in the results
+				attempt.Requests = []*common.HttpRequestResponse{request}
 				attempts = append(attempts, attempt)
 				break
 			}
 		}
 
-		attempt.Requests = requests
+		// For unsuccessful attempts, include all requests made
 		if !attempt.Finding {
+			attempt.Requests = allRequests
 			attempts = append(attempts, attempt)
 		}
 	}


### PR DESCRIPTION
### TL;DR

Improved request handling in application discovery to optimize result reporting.

### What changed?

Modified the application discovery engine to handle requests differently based on whether a finding was successful:
- Renamed `requests` variable to `allRequests` for clarity
- For successful findings, only the matching request is included in the results
- For unsuccessful findings, all attempted requests are included in the results

### How to test?

1. Run application discovery against a target with both successful and unsuccessful module matches
2. Verify that successful findings only include the specific request that matched
3. Verify that unsuccessful findings include all requests that were attempted

### Why make this change?

This change optimizes the output data by only including relevant requests in successful findings, making the results more focused and easier to analyze. For unsuccessful findings, all requests are still included to provide complete diagnostic information for troubleshooting. This improves both the efficiency and usability of the discovery results.