### PR TITLE
Webscan CLI Dast + Path Cleaning Update

### DIFF
--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -123,7 +123,13 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 		requestCount := 0
 		for _, path := range allPaths {
 			attemptInfo := pentestapplicationfern.PathTraversalAttemptInfo{}
-			fullPath := fmt.Sprintf("%s%s", parsedTargetPath, path)
+
+			// Clean path (ie. /foo/bar/ -> /foo/bar or foo/bar -> /foo/bar)
+			cleanPath := strings.Trim(path, "/")
+			if cleanPath != "" { // If the path is not empty, add a leading slash else leave it as ""
+				cleanPath = fmt.Sprintf("/%s", cleanPath)
+			}
+			fullPath := fmt.Sprintf("%s%s", parsedTargetPath, cleanPath)
 			for i := 0; i <= config.Retries; i++ {
 				for _, method := range config.HttpMethods {
 					// Check if context has expired

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -4,6 +4,8 @@ import (
 	// Generated
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 	// External
+	"fmt"
+
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
@@ -40,7 +42,32 @@ func (b *Builder) PopulateProbes(eng *nucleilib.NucleiEngine) error {
 			}
 			// Extract expected matchers
 			for _, matcher := range request.Matchers {
-				vals := append(matcher.Words, matcher.Regex...)
+				var vals []string
+
+				// Handle different matcher types
+				switch matcher.Type.String() {
+				case "word":
+					vals = append(vals, matcher.Words...)
+				case "regex":
+					vals = append(vals, matcher.Regex...)
+				case "status":
+					for _, status := range matcher.Status {
+						vals = append(vals, fmt.Sprintf("%d", status))
+					}
+				case "size":
+					for _, size := range matcher.Size {
+						vals = append(vals, fmt.Sprintf("%d", size))
+					}
+				case "dsl":
+					vals = append(vals, matcher.DSL...)
+				case "binary":
+					vals = append(vals, matcher.Binary...)
+				default:
+					// Fallback for unknown types - try to extract from common fields
+					vals = append(vals, matcher.Words...)
+					vals = append(vals, matcher.Regex...)
+				}
+
 				probe.ExpectedMatchers = append(probe.ExpectedMatchers, &nuclei.NucleiExpectedMatcher{
 					Type:  matcher.Type.String(),
 					Value: vals,

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -37,7 +37,10 @@ func SplitTargetURL(target string) (string, string, error) {
 
 	// Standardize the path
 	// If the path is empty or '/', set it to "", else trim the trailing slash (ie. "/foo/" -> "/foo")
-	path := strings.TrimRight(parsedURL.Path, "/")
+	path := strings.Trim(parsedURL.Path, "/")
+	if path != "" {
+		path = fmt.Sprintf("/%s", path)
+	}
 
 	return baseURL, path, nil
 }


### PR DESCRIPTION
### TL;DR

Enhanced path handling and improved Nuclei matcher type support for more accurate reporting.

### What changed?

- **Path Traversal Fix**: Improved path handling in the path traversal module by properly cleaning paths with a leading slash, preventing potential duplicate slashes when combining paths.

- **URL Path Standardization**: Enhanced the `SplitTargetURL` function to ensure consistent path formatting by properly trimming slashes and adding a leading slash when needed.

- **Nuclei Matcher Type Support**: Significantly improved the `PopulateProbes` function in the Nuclei report builder to properly handle all matcher types:
  - Added specific handling for `word`, `regex`, `status`, `size`, `dsl`, and `binary` matcher types
  - Each matcher type now correctly extracts its relevant values
  - Status codes and sizes are properly converted to strings
  - Maintains backward compatibility with a fallback for unknown types

These changes ensure more accurate path handling during security testing and more comprehensive reporting of Nuclei scan results.