### PR TITLE
Clean Up Nuclei Fern for Classification + Probe 

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -126,7 +126,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, proxy, verboseLogs)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, &proxy, verboseLogs)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -673,7 +673,7 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy string, verboseLogs bool) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy *string, verboseLogs bool) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
 		Targets:           targets,
 		DastCategories:    dastCategories,
@@ -681,7 +681,7 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 		HttpMethods:       httpMethods,
 		Timeout:           timeout,
 		Threads:           threads,
-		Proxy:             &proxy,
+		Proxy:             proxy,
 		VerboseLogs:       verboseLogs,
 	}
 	return config

--- a/fern/definition/common/nuclei/report.yml
+++ b/fern/definition/common/nuclei/report.yml
@@ -3,17 +3,29 @@ imports:
   http: ../../common/http.yml
   probe: ./probe.yml
 types:
+  CweDetails:
+    properties:
+      id: string
+      name: optional<string>
+      description: optional<string>
+  CveDetails:
+    properties:
+      id: string
+      cvssMetrics: optional<string>
+      cvssScore: optional<float>
+      epssScore: optional<float>
+      epssPercentile: optional<float>
+      cpe: optional<string>
   ClassificationDetails:
     properties:
-      cweIds: optional<list<string>>
-      cveIds: optional<list<string>>
+      cwes: optional<list<CweDetails>>
+      cves: optional<list<CveDetails>>
   NucleiFindingInfo:
     properties:
-      name: optional<string>
       finding: boolean
+      probe: optional<probe.NucleiProbe>
       severity: optional<string>
       classification: optional<ClassificationDetails>
-      tags: optional<list<string>>
   NucleiAttemptInfo:
     properties:
       probeId: string
@@ -25,8 +37,3 @@ types:
       baselineAttempt: optional<NucleiAttemptInfo>
       attempts: optional<list<NucleiAttemptInfo>>
       requestCount: integer
-  NucleiReport:
-    properties:
-      targets: optional<list<NucleiTargetInfo>>
-      probes: optional<list<probe.NucleiProbe>>
-

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -28,8 +28,11 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+  PentestApplicationDastResult:
+    properties:
+      report: optional<list<nuclei.NucleiTargetInfo>>
   PentestApplicationDastReport:
     properties:
-      report: nuclei.NucleiReport
+      result: PentestApplicationDastResult
       config: PentestApplicationDastConfig
       errors: optional<list<string>>

--- a/fern/definition/pentest/application/scan.yml
+++ b/fern/definition/pentest/application/scan.yml
@@ -10,8 +10,11 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+  PentestApplicationScanResult:
+    properties:
+      report: optional<list<nuclei.NucleiTargetInfo>>
   PentestApplicationScanReport:
     properties:
-      report: nuclei.NucleiReport
+      result: PentestApplicationScanResult
       config: PentestApplicationScanConfig
       errors: optional<list<string>>

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -56,20 +56,24 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 // RunPentestApplicationDast runs a dast pentest on the given targets.
 func RunPentestApplicationDast(ctx context.Context, config pentestapplicationfern.PentestApplicationDastConfig) (*pentestapplicationfern.PentestApplicationDastReport, error) {
 	// Initialize the application report
-	applicationReport := pentestapplicationfern.PentestApplicationDastReport{Config: &config}
+	applicationResult := pentestapplicationfern.PentestApplicationDastReport{Config: &config}
+	report := pentestapplicationfern.PentestApplicationDastResult{}
 	errors := []string{}
 
 	// Create the nuclei config
 	nucleiConfig := createDastNucleiConfig(config)
 
 	// Run the nuclei engine
-	nucleiReport, err := nucleiutils.RunNucleiEngine(ctx, nucleiConfig)
+	nucleiTargets, err := nucleiutils.RunNucleiEngine(ctx, nucleiConfig)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
-
 	// Populate the application report
-	applicationReport.Report = nucleiReport
-	applicationReport.Errors = errors
-	return &applicationReport, nil
+	if nucleiTargets != nil {
+		report.Report = nucleiTargets
+	}
+
+	applicationResult.Result = &report
+	applicationResult.Errors = errors
+	return &applicationResult, nil
 }

