### PR TITLE
XML-RPC Update Fern

### DIFF
--- a/fern/definition/pentest/cms/wordpress/xmlrpcfunctionauth.yml
+++ b/fern/definition/pentest/cms/wordpress/xmlrpcfunctionauth.yml
@@ -21,8 +21,11 @@ types:
       target: string
       functionGrabRequest: http.HttpRequestResponse
       functionAuthAttempts: optional<list<XmlrpcFunctionAuthAttempt>>
+  XmlrpcFunctionAuthResult:
+    properties:
+      targets: list<XmlrpcFunctionAuthTarget>
   PentestCmsWordpressXmlrpcFunctionAuthReport:
     properties:
-      targets: optional<list<XmlrpcFunctionAuthTarget>>
+      result: XmlrpcFunctionAuthResult
       config: PentestCmsWordpressXmlrpcFunctionAuthConfig
       errors: optional<list<string>>

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionauth.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionauth.go
@@ -46,6 +46,7 @@ func createSendHTTPRequestConfig(baseURL, path string, body string, config *pent
 func PerformWordpressXMLRPCFunctionAuthInjection(ctx context.Context, config pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthConfig) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthReport {
 	// Initialize report
 	report := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthReport{Config: &config}
+	result := pentestcmswordpressfern.XmlrpcFunctionAuthResult{}
 	var errors []string
 
 	// Inilize logger
@@ -122,7 +123,11 @@ func PerformWordpressXMLRPCFunctionAuthInjection(ctx context.Context, config pen
 		targetInfo.FunctionAuthAttempts = xmlrpcAuthRequests
 		targets = append(targets, &targetInfo)
 	}
-	report.Targets = targets
+	// Set result
+	result.Targets = targets
+
+	// Set report
+	report.Result = &result
 	report.Errors = errors
 	return report
 }
@@ -184,10 +189,10 @@ func detectSuccessfulFunctionAuth(requestInfo *common.HttpRequestResponse) *bool
 		return &success
 	}
 
-	body := *requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody)
+	body := strings.ToLower(*requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody))
 	success = strings.Contains(body, "<param>") &&
-		!strings.Contains(body, "Invalid method parameters") &&
+		!strings.Contains(body, "invalid method parameters") &&
 		!strings.Contains(body, "<fault>") &&
-		!strings.Contains(body, "<name>faultCode</name>")
+		!strings.Contains(body, "<name>faultcode</name>")
 	return &success
 }


### PR DESCRIPTION
### TL;DR

Restructured WordPress XML-RPC function auth report format and improved authentication detection logic.

### What changed?

- Created a new `XmlrpcFunctionAuthResult` type to encapsulate targets
- Modified `PentestCmsWordpressXmlrpcFunctionAuthReport` to use the new result type
- Updated the implementation to populate the new result structure
- Improved the authentication detection logic:
  - Now converts response body to lowercase before checking for error strings
  - Updated error string checks to match lowercase versions

### How to test?

1. Run WordPress XML-RPC function authentication tests against a test WordPress instance
2. Verify that the report structure contains the targets under the `result` field
3. Confirm that authentication detection works correctly with various response formats

### Why make this change?

This change standardizes the report structure to follow a consistent pattern with other pentests and improves the reliability of authentication detection by making string comparisons case-insensitive. This helps prevent false negatives when WordPress returns error messages with varying capitalization.