### PR TITLE
Webscan: Path Traversal Fix

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -235,6 +235,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirectsBaselineRequest, err := cmd.Flags().GetInt("max-redirects-baseline-request")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			maxRuntime, err := cmd.Flags().GetInt("max-runtime")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -251,7 +256,7 @@ func (a *WebScan) InitPentestCommand() {
 				return
 			}
 			// Set config
-			config := getPentestApplicationPathTraversalConfig(targets, paths, filePaths, httpMethods, responseCodes, ignoreBaseContentMatch, successfulOnly, verifyTLS, threshold, timeout, maxRuntime, retries, sleep)
+			config := getPentestApplicationPathTraversalConfig(targets, paths, filePaths, httpMethods, responseCodes, ignoreBaseContentMatch, successfulOnly, verifyTLS, threshold, timeout, maxRedirectsBaselineRequest, maxRuntime, retries, sleep)
 
 			// Generate a report
 			rep, err := pentestapplication.RunApplicationPathTraversal(cmd.Context(), config)
@@ -274,6 +279,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationPathTraversalCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestApplicationPathTraversalCmd.Flags().Float64("threshold", 0.25, "Threshold for successful results")
 	pentestApplicationPathTraversalCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	pentestApplicationPathTraversalCmd.Flags().Int("max-redirects-baseline-request", 10, "Maximum number of redirects to follow for the baseline request")
 	pentestApplicationPathTraversalCmd.Flags().Int("max-runtime", 0, "Maximum time to run the engagement (seconds) (Default is 0, which will run indefinitely)")
 	pentestApplicationPathTraversalCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	pentestApplicationPathTraversalCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
@@ -688,21 +694,22 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 }
 
 // getPentestDastPathTraversalConfig builds the config for dast path traversal pentest.
-func getPentestApplicationPathTraversalConfig(targets []string, paths []string, filePaths []string, httpMethods []common.HttpMethod, responseCodes string, ignoreBaseContentMatch bool, successfulOnly bool, verifyTLS bool, threshold float64, timeout int, maxRuntime int, retries int, sleep int) pentestapplicationfern.PentestApplicationPathTraversalConfig {
+func getPentestApplicationPathTraversalConfig(targets []string, paths []string, filePaths []string, httpMethods []common.HttpMethod, responseCodes string, ignoreBaseContentMatch bool, successfulOnly bool, verifyTLS bool, threshold float64, timeout int, maxRedirectsBaselineRequest int, maxRuntime int, retries int, sleep int) pentestapplicationfern.PentestApplicationPathTraversalConfig {
 	config := pentestapplicationfern.PentestApplicationPathTraversalConfig{
-		Targets:           targets,
-		Paths:             paths,
-		FilePaths:         filePaths,
-		HttpMethods:       httpMethods,
-		ResponseCodes:     responseCodes,
-		IgnoreBaseContentMatch: ignoreBaseContentMatch,
-		SuccessfulOnly:    successfulOnly,
-		VerifyTls:         verifyTLS,
-		Threshold:         threshold,
-		Timeout:           timeout,
-		MaxRuntime:        maxRuntime,
-		Retries:           retries,
-		Sleep:             sleep,
+		Targets:                     targets,
+		Paths:                       paths,
+		FilePaths:                   filePaths,
+		HttpMethods:                 httpMethods,
+		ResponseCodes:               responseCodes,
+		IgnoreBaseContentMatch:      ignoreBaseContentMatch,
+		SuccessfulOnly:              successfulOnly,
+		VerifyTls:                   verifyTLS,
+		Threshold:                   threshold,
+		Timeout:                     timeout,
+		MaxRedirectsBaselineRequest: maxRedirectsBaselineRequest,
+		MaxRuntime:                  maxRuntime,
+		Retries:                     retries,
+		Sleep:                       sleep,
 	}
 	return config
 }

--- a/fern/definition/pentest/application/pathtraversal.yml
+++ b/fern/definition/pentest/application/pathtraversal.yml
@@ -14,6 +14,7 @@ types:
       verifyTls: boolean
       threshold: float
       timeout: integer
+      maxRedirectsBaselineRequest: integer
       maxRuntime: integer
       retries: integer
       sleep: integer

--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -24,7 +24,7 @@ import (
 )
 
 // createPathTraversalSendHTTPRequestConfig builds the config for dast path traversal pentest.
-func createPathTraversalSendHTTPRequestConfig(baseURL, path string, method common.HttpMethod, requestParams common.HttpRequestParams, config *pentestapplicationfern.PentestApplicationPathTraversalConfig) common.SendHttpRequestConfig {
+func createPathTraversalSendHTTPRequestConfig(baseURL, path string, method common.HttpMethod, requestParams common.HttpRequestParams, MaxRedirects int, config *pentestapplicationfern.PentestApplicationPathTraversalConfig) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -33,7 +33,7 @@ func createPathTraversalSendHTTPRequestConfig(baseURL, path string, method commo
 	}
 	return common.SendHttpRequestConfig{
 		Request:            &request,
-		MaxRedirects:       0,
+		MaxRedirects:       MaxRedirects,
 		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
 		RequestMethod:      common.RequestMethodStandard,
@@ -139,7 +139,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 					}
 
 					// Send request
-					requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, fullPath, method, common.HttpRequestParams{}, &config)
+					requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, fullPath, method, common.HttpRequestParams{}, 0, &config)
 					request, err := request.SendRequest(ctx, requestConfig)
 					if err != nil {
 						report.Errors = append(report.Errors, err.Error())
@@ -203,7 +203,7 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 // baseLine gets the baseline size and word count of the target to be used for validation of the response
 func baseLine(ctx context.Context, baseURL string, path string, validCodes map[int]bool, config *pentestapplicationfern.PentestApplicationPathTraversalConfig) (*common.HttpRequestResponse, *int, *int, error) {
 	// set request config
-	requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, path, common.HttpMethodGet, common.HttpRequestParams{}, config)
+	requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, path, common.HttpMethodGet, common.HttpRequestParams{}, config.MaxRedirectsBaselineRequest, config)
 
 	// send request
 	request, err := request.SendRequest(ctx, requestConfig)