--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -75,7 +75,6 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 		report.Errors = append(report.Errors, err.Error())
 		return &report, nil
 	}
-	log.Info("Valid codes", svc1log.SafeParam("codes", fmt.Sprintf("%v", validCodes)))
 
 	// Initialize targets
 	var targets []*pentestapplicationfern.PathTraversalTargetInfo

--- a/internal/pentest/application/scan.go
+++ b/internal/pentest/application/scan.go
@@ -28,7 +28,10 @@ func createScanNucleiConfig(config pentestapplicationfern.PentestApplicationScan
 // RunPentestApplicationScan runs a scan on the given targets.
 func RunPentestApplicationScan(ctx context.Context, config pentestapplicationfern.PentestApplicationScanConfig) (*pentestapplicationfern.PentestApplicationScanReport, error) {
 	// Initialize the application report
-	applicationReport := pentestapplicationfern.PentestApplicationScanReport{Config: &config}
+	applicationResult := pentestapplicationfern.PentestApplicationScanReport{
+		Config: &config,
+	}
+	report := pentestapplicationfern.PentestApplicationScanResult{}
 	errors := []string{}
 
 	// Create the nuclei config
@@ -40,8 +43,12 @@ func RunPentestApplicationScan(ctx context.Context, config pentestapplicationfer
 		errors = append(errors, err.Error())
 	}
 
-	// Populate the application report
-	applicationReport.Report = nucleiReport
-	applicationReport.Errors = errors
-	return &applicationReport, nil
+	// Only populate the report if there are targets found
+	if nucleiReport != nil {
+		report.Report = nucleiReport
+	}
+
+	applicationResult.Result = &report
+	applicationResult.Errors = errors
+	return &applicationResult, nil
 }

--- a/internal/pentest/waf/detect/detect.go
+++ b/internal/pentest/waf/detect/detect.go
@@ -51,8 +51,8 @@ func RunPentestWafDetect(ctx context.Context, config pentestwaffern.PentestWafDe
 
 	// Process the nuclei results and fingerprint WAFs
 	targetResults := []*pentestwaffern.WafDetectTarget{}
-	if nucleiReport != nil && nucleiReport.Targets != nil {
-		for _, nucleiTarget := range nucleiReport.Targets {
+	if nucleiReport != nil && len(nucleiReport) > 0 {
+		for _, nucleiTarget := range nucleiReport {
 			// Create WAF detect target for this nuclei target
 			wafDetectTarget := &pentestwaffern.WafDetectTarget{
 				Target:            nucleiTarget.Target,

--- a/utils/nuclei/engine.go
+++ b/utils/nuclei/engine.go
@@ -34,7 +34,7 @@ type proxifyRequest struct {
 }
 
 // RunNucleiEngine runs the Nuclei engine with the given config.
-func RunNucleiEngine(ctx context.Context, config nuclei.NucleiConfig) (*nuclei.NucleiReport, error) {
+func RunNucleiEngine(ctx context.Context, config nuclei.NucleiConfig) ([]*nuclei.NucleiTargetInfo, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Starting Nuclei Run of mode: Scan")
 

--- a/utils/nuclei/report/builder.go
+++ b/utils/nuclei/report/builder.go
@@ -11,7 +11,7 @@ import (
 // It maintains indexes for probes and targets to efficiently process scan results.
 type Builder struct {
 	mu        sync.Mutex
-	report    *nuclei.NucleiReport
+	targets   []*nuclei.NucleiTargetInfo
 	probeIdx  map[string]*nuclei.NucleiProbe      // template-id → Probe
 	targetIdx map[string]*nuclei.NucleiTargetInfo // host/baseURL → TargetInfo
 }
@@ -19,7 +19,7 @@ type Builder struct {
 // NewBuilder creates and returns a new Builder instance.
 func NewBuilder() *Builder {
 	return &Builder{
-		report:    &nuclei.NucleiReport{},
+		targets:   []*nuclei.NucleiTargetInfo{},
 		probeIdx:  make(map[string]*nuclei.NucleiProbe),
 		targetIdx: make(map[string]*nuclei.NucleiTargetInfo),
 	}

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -3,7 +3,6 @@ package nuclei
 import (
 	// Generated
 	"regexp"
-	"slices"
 
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 
@@ -13,6 +12,65 @@ import (
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
+
+// addOrMergeCWE adds a CWE to the slice if it doesn't exist by ID, or merges additional fields if it does
+func addOrMergeCWE(cwes *[]*nuclei.CweDetails, cweID string, name *string, description *string) {
+	// Check if CWE with this ID already exists
+	for _, existing := range *cwes {
+		if existing.Id == cweID {
+			// CWE already exists, merge additional fields if they're not already set
+			if existing.Name == nil && name != nil {
+				existing.Name = name
+			}
+			if existing.Description == nil && description != nil {
+				existing.Description = description
+			}
+			return
+		}
+	}
+
+	// CWE doesn't exist, add it
+	*cwes = append(*cwes, &nuclei.CweDetails{
+		Id:          cweID,
+		Name:        name,
+		Description: description,
+	})
+}
+
+// addOrMergeCVE adds a CVE to the slice if it doesn't exist by ID, or merges additional fields if it does
+func addOrMergeCVE(cves *[]*nuclei.CveDetails, cveID string, cvssMetrics *string, cvssScore *float64, epssScore *float64, epssPercentile *float64, cpe *string) {
+	// Check if CVE with this ID already exists
+	for _, existing := range *cves {
+		if existing.Id == cveID {
+			// Merge additional fields if they're not already set
+			if existing.CvssMetrics == nil && cvssMetrics != nil {
+				existing.CvssMetrics = cvssMetrics
+			}
+			if existing.CvssScore == nil && cvssScore != nil {
+				existing.CvssScore = cvssScore
+			}
+			if existing.EpssScore == nil && epssScore != nil {
+				existing.EpssScore = epssScore
+			}
+			if existing.EpssPercentile == nil && epssPercentile != nil {
+				existing.EpssPercentile = epssPercentile
+			}
+			if existing.Cpe == nil && cpe != nil {
+				existing.Cpe = cpe
+			}
+			return
+		}
+	}
+
+	// CVE doesn't exist, add it with all available fields
+	*cves = append(*cves, &nuclei.CveDetails{
+		Id:             cveID,
+		CvssScore:      cvssScore,
+		EpssScore:      epssScore,
+		EpssPercentile: epssPercentile,
+		Cpe:            cpe,
+	})
+}
 
 // PopulateProbes loads all templates from the Nuclei engine and populates the probe information.
 // It extracts payloads and expected matchers from each template.
@@ -79,7 +137,6 @@ func (b *Builder) PopulateProbes(eng *nucleilib.NucleiEngine) error {
 			}
 		}
 		b.probeIdx[id] = probe
-		b.report.Probes = append(b.report.Probes, probe)
 	}
 	return nil
 }
@@ -95,7 +152,6 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	if !ok {
 		probe = &nuclei.NucleiProbe{Id: ev.TemplateID}
 		b.probeIdx[ev.TemplateID] = probe
-		b.report.Probes = append(b.report.Probes, probe)
 	}
 
 	// Get or create target
@@ -104,7 +160,7 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	if !ok {
 		targetInfo = &nuclei.NucleiTargetInfo{Target: host}
 		b.targetIdx[host] = targetInfo
-		b.report.Targets = append(b.report.Targets, targetInfo)
+		b.targets = append(b.targets, targetInfo)
 	}
 
 	// Build attempt information
@@ -116,39 +172,54 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 
 	// Extract vulnerability details from template if present
 	var classificationDetails *nuclei.ClassificationDetails
-	var cweIds []string
-	var cveIds []string
+	var cwes []*nuclei.CweDetails
+	var cves []*nuclei.CveDetails
 
 	// Use regex to match CVE template IDs (e.g., CVE-2001-0537)
 	cveRegex := regexp.MustCompile(`^CVE-\d{4}-\d{4,}$`)
 	if cveRegex.MatchString(ev.TemplateID) {
-		if !slices.Contains(cveIds, ev.TemplateID) {
-			cveIds = append(cveIds, ev.TemplateID)
-		}
+		addOrMergeCVE(&cves, ev.TemplateID, nil, nil, nil, nil, nil)
 	}
 	// Pull out CWE and CVE IDs from the template classification
 	if ev.Info.Classification != nil {
 		for _, cweID := range ev.Info.Classification.CWEID.ToSlice() {
-			if !slices.Contains(cweIds, cweID) {
-				cweIds = append(cweIds, cweID)
-			}
+			addOrMergeCWE(&cwes, cweID, nil, nil)
+		}
+
+		// Extract CVE fields from classification if available
+		var cvssMetrics *string
+		var cvssScore *float64
+		var epssScore *float64
+		var epssPercentile *float64
+		var cpe *string
+		if ev.Info.Classification.CVSSMetrics != "" {
+			cvssMetrics = &ev.Info.Classification.CVSSMetrics
+		}
+		if ev.Info.Classification.CVSSScore != 0 {
+			cvssScore = &ev.Info.Classification.CVSSScore
+		}
+		if ev.Info.Classification.EPSSScore != 0 {
+			epssScore = &ev.Info.Classification.EPSSScore
+		}
+		if ev.Info.Classification.EPSSPercentile != 0 {
+			epssPercentile = &ev.Info.Classification.EPSSPercentile
+		}
+		if ev.Info.Classification.CPE != "" {
+			cpe = &ev.Info.Classification.CPE
 		}
 		for _, cveID := range ev.Info.Classification.CVEID.ToSlice() {
-			if !slices.Contains(cveIds, cveID) {
-				cveIds = append(cveIds, cveID)
-			}
+			addOrMergeCVE(&cves, cveID, cvssMetrics, cvssScore, epssScore, epssPercentile, cpe)
 		}
 	}
 	classificationDetails = &nuclei.ClassificationDetails{
-		CweIds: cweIds,
-		CveIds: cveIds,
+		Cwes: cwes,
+		Cves: cves,
 	}
 	severity := ev.Info.SeverityHolder.Severity.String()
 	attemptInfo.Finding = &nuclei.NucleiFindingInfo{
-		Name:           &ev.MatcherName,
 		Finding:        ev.MatcherStatus,
+		Probe:          probe,
 		Severity:       &severity,
-		Tags:           ev.Info.Tags.ToSlice(),
 		Classification: classificationDetails,
 	}
 
@@ -159,6 +230,6 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 
 // Final returns the fully-populated Fern report.
 // It should be called after all ResultEvents have been consumed.
-func (b *Builder) Final() *nuclei.NucleiReport {
-	return b.report
+func (b *Builder) Final() []*nuclei.NucleiTargetInfo {
+	return b.targets
 }

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -171,7 +171,7 @@ func GetRunnerConfig(fileSystems []fs.FS, config nuclei.NucleiConfig) Config {
 	return rconfig
 }
 
-func Run(ctx context.Context, cfg Config, reportBuilder *report.Builder) (*nuclei.NucleiReport, error) {
+func Run(ctx context.Context, cfg Config, reportBuilder *report.Builder) ([]*nuclei.NucleiTargetInfo, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Validating config")
 	if err := validateConfig(cfg); err != nil {


### PR DESCRIPTION
### TL;DR

Updated the Nuclei report structure to improve vulnerability data organization and fixed proxy parameter handling.

### What changed?

- Changed `proxy` parameter in `getPentestApplicationDastConfig` to be a pointer type for consistency
- Restructured the Nuclei report format:
  - Added dedicated `CweDetails` and `CveDetails` types with more comprehensive information
  - Replaced string lists with structured objects for better vulnerability data representation
  - Moved probe information directly into finding data to simplify the structure
  - Added helper functions to properly merge CWE and CVE information
- Updated report handling in pentest application modules:
  - Modified `RunPentestApplicationDast` and `RunPentestApplicationScan` to use the new structure
  - Added result wrapper objects to maintain backward compatibility
- Updated the WAF detection module to work with the new report format
