### PR TITLE
Improve XMLHttpRequest detection and fix fetch method extraction

### DIFF
--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -39,8 +39,10 @@ var apiPatterns = []struct {
 	{regexp.MustCompile(`\$\.(get|post|put|delete)\(['"]([^'"]+)['"]`), ""},                                  // Method and URL in capture groups
 	{regexp.MustCompile(`\$\.ajax\({\s*(?:method|type):\s*['"]([^'"]+)['"],\s*url:\s*['"]([^'"]+)['"]`), ""}, // Method and URL in capture groups
 
-	// XMLHttpRequest calls
-	{regexp.MustCompile(`\.open\(['"]([^'"]+)['"],\s*['"]([^'"]+)['"]`), ""}, // Method and URL in capture groups
+	// XMLHttpRequest calls (more specific to avoid matching window.open)
+	{regexp.MustCompile(`xhr\.open\(['"]([^'"]+)['"],\s*['"]([^'"]+)['"]`), ""},     // Method and URL in capture groups
+	{regexp.MustCompile(`request\.open\(['"]([^'"]+)['"],\s*['"]([^'"]+)['"]`), ""}, // Method and URL in capture groups
+	{regexp.MustCompile(`xmlhttp\.open\(['"]([^'"]+)['"],\s*['"]([^'"]+)['"]`), ""}, // Method and URL in capture groups
 
 	// Generic URL patterns that might be API endpoints
 	{regexp.MustCompile(`['"](/api/[^'"]+)['"]`), "GET"},
@@ -67,9 +69,20 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 				urlStr = match[1]
 				method = pattern.method
 			} else if len(match) == 3 {
-				// Pattern with two capture groups (method and URL)
-				method = strings.ToUpper(match[1])
-				urlStr = match[2]
+				patternStr := pattern.pattern.String()
+
+				// Only the fetch pattern with method options has URL first, method second
+				// All other patterns have method first, URL second
+				if strings.Contains(patternStr, "fetch") && strings.Contains(patternStr, "method") && strings.Contains(patternStr, `{\s*method`) {
+					// fetch('url', { method: 'method' }) - URL first, method second
+					urlStr = match[1]
+					method = strings.ToUpper(match[2])
+				} else {
+					// All other patterns: method first, URL second
+					// xhr.open('method', 'url'), axios.*, jquery.*, etc.
+					method = strings.ToUpper(match[1])
+					urlStr = match[2]
+				}
 			}
 
 			// Skip if no URL found


### PR DESCRIPTION
### TL;DR

Improved JavaScript route extraction by making XMLHttpRequest pattern more specific and fixing fetch method extraction.

### What changed?

- Made XMLHttpRequest pattern more specific by targeting common variable names (`xhr`, `request`, `xmlhttp`) instead of any object to avoid false positives with `window.open`
- Added logic to correctly handle different parameter ordering between fetch API and other HTTP request methods
- Fixed method extraction for fetch API calls where URL is the first parameter and method is in the options object

### How to test?

1. Test with JavaScript code containing both `window.open` calls and XMLHttpRequest calls to verify only the latter are matched
2. Test with various fetch API patterns like `fetch('/api', { method: 'POST' })` to ensure correct method extraction
3. Test with XMLHttpRequest patterns like `xhr.open('GET', '/api')` to confirm proper extraction

### Why make this change?

The previous implementation had two issues:
1. The generic `.open()` pattern was matching `window.open()` calls which are not API requests
2. The method extraction logic didn't account for the different parameter ordering in fetch API calls, potentially causing incorrect method identification