--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -96,7 +96,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 
 		// Get baseline size and word count
 		// Follow redirects to get the correct baseline size and word count
-		baselineRequest, baselineSize, baselineWords, err := baseLine(ctx, baseURL, parsedTargetPath, validCodes, &config)
+		baselineRequest, baselineSize, baselineWords, err := baseLine(ctx, baseURL, parsedTargetPath, validCodes, config.MaxRedirectsBaselineRequest, &config)
 		if err != nil {
 			err = errors.New("failed to get baseline body, stopping enumeration")
 			allErrors = append(allErrors, err.Error())
@@ -109,7 +109,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 
 		// Do not follow redirects to get the correct baseline size and word count
 		// This is to prevent false positives from remote configurations that dont redirect but give blanket responses on all paths
-		baselineRandomRequest, baselineSizeRandomPath, baselineWordsRandomPath, err := baseLine(ctx, baseURL, "xxxx", validCodes, &config)
+		baselineRandomRequest, baselineSizeRandomPath, baselineWordsRandomPath, err := baseLine(ctx, baseURL, "xxxx", validCodes, 0, &config)
 		if err != nil {
 			err = errors.New("failed to get baseline random path, continuing enumeration")
 			allErrors = append(allErrors, err.Error())
@@ -201,9 +201,9 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 }
 
 // baseLine gets the baseline size and word count of the target to be used for validation of the response
-func baseLine(ctx context.Context, baseURL string, path string, validCodes map[int]bool, config *pentestapplicationfern.PentestApplicationPathTraversalConfig) (*common.HttpRequestResponse, *int, *int, error) {
+func baseLine(ctx context.Context, baseURL string, path string, validCodes map[int]bool, maxRedirects int, config *pentestapplicationfern.PentestApplicationPathTraversalConfig) (*common.HttpRequestResponse, *int, *int, error) {
 	// set request config
-	requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, path, common.HttpMethodGet, common.HttpRequestParams{}, config.MaxRedirectsBaselineRequest, config)
+	requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, path, common.HttpMethodGet, common.HttpRequestParams{}, maxRedirects, config)
 
 	// send request
 	request, err := request.SendRequest(ctx, requestConfig)


### PR DESCRIPTION
## Overview

- Redirects were not enabled (but should be) for baseline request so the commands was exiting early