### PR TITLE
Simplify GraphQL enumeration by removing URL parsing

### DIFF
--- a/internal/enumerate/apiapplication/graphql.go
+++ b/internal/enumerate/apiapplication/graphql.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 
 	// Generated
@@ -25,10 +24,7 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapi
 	}
 	report := enumerateapiapplicationfern.EnumerateGraphqlReport{Config: &enumerateapiapplicationfern.EnumerateGraphqlConfig{Target: target}, Result: &result}
 
-	basePath, baseEndpointURL := extractBasePathAndEndpoint(target)
-	result.BaseEndpointUrl = baseEndpointURL
-
-	addTopLevelRoute(&result, basePath)
+	result.BaseEndpointUrl = target
 
 	body, err := fetchGraphQLSchema(target)
 	if err != nil {
@@ -50,31 +46,6 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapi
 	populateReportWithQueries(&result, schema, typeFields)
 
 	return report
-}
-
-func extractBasePathAndEndpoint(target string) (string, string) {
-	u, err := url.Parse(target)
-	if err != nil {
-		return "/", target // fallback if parsing fails
-	}
-	baseEndpoint := u.Scheme + "://" + u.Host
-	basePath := u.Path
-	if basePath == "" {
-		basePath = "/"
-	}
-	return basePath, baseEndpoint
-}
-
-func addTopLevelRoute(report *enumerateapiapplicationfern.EnumerateGraphqlResult, basePath string) {
-	baseRoute := enumerateapiapplicationfern.ApiApplicationRouteDetails{
-		Path:        basePath,
-		QueryParams: nil,
-		Security:    nil,
-		Method:      "POST",
-		Type:        enumerateapiapplicationfern.ApiTypeGraphQl,
-		Description: "Top-level GraphQL route",
-	}
-	report.Routes = append(report.Routes, &baseRoute)
 }
 
 func fetchGraphQLSchema(target string) ([]byte, error) {


### PR DESCRIPTION
### TL;DR

Simplified GraphQL enumeration by removing URL parsing and top-level route generation.

### What changed?

- Removed the `extractBasePathAndEndpoint` function that was parsing the target URL
- Eliminated the `addTopLevelRoute` function that was creating a default route entry
- Set `result.BaseEndpointUrl` directly to the target string instead of extracting it
- Removed the unused `net/url` import

### How to test?

1. Run the GraphQL enumeration against a test endpoint
2. Verify that the enumeration still works correctly without the base path extraction
3. Confirm that the results don't include the automatically generated top-level route

### Why make this change?

The URL parsing and automatic route generation were unnecessary complications. The GraphQL endpoint is typically accessed directly at the provided URL, making the base path extraction redundant. Removing the automatic top-level route generation provides more accurate results that reflect only the actual schema discovered through introspection.