### PR TITLE
Path Traversal Stale Flag Bug

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -215,11 +215,6 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			successfulOnly, err := cmd.Flags().GetBool("successful-only")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -256,7 +251,7 @@ func (a *WebScan) InitPentestCommand() {
 				return
 			}
 			// Set config
-			config := getPentestApplicationPathTraversalConfig(targets, paths, filePaths, httpMethods, responseCodes, ignoreBaseContentMatch, successfulOnly, verifyTLS, threshold, timeout, maxRedirectsBaselineRequest, maxRuntime, retries, sleep)
+			config := getPentestApplicationPathTraversalConfig(targets, paths, filePaths, httpMethods, responseCodes, ignoreBaseContentMatch, verifyTLS, threshold, timeout, maxRedirectsBaselineRequest, maxRuntime, retries, sleep)
 
 			// Generate a report
 			rep, err := pentestapplication.RunApplicationPathTraversal(cmd.Context(), config)
@@ -275,7 +270,6 @@ func (a *WebScan) InitPentestCommand() {
 	// Config Flags
 	pentestApplicationPathTraversalCmd.Flags().String("response-codes", "200-299", "Response codes to consider as valid responses")
 	pentestApplicationPathTraversalCmd.Flags().Bool("ignore-base-content-match", true, "Ignores valid responses with identical size and word length to the base path, typically signifying a web backend redirect")
-	pentestApplicationPathTraversalCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
 	pentestApplicationPathTraversalCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestApplicationPathTraversalCmd.Flags().Float64("threshold", 0.25, "Threshold for successful results")
 	pentestApplicationPathTraversalCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
@@ -694,7 +688,7 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 }
 
 // getPentestDastPathTraversalConfig builds the config for dast path traversal pentest.
