### PR TITLE
Discover Page: Add Response Code Flag

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -137,6 +137,11 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Config flags
+			responseCodes, err := cmd.Flags().GetString("response-codes")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			maxRedirects, err := cmd.Flags().GetInt("max-redirects")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -173,7 +178,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPageConfig(target, maxRedirects, verifyTLS, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverPageConfig(target, responseCodes, maxRedirects, verifyTLS, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverpage.PerformPageCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -183,6 +188,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverPageCmd.Flags().String("target", "", "URL target to capture and analyze")
 	// Config Flags
+	discoverPageCmd.Flags().String("response-codes", "200-299", "Response codes to consider as valid responses")
 	discoverPageCmd.Flags().Bool("screenshot", false, "Capture a screenshot of the page")
 	discoverPageCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverPageCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
@@ -526,9 +532,10 @@ func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums
 }
 
 // getDiscoverPageConfig builds the config for page capture and analysis.
-func getDiscoverPageConfig(target string, maxRedirects int, verifyTLS bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
+func getDiscoverPageConfig(target string, responseCodes string, maxRedirects int, verifyTLS bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
 	config := discover.DiscoverPageConfig{
 		Target:            target,
+		ResponseCodes:     responseCodes,
 		MaxRedirects:      maxRedirects,
 		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),

--- a/fern/definition/discover/page.yml
+++ b/fern/definition/discover/page.yml
@@ -6,6 +6,7 @@ types:
   DiscoverPageConfig:
     properties:
       target: string
+      responseCodes: string
       screenshot: boolean
       maxRedirects: integer
       verifyTls: boolean

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -6,6 +6,7 @@ import (
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	"github.com/Method-Security/webscan/generated/go/discover"
+	"github.com/Method-Security/webscan/utils"
 
 	// Utils
 	headless "github.com/Method-Security/webscan/utils/request/headless"
@@ -75,7 +76,26 @@ func PerformPageCapture(
 		report.Errors = errors
 		return &report
 	}
-	result.Request = httpRequestResponse
+
+	// Check if response code is in the allowed list
+	validCodes, err := utils.ParseResponseCodes(config.ResponseCodes)
+	if err != nil {
+		errors = append(errors, err.Error())
+		report.Errors = errors
+		return &report
+	}
+
+	// Only add request if response code is in the allowed list
+	if httpRequestResponse != nil &&
+		httpRequestResponse.Response != nil &&
+		httpRequestResponse.Response.StatusCode != nil {
+		if _, exists := validCodes[*httpRequestResponse.Response.StatusCode]; exists {
+			result.Request = httpRequestResponse
+			return &report
+		}
+	}
+
+	// Return report
 	report.Errors = errors
 	return &report
 }

--- a/internal/pentest/application/pathtraversal.go
+++ b/internal/pentest/application/pathtraversal.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 	"time"
 
@@ -69,7 +68,7 @@ func RunApplicationPathTraversal(ctx context.Context, config pentestapplicationf
 	}
 
 	// Parse response codes
-	validCodes, err := parseResponseCodes(config.ResponseCodes)
+	validCodes, err := utils.ParseResponseCodes(config.ResponseCodes)
 	if err != nil {
 		report.Result = &result
 		report.Errors = append(report.Errors, err.Error())
@@ -220,32 +219,6 @@ func baseLine(ctx context.Context, baseURL string, path string, validCodes map[i
 	wordCount := len(strings.Fields(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)))
 
 	return request, &bodySize, &wordCount, nil
-}
-
-// parseResponseCodes parses a comma-separated or range-based string of response codes
-// (e.g., "200,301,404-410") and returns a map of valid codes.
-func parseResponseCodes(responseCodes string) (map[int]bool, error) {
-	validCodes := make(map[int]bool)
-	for _, part := range strings.Split(responseCodes, ",") {
-		if strings.Contains(part, "-") {
-			rangeParts := strings.Split(part, "-")
-			start, err1 := strconv.Atoi(rangeParts[0])
-			end, err2 := strconv.Atoi(rangeParts[1])
-			if err1 != nil || err2 != nil || start > end {
-				return nil, errors.New("invalid response code range")
-			}
-			for i := start; i <= end; i++ {
-				validCodes[i] = true
-			}
-		} else {
-			code, err := strconv.Atoi(part)
-			if err != nil {
-				return nil, errors.New("invalid response code")
-			}
-			validCodes[code] = true
-		}
-	}
-	return validCodes, nil
 }
 
 // gatherPaths gathers all paths from the config

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -197,7 +197,7 @@ func Run(ctx context.Context, cfg Config, reportBuilder *report.Builder) ([]*nuc
 	defer eng.Close()
 
 	// To-Do: Write Customer Writer to enable this to work
-	eng.Options().MatcherStatus = true
+	eng.Options().MatcherStatus = false
 	log.Info("Set matcher status", svc1log.SafeParam("status", eng.Options().MatcherStatus))
 
 	log.Info("Loading targets")

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -197,7 +197,7 @@ func Run(ctx context.Context, cfg Config, reportBuilder *report.Builder) ([]*nuc
 	defer eng.Close()
 
 	// To-Do: Write Customer Writer to enable this to work
-	eng.Options().MatcherStatus = false
+	eng.Options().MatcherStatus = true
 	log.Info("Set matcher status", svc1log.SafeParam("status", eng.Options().MatcherStatus))
 
 	log.Info("Loading targets")

--- a/utils/statuscode.go
+++ b/utils/statuscode.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// ParseResponseCodes parses a comma-separated or range-based string of response codes
+// (e.g., "200,301,404-410") and returns a map of valid codes.
+func ParseResponseCodes(responseCodes string) (map[int]bool, error) {
+	validCodes := make(map[int]bool)
+	for _, part := range strings.Split(responseCodes, ",") {
+		if strings.Contains(part, "-") {
+			rangeParts := strings.Split(part, "-")
+			start, err1 := strconv.Atoi(rangeParts[0])
+			end, err2 := strconv.Atoi(rangeParts[1])
+			if err1 != nil || err2 != nil || start > end {
+				return nil, errors.New("invalid response code range")
+			}
+			for i := start; i <= end; i++ {
+				validCodes[i] = true
+			}
+		} else {
+			code, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, errors.New("invalid response code")
+			}
+			validCodes[code] = true
+		}
+	}
+	return validCodes, nil
+}


### PR DESCRIPTION
### TL;DR

Added response code filtering to the discover page command to allow users to specify which HTTP status codes should be considered valid responses.

### What changed?

- Added a new `--response-codes` flag to the discover page command with a default value of "200-299"
- Created a utility function `ParseResponseCodes` in a new file `utils/statuscode.go` to handle parsing response code ranges
- Modified the page discovery logic to filter responses based on the specified response codes
- Moved the response code parsing logic from `pathtraversal.go` to the new utility function
- Enabled matcher status in the Nuclei runner
