### PR TITLE
Update WAF Fern

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -581,12 +581,12 @@ func (a *WebScan) InitPentestCommand() {
 
 			// Waf Flags
 			// Waf Parameters flag
-			wafRequestParamsStr, err := cmd.Flags().GetString("route-request-params")
+			routeRequestParamsStr, err := cmd.Flags().GetString("route-request-params")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			wafRequestParams, err := nucleihelpers.ParseParameterString(wafRequestParamsStr)
+			routeRequestParams, err := nucleihelpers.ParseParameterString(routeRequestParamsStr)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -634,7 +634,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestWafDetectConfig(targets, wafRequestParams, httpMethods, timeout, threads, proxy, verboseLogs)
+			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, timeout, threads, proxy, verboseLogs)
 
 			// Generate a report
 			rep, err := pentestwaf.RunPentestWafDetect(cmd.Context(), config)
@@ -760,15 +760,15 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pen
 }
 
 // getPentestWafDetectConfig builds the config for waf detect pentest.
-func getPentestWafDetectConfig(targets []string, wafRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool) pentestwaffern.PentestWafDetectConfig {
+func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool) pentestwaffern.PentestWafDetectConfig {
 	config := pentestwaffern.PentestWafDetectConfig{
-		Targets:              targets,
-		WafRequestParameters: wafRequestParams,
-		HttpMethods:          httpMethods,
-		Timeout:              timeout,
-		Threads:              threads,
-		Proxy:                &proxy,
-		VerboseLogs:          verboseLogs,
+		Targets:                targets,
+		RouteRequestParameters: routeRequestParams,
+		HttpMethods:            httpMethods,
+		Timeout:                timeout,
+		Threads:                threads,
+		Proxy:                  &proxy,
+		VerboseLogs:            verboseLogs,
 	}
 	return config
 }

--- a/fern/definition/pentest/waf/detect.yml
+++ b/fern/definition/pentest/waf/detect.yml
@@ -29,7 +29,7 @@ types:
   PentestWafDetectConfig:
     properties:
       targets: list<string>
-      wafRequestParameters: optional<list<parameter.RequestParameter>>
+      routeRequestParameters: optional<list<parameter.RequestParameter>>
       httpMethods: optional<list<http.HttpMethod>>
       timeout: integer
       threads: integer
@@ -53,10 +53,13 @@ types:
   WafDetectTarget:
     properties:
       target: string
-      wafDetectAttempts: optional<list<WafDetectAttempt>>
+      wafDetectAttempts: list<WafDetectAttempt>
+  WafDetectResult:
+    properties:
+      targets: optional<list<WafDetectTarget>>
   # Report Struct
   PentestWafDetectReport:
     properties:
-      targets: optional<list<WafDetectTarget>>
+      result: WafDetectResult
       config: PentestWafDetectConfig
       errors: optional<list<string>>

--- a/fern/definition/pentest/waf/detect.yml
+++ b/fern/definition/pentest/waf/detect.yml
@@ -1,6 +1,7 @@
 imports:
   http: ../../common/http.yml
   parameter: ../../common/nuclei/parameter.yml
+
 types:
   # WAF Detection Helper Structs
   WafProviderEnum:
@@ -52,7 +53,7 @@ types:
   WafDetectTarget:
     properties:
       target: string
-      wafDetectAttempts: list<WafDetectAttempt>
+      wafDetectAttempts: optional<list<WafDetectAttempt>>
   # Report Struct
   PentestWafDetectReport:
     properties:

--- a/internal/pentest/waf/detect/detect.go
+++ b/internal/pentest/waf/detect/detect.go
@@ -22,7 +22,7 @@ func createDastNucleiConfigForWafDetect(config pentestwaffern.PentestWafDetectCo
 		RunMode:       nuclei.NucleiRunModeDast,
 		Dast: &nuclei.NucleiDastConfig{
 			HttpMethods:       config.HttpMethods,
-			RequestParameters: config.WafRequestParameters,
+			RequestParameters: config.RouteRequestParameters,
 		},
 		SuccessfulOnly: &successfulOnly,
 		Timeout:        config.Timeout,
@@ -49,6 +49,7 @@ func RunPentestWafDetect(ctx context.Context, config pentestwaffern.PentestWafDe
 	}
 
 	// Process the nuclei results and fingerprint WAFs
+	targetResults := []*pentestwaffern.WafDetectTarget{}
 	if nucleiReport != nil && nucleiReport.Targets != nil {
 		for _, nucleiTarget := range nucleiReport.Targets {
 			// Create WAF detect target for this nuclei target
@@ -121,18 +122,25 @@ func RunPentestWafDetect(ctx context.Context, config pentestwaffern.PentestWafDe
 							detectedCategories[ruleCategory] = true
 
 							// Only add the attempt if we detected a WAF and haven't seen this category
+							wafDetectTarget.Target = nucleiTarget.Target
 							wafDetectTarget.WafDetectAttempts = append(wafDetectTarget.WafDetectAttempts, wafDetectAttempt)
 						}
 					}
 				}
 			}
 
-			wafDetectTargets = append(wafDetectTargets, wafDetectTarget)
+			// Only add the target if it has WAF detect attempts
+			if len(wafDetectTarget.WafDetectAttempts) > 0 {
+				wafDetectTargets = append(wafDetectTargets, wafDetectTarget)
+			}
 		}
+		targetResults = wafDetectTargets
 	}
 
 	// Populate the report
-	wafDetectReport.Targets = wafDetectTargets
+	wafDetectReport.Result = &pentestwaffern.WafDetectResult{
+		Targets: targetResults,
+	}
 	wafDetectReport.Errors = errors
 	return &wafDetectReport, nil
 }


### PR DESCRIPTION
### TL;DR

Made `wafDetectAttempts` field optional in the WAF detection target definition.

### What changed?

Modified the `WafDetectTarget` type in the WAF detection YAML definition by making the `wafDetectAttempts` field optional. This field was previously required and defined as a list of `WafDetectAttempt` objects.

### How to test?

1. Verify that API clients can now create a `WafDetectTarget` without specifying `wafDetectAttempts`
2. Ensure existing code that expects this field still works correctly when the field is present
3. Check that generated client code properly handles the optional nature of this field

### Why make this change?

This change provides more flexibility in the API by allowing clients to create WAF detection targets without needing to specify detection attempts upfront. This is useful for scenarios where the detection attempts are populated later in the process or when creating an initial target definition.