-func getPentestApplicationPathTraversalConfig(targets []string, paths []string, filePaths []string, httpMethods []common.HttpMethod, responseCodes string, ignoreBaseContentMatch bool, successfulOnly bool, verifyTLS bool, threshold float64, timeout int, maxRedirectsBaselineRequest int, maxRuntime int, retries int, sleep int) pentestapplicationfern.PentestApplicationPathTraversalConfig {
+func getPentestApplicationPathTraversalConfig(targets []string, paths []string, filePaths []string, httpMethods []common.HttpMethod, responseCodes string, ignoreBaseContentMatch bool, verifyTLS bool, threshold float64, timeout int, maxRedirectsBaselineRequest int, maxRuntime int, retries int, sleep int) pentestapplicationfern.PentestApplicationPathTraversalConfig {
 	config := pentestapplicationfern.PentestApplicationPathTraversalConfig{
 		Targets:                     targets,
 		Paths:                       paths,
@@ -702,7 +696,6 @@ func getPentestApplicationPathTraversalConfig(targets []string, paths []string, 
 		HttpMethods:                 httpMethods,
 		ResponseCodes:               responseCodes,
 		IgnoreBaseContentMatch:      ignoreBaseContentMatch,
-		SuccessfulOnly:              successfulOnly,
 		VerifyTls:                   verifyTLS,
 		Threshold:                   threshold,
 		Timeout:                     timeout,

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -32,7 +32,6 @@ Flags:
   -h, --help                      help for application
       --modules strings           Specific fingerprinting modules to run
       --resource-type string      Type of resource to fingerprint (e.g., web, api, cms)
-      --successful-only           Only show successful fingerprint matches
       --targets strings           URL targets to perform fingerprinting against
       --verify-tls                Verify TLS certificates when making HTTPS requests (default true)
       --timeout int               Timeout per request in seconds (default 30)
@@ -199,7 +198,6 @@ Flags:
       --saas-file-paths strings         Files containing SaaS application fingerprints (default ["configs/discover/saas/active/saas_fingerprints.json"]) 
       --sso-companies strings           The specific SSO companies to use for discovery (Must be present in the SSO fingerprints file)
       --sso-file-paths strings          Files containing SSO application fingerprints (default ["configs/discover/saas/active/sso_fingerprints.json"]) 
-      --successful-only                 Only show successful attempts
       --timeout int                     Timeout in seconds for the capture (default 30)
       --verify-tls                      Verify TLS certificates when making HTTPS requests (default true)
 

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -65,7 +65,6 @@ Flags:
       --response-codes string          Response codes to consider as valid responses (default "200-299")
       --retries int                    Number of times to retry a request if it fails
       --sleep int                      Number of seconds to sleep between requests
-      --successful-only                Only include successful results in the report
       --targets strings                Targets to be scanned
       --threshold float                Threshold for successful results (default 0.25)
       --timeout int                    Timeout per request in seconds (default 30)

--- a/fern/definition/pentest/application/pathtraversal.yml
+++ b/fern/definition/pentest/application/pathtraversal.yml
@@ -10,7 +10,6 @@ types:
       httpMethods: list<http.HttpMethod>
       responseCodes: string
       ignoreBaseContentMatch: boolean
-      successfulOnly: boolean
       verifyTls: boolean
       threshold: float
       timeout: integer

--- a/fern/definition/pentest/application/pathtraversal.yml
+++ b/fern/definition/pentest/application/pathtraversal.yml
@@ -18,18 +18,16 @@ types:
       retries: integer
       sleep: integer
   # Report Structs
-  PathTraversalAttemptInfo:
-    properties:
-      httpRequestResponse: http.HttpRequestResponse
-      finding: boolean
   PathTraversalTargetInfo:
     properties:
       target: string
-      baselineAttempts: optional<list<http.HttpRequestResponse>>
-      attempts: optional<list<PathTraversalAttemptInfo>>
-      requestCount: integer
-  PentestApplicationPathTraversalReport:
+      baselineAttempts: list<http.HttpRequestResponse>
+      attempts: list<http.HttpRequestResponse>
+  PathTraversalResult:
     properties:
       targets: optional<list<PathTraversalTargetInfo>>
+  PentestApplicationPathTraversalReport:
+    properties:
+      result: PathTraversalResult
       config: PentestApplicationPathTraversalConfig
       errors: optional<list<string>>

--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -23,7 +23,7 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// createPathTraversalSendHTTPRequestConfig builds the config for dast path traversal pentest.
+// createPathTraversalSendHTTPRequestConfig builds the config for path traversal pentest.
 func createPathTraversalSendHTTPRequestConfig(baseURL, path string, method common.HttpMethod, requestParams common.HttpRequestParams, MaxRedirects int, config *pentestapplicationfern.PentestApplicationPathTraversalConfig) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
@@ -54,7 +54,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 
 	// Set log
 	log := svc1log.FromContext(ctx)
-	log.Info("Starting Dast Path Traversal")
+	log.Info("Starting Path Traversal")
 
 	// Initialize report
 	report := pentestapplicationfern.PentestApplicationPathTraversalReport{}
@@ -73,6 +73,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 		report.Errors = append(report.Errors, err.Error())
 		return &report, nil
 	}
+	log.Info("Valid codes", svc1log.SafeParam("codes", fmt.Sprintf("%v", validCodes)))
 
 	// Initialize targets
 	var targets []*pentestapplicationfern.PathTraversalTargetInfo
@@ -150,7 +151,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 					isValid := AnalyzeResponse(ctx, *request, validCodes, config.IgnoreBaseContentMatch, baselineSizeInt, baselineWordsInt, baselineSizeRandomPath, baselineWordsRandomPath, config.Threshold)
 
 					// Marshal data
-					if !config.SuccessfulOnly || isValid {
+					if isValid {
 						attemptInfo.HttpRequestResponse = request
 						attemptInfo.Finding = isValid
 						attempts = append(attempts, &attemptInfo)
@@ -181,6 +182,8 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 	if request.Response == nil || request.Response.StatusCode == nil || !validCodes[*request.Response.StatusCode] {
 		return false
 	}
+	log.Info("Valid codes", svc1log.SafeParam("codes", fmt.Sprintf("%v", validCodes)))
+	log.Info("statuscode", svc1log.SafeParam("statuscode", request.Response.StatusCode))
 
 	bodySize := len(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody))
 	if bodySize == 0 {

--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -58,7 +58,8 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 
 	// Initialize report
 	report := pentestapplicationfern.PentestApplicationPathTraversalReport{}
-	var allErrors []string
+	errors := []string{}
+	result := pentestapplicationfern.PathTraversalResult{}
 
 	// Gather all paths
 	allPaths, err := gatherPaths(config.Paths, config.FilePaths)
@@ -70,6 +71,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 	// Parse response codes
 	validCodes, err := parseResponseCodes(config.ResponseCodes)
 	if err != nil {
+		report.Result = &result
 		report.Errors = append(report.Errors, err.Error())
 		return &report, nil
 	}
@@ -91,7 +93,8 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 		// Split target
 		baseURL, parsedTargetPath, err := requesthelpers.SplitTargetURL(target)
 		if err != nil {
-			allErrors = append(allErrors, err.Error())
+			errors = append(errors, fmt.Sprintf("failed to split target url: %v", err))
+			report.Errors = errors
 			continue
 		}
 
@@ -99,8 +102,8 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 		// Follow redirects to get the correct baseline size and word count
 		baselineRequest, baselineSize, baselineWords, err := baseLine(ctx, baseURL, parsedTargetPath, validCodes, config.MaxRedirectsBaselineRequest, &config)
 		if err != nil {
-			err = errors.New("failed to get baseline body, stopping enumeration")
-			allErrors = append(allErrors, err.Error())
+			errors = append(errors, "failed to get baseline body, stopping enumeration")
+			report.Errors = errors
 			continue
 		}
 		baselineSizeInt := *baselineSize
@@ -112,18 +115,16 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 		// This is to prevent false positives from remote configurations that dont redirect but give blanket responses on all paths
 		baselineRandomRequest, baselineSizeRandomPath, baselineWordsRandomPath, err := baseLine(ctx, baseURL, "xxxx", validCodes, 0, &config)
 		if err != nil {
-			err = errors.New("failed to get baseline random path, continuing enumeration")
-			allErrors = append(allErrors, err.Error())
+			err = fmt.Errorf("failed to get baseline random path, continuing enumeration")
+			errors = append(errors, err.Error())
 		}
 		if baselineSizeRandomPath != nil && baselineWordsRandomPath != nil {
 			targetInfo.BaselineAttempts = append(targetInfo.BaselineAttempts, baselineRandomRequest)
 			log.Info("Baseline size random path", svc1log.SafeParam("size", *baselineSizeRandomPath), svc1log.SafeParam("words", *baselineWordsRandomPath))
 		}
 
-		var attempts []*pentestapplicationfern.PathTraversalAttemptInfo
-		requestCount := 0
+		var attempts []*common.HttpRequestResponse
 		for _, path := range allPaths {
-			attemptInfo := pentestapplicationfern.PathTraversalAttemptInfo{}
 
 			// Clean path (ie. /foo/bar/ -> /foo/bar or foo/bar -> /foo/bar)
 			cleanPath := strings.Trim(path, "/")
@@ -143,7 +144,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 					requestConfig := createPathTraversalSendHTTPRequestConfig(baseURL, fullPath, method, common.HttpRequestParams{}, 0, &config)
 					request, err := request.SendRequest(ctx, requestConfig)
 					if err != nil {
-						report.Errors = append(report.Errors, err.Error())
+						errors = append(errors, fmt.Sprintf("failed to send request: %v", err))
 						continue
 					}
 
@@ -152,27 +153,27 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 
 					// Marshal data
 					if isValid {
-						attemptInfo.HttpRequestResponse = request
-						attemptInfo.Finding = isValid
-						attempts = append(attempts, &attemptInfo)
+						attempts = append(attempts, request)
 						log.Info("Valid finding", svc1log.SafeParam("base_url", request.Request.BaseUrl), svc1log.SafeParam("path", request.Request.Path), svc1log.SafeParam("size", len(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody))), svc1log.SafeParam("words", len(strings.Fields(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)))))
 					}
 
 					if config.Sleep > 0 {
 						time.Sleep(time.Duration(config.Sleep) * time.Second)
 					}
-					requestCount++
 				}
 			}
 		}
-		targetInfo.Attempts = attempts
-		targetInfo.RequestCount = requestCount
-		targets = append(targets, &targetInfo)
+		if len(attempts) > 0 {
+			targetInfo.Attempts = attempts
+			targets = append(targets, &targetInfo)
+		}
 	}
 
-	report.Targets = targets
+	result.Targets = targets
+
+	report.Result = &result
 	report.Config = &config
-	report.Errors = allErrors
+	report.Errors = errors
 	return &report, nil
 }
 
@@ -182,8 +183,6 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 	if request.Response == nil || request.Response.StatusCode == nil || !validCodes[*request.Response.StatusCode] {
 		return false
 	}
-	log.Info("Valid codes", svc1log.SafeParam("codes", fmt.Sprintf("%v", validCodes)))
-	log.Info("statuscode", svc1log.SafeParam("statuscode", request.Response.StatusCode))
 
 	bodySize := len(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody))
 	if bodySize == 0 {


### PR DESCRIPTION
### TL;DR

Removed the `successful-only` flag from path traversal functionality and improved logging.

We werent setting this flag in the platform so it was returning all statuses 