### PR TITLE
Add protocol selection option for discover probe command

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"errors"
 	"fmt"
+	"strings"
 
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
@@ -224,6 +225,11 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Config flags
+			protocol, err := cmd.Flags().GetString("protocol")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			maxRedirects, err := cmd.Flags().GetInt("max-redirects")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -248,7 +254,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverProbeConfig(targets, maxRedirects, verifyTLS, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverProbeConfig(targets, protocol, maxRedirects, verifyTLS, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate report
 			report, err := discoverprobe.PerformWebProbe(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -261,6 +267,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	}
 	// Target Flags
 	discoverProbeCmd.Flags().StringSlice("targets", []string{}, "URL targets to probe for web applications")
+	discoverProbeCmd.Flags().String("protocol", "", "Protocol to use for the probe (HTTP, HTTPS)")
 	// Config Flags
 	discoverProbeCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverProbeCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
@@ -548,7 +555,7 @@ func getDiscoverPageConfig(target string, responseCodes string, maxRedirects int
 }
 
 // getDiscoverProbeConfig builds the config for probe discovery.
-func getDiscoverProbeConfig(targets []string, maxRedirects int, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
+func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
 		Targets:           targets,
 		MaxRedirects:      maxRedirects,
@@ -557,6 +564,19 @@ func getDiscoverProbeConfig(targets []string, maxRedirects int, verifyTLS bool, 
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,
 		BrowserbaseConfig: browserbaseConfig,
+	}
+
+	// Set protocol if provided, otherwise leave unset for backward compatibility
+	if protocol != "" {
+		switch strings.ToUpper(protocol) {
+		case "HTTP":
+			config.Protocol = common.WebProtocolHttp
+		case "HTTPS":
+			config.Protocol = common.WebProtocolHttps
+		default:
+			// Invalid protocol - will be handled by validation in the probe function
+			// For now, leave it unset to maintain existing behavior
+		}
 	}
 
 	return config

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -570,9 +570,11 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 	if protocol != "" {
 		switch strings.ToUpper(protocol) {
 		case "HTTP":
-			config.Protocol = common.WebProtocolHttp
+			httpProtocol := common.WebProtocolHttp
+			config.Protocol = &httpProtocol
 		case "HTTPS":
-			config.Protocol = common.WebProtocolHttps
+			httpsProtocol := common.WebProtocolHttps
+			config.Protocol = &httpsProtocol
 		default:
 			// Invalid protocol - will be handled by validation in the probe function
 			// For now, leave it unset to maintain existing behavior

--- a/fern/definition/common/http.yml
+++ b/fern/definition/common/http.yml
@@ -1,6 +1,11 @@
 imports:
   method: method.yml
 types:
+  # Web Protocol Enum
+  WebProtocol:
+    enum:
+      - HTTP
+      - HTTPS
   # Http Method Enum
   HttpMethod:
     enum:
@@ -77,5 +82,3 @@ types:
     properties:
       request: HttpRequest
       response: optional<HttpResponse>
-
-

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -6,7 +6,7 @@ types:
   DiscoverProbeConfig:
     properties:
       targets: list<string>
-      protocol: http.WebProtocol
+      protocol: optional<http.WebProtocol>
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -6,6 +6,7 @@ types:
   DiscoverProbeConfig:
     properties:
       targets: list<string>
+      protocol: http.WebProtocol
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -71,29 +71,62 @@ func sendHTTPSRequest(ctx context.Context, target string, config *discover.Disco
 	return httpRequestResponse, nil
 }
 
-// sendRequests attempts to connect to a target using both HTTPS and HTTP protocols
+// sendRequests attempts to connect to a target using the specified protocol(s)
+// If a specific protocol is set in config, only that protocol is used
+// Otherwise, attempts both HTTPS and HTTP protocols for backward compatibility
 func sendRequests(ctx context.Context, target string, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) ([]*common.HttpRequestResponse, []string) {
 	httpRequestResponses := []*common.HttpRequestResponse{}
 	var httpErr, httpsErr error
 
-	// Try HTTP request
-	if httpResponse, err := sendHTTPRequest(ctx, target, config, browserbaseSecrets); err != nil {
-		httpErr = err
+	// Check if a specific protocol is configured
+	if config.Protocol != "" {
+		switch config.Protocol {
+		case common.WebProtocolHttp:
+			// Only try HTTP
+			if httpResponse, err := sendHTTPRequest(ctx, target, config, browserbaseSecrets); err != nil {
+				httpErr = err
+			} else {
+				httpRequestResponses = append(httpRequestResponses, httpResponse)
+			}
+		case common.WebProtocolHttps:
+			// Only try HTTPS
+			if httpsResponse, err := sendHTTPSRequest(ctx, target, config, browserbaseSecrets); err != nil {
+				httpsErr = err
+			} else {
+				httpRequestResponses = append(httpRequestResponses, httpsResponse)
+			}
+		}
 	} else {
-		httpRequestResponses = append(httpRequestResponses, httpResponse)
+		// No specific protocol set - maintain existing behavior (try both)
+		// Try HTTP request
+		if httpResponse, err := sendHTTPRequest(ctx, target, config, browserbaseSecrets); err != nil {
+			httpErr = err
+		} else {
+			httpRequestResponses = append(httpRequestResponses, httpResponse)
+		}
+
+		// Try HTTPS request
+		if httpsResponse, err := sendHTTPSRequest(ctx, target, config, browserbaseSecrets); err != nil {
+			httpsErr = err
+		} else {
+			httpRequestResponses = append(httpRequestResponses, httpsResponse)
+		}
 	}
 
-	// Try HTTPS request
-	if httpsResponse, err := sendHTTPSRequest(ctx, target, config, browserbaseSecrets); err != nil {
-		httpsErr = err
-	} else {
-		httpRequestResponses = append(httpRequestResponses, httpsResponse)
-	}
-
-	// Only return errors if both requests failed
+	// Return errors based on what was attempted
 	var errors []string
-	if httpErr != nil && httpsErr != nil {
-		errors = append(errors, httpErr.Error(), httpsErr.Error())
+	if config.Protocol != "" {
+		// If specific protocol was set, only return its error if it failed
+		if config.Protocol == common.WebProtocolHttp && httpErr != nil {
+			errors = append(errors, httpErr.Error())
+		} else if config.Protocol == common.WebProtocolHttps && httpsErr != nil {
+			errors = append(errors, httpsErr.Error())
+		}
+	} else {
+		// If no specific protocol was set, only return errors if both requests failed
+		if httpErr != nil && httpsErr != nil {
+			errors = append(errors, httpErr.Error(), httpsErr.Error())
+		}
 	}
 
 	return httpRequestResponses, errors

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -79,8 +79,8 @@ func sendRequests(ctx context.Context, target string, config *discover.DiscoverP
 	var httpErr, httpsErr error
 
 	// Check if a specific protocol is configured
-	if config.Protocol != "" {
-		switch config.Protocol {
+	if config.Protocol != nil {
+		switch *config.Protocol {
 		case common.WebProtocolHttp:
 			// Only try HTTP
 			if httpResponse, err := sendHTTPRequest(ctx, target, config, browserbaseSecrets); err != nil {
@@ -115,11 +115,11 @@ func sendRequests(ctx context.Context, target string, config *discover.DiscoverP
 
 	// Return errors based on what was attempted
 	var errors []string
-	if config.Protocol != "" {
+	if config.Protocol != nil {
 		// If specific protocol was set, only return its error if it failed
-		if config.Protocol == common.WebProtocolHttp && httpErr != nil {
+		if *config.Protocol == common.WebProtocolHttp && httpErr != nil {
 			errors = append(errors, httpErr.Error())
-		} else if config.Protocol == common.WebProtocolHttps && httpsErr != nil {
+		} else if *config.Protocol == common.WebProtocolHttps && httpsErr != nil {
 			errors = append(errors, httpsErr.Error())
 		}
 	} else {

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -33,39 +33,20 @@ func createSendHTTPRequestConfig(baseURL, path string, config *discover.Discover
 	}
 }
 
-// sendHTTPRequest attempts to connect to a target using HTTP protocol
-func sendHTTPRequest(ctx context.Context, target string, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) (*common.HttpRequestResponse, error) {
+// sendRequestWithProtocol attempts to connect to a target using the specified protocol
+func sendRequestWithProtocol(ctx context.Context, target string, protocol string, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) (*common.HttpRequestResponse, error) {
 	sanitizedTarget := requesthelpers.RemoveScheme(target)
-	httpURL := "http://" + sanitizedTarget
+	fullURL := protocol + "://" + sanitizedTarget
 
-	baseURL, path, err := requesthelpers.SplitTargetURL(httpURL)
+	baseURL, path, err := requesthelpers.SplitTargetURL(fullURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid address %s: %v", httpURL, err)
+		return nil, fmt.Errorf("invalid address %s: %v", fullURL, err)
 	}
 
-	httpConfig := createSendHTTPRequestConfig(baseURL, path, config, browserbaseSecrets)
-	httpRequestResponse, err := request.SendRequest(ctx, httpConfig)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, config, browserbaseSecrets)
+	httpRequestResponse, err := request.SendRequest(ctx, requestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to probe %s - %s", httpURL, err)
-	}
-
-	return httpRequestResponse, nil
-}
-
-// sendHTTPSRequest attempts to connect to a target using HTTPS protocol
-func sendHTTPSRequest(ctx context.Context, target string, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) (*common.HttpRequestResponse, error) {
-	sanitizedTarget := requesthelpers.RemoveScheme(target)
-	httpsURL := "https://" + sanitizedTarget
-
-	baseURL, path, err := requesthelpers.SplitTargetURL(httpsURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid address %s: %v", httpsURL, err)
-	}
-
-	httpsConfig := createSendHTTPRequestConfig(baseURL, path, config, browserbaseSecrets)
-	httpRequestResponse, err := request.SendRequest(ctx, httpsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to probe %s - %s", httpsURL, err)
+		return nil, fmt.Errorf("failed to probe %s - %s", fullURL, err)
 	}
 
 	return httpRequestResponse, nil
@@ -83,14 +64,14 @@ func sendRequests(ctx context.Context, target string, config *discover.DiscoverP
 		switch *config.Protocol {
 		case common.WebProtocolHttp:
 			// Only try HTTP
-			if httpResponse, err := sendHTTPRequest(ctx, target, config, browserbaseSecrets); err != nil {
+			if httpResponse, err := sendRequestWithProtocol(ctx, target, "http", config, browserbaseSecrets); err != nil {
 				httpErr = err
 			} else {
 				httpRequestResponses = append(httpRequestResponses, httpResponse)
 			}
 		case common.WebProtocolHttps:
 			// Only try HTTPS
-			if httpsResponse, err := sendHTTPSRequest(ctx, target, config, browserbaseSecrets); err != nil {
+			if httpsResponse, err := sendRequestWithProtocol(ctx, target, "https", config, browserbaseSecrets); err != nil {
 				httpsErr = err
 			} else {
 				httpRequestResponses = append(httpRequestResponses, httpsResponse)
@@ -99,14 +80,14 @@ func sendRequests(ctx context.Context, target string, config *discover.DiscoverP
 	} else {
 		// No specific protocol set - maintain existing behavior (try both)
 		// Try HTTP request
-		if httpResponse, err := sendHTTPRequest(ctx, target, config, browserbaseSecrets); err != nil {
+		if httpResponse, err := sendRequestWithProtocol(ctx, target, "http", config, browserbaseSecrets); err != nil {
 			httpErr = err
 		} else {
 			httpRequestResponses = append(httpRequestResponses, httpResponse)
 		}
 
 		// Try HTTPS request
-		if httpsResponse, err := sendHTTPSRequest(ctx, target, config, browserbaseSecrets); err != nil {
+		if httpsResponse, err := sendRequestWithProtocol(ctx, target, "https", config, browserbaseSecrets); err != nil {
 			httpsErr = err
 		} else {
 			httpRequestResponses = append(httpRequestResponses, httpsResponse)


### PR DESCRIPTION
### TL;DR

Added protocol selection option to the discover probe command, allowing users to specify HTTP or HTTPS instead of trying both.

### What changed?

- Added a new `--protocol` flag to the discover probe command that accepts "HTTP" or "HTTPS" values
- Created a new `WebProtocol` enum in the Fern definition to represent HTTP/HTTPS protocols
- Modified the `DiscoverProbeConfig` to include the protocol field
- Updated the `sendRequests` function to respect the specified protocol when provided
- Maintained backward compatibility by trying both protocols when no specific protocol is specified

### How to test?

1. Run the discover probe command with the new protocol flag:
   ```
   webscan discover probe --targets example.com --protocol HTTP
   ```

2. Run the discover probe command with HTTPS protocol:
   ```
   webscan discover probe --targets example.com --protocol HTTPS
   ```

3. Run without specifying a protocol to verify backward compatibility:
   ```
   webscan discover probe --targets example.com
   ```

### Why make this change?

This change gives users more control over the discovery process by allowing them to specify which protocol to use when probing targets. This is useful in environments where one protocol might be blocked or when users want to test a specific protocol. It improves efficiency by avoiding unnecessary requests when the protocol is known in advance.