### PR TITLE
Add additional CVE details fields to nuclei report

### DIFF
--- a/fern/definition/common/nuclei/report.yml
+++ b/fern/definition/common/nuclei/report.yml
@@ -11,6 +11,11 @@ types:
   CveDetails:
     properties:
       id: string
+      name: optional<string>
+      description: optional<string>
+      impact: optional<string>
+      remediation: optional<string>
+      reference: optional<list<string>>
       cvssMetrics: optional<string>
       cvssScore: optional<float>
       epssScore: optional<float>

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -39,7 +39,7 @@ func addOrMergeCWE(cwes *[]*nuclei.CweDetails, cweID string, name *string, descr
 }
 
 // addOrMergeCVE adds a CVE to the slice if it doesn't exist by ID, or merges additional fields if it does
-func addOrMergeCVE(cves *[]*nuclei.CveDetails, cveID string, cvssMetrics *string, cvssScore *float64, epssScore *float64, epssPercentile *float64, cpe *string) {
+func addOrMergeCVE(cves *[]*nuclei.CveDetails, cveID string, cvssMetrics *string, cvssScore *float64, epssScore *float64, epssPercentile *float64, cpe *string, name *string, description *string, impact *string, remediation *string, reference []string) {
 	// Check if CVE with this ID already exists
 	for _, existing := range *cves {
 		if existing.Id == cveID {
@@ -59,6 +59,21 @@ func addOrMergeCVE(cves *[]*nuclei.CveDetails, cveID string, cvssMetrics *string
 			if existing.Cpe == nil && cpe != nil {
 				existing.Cpe = cpe
 			}
+			if existing.Name == nil && name != nil {
+				existing.Name = name
+			}
+			if existing.Description == nil && description != nil {
+				existing.Description = description
+			}
+			if existing.Impact == nil && impact != nil {
+				existing.Impact = impact
+			}
+			if existing.Remediation == nil && remediation != nil {
+				existing.Remediation = remediation
+			}
+			if existing.Reference == nil && len(reference) > 0 {
+				existing.Reference = reference
+			}
 			return
 		}
 	}
@@ -66,10 +81,16 @@ func addOrMergeCVE(cves *[]*nuclei.CveDetails, cveID string, cvssMetrics *string
 	// CVE doesn't exist, add it with all available fields
 	*cves = append(*cves, &nuclei.CveDetails{
 		Id:             cveID,
+		CvssMetrics:    cvssMetrics,
 		CvssScore:      cvssScore,
 		EpssScore:      epssScore,
 		EpssPercentile: epssPercentile,
 		Cpe:            cpe,
+		Name:           name,
+		Description:    description,
+		Impact:         impact,
+		Remediation:    remediation,
+		Reference:      reference,
 	})
 }
 
@@ -197,7 +218,7 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	// Use regex to match CVE template IDs (e.g., CVE-2001-0537)
 	cveRegex := regexp.MustCompile(`^CVE-\d{4}-\d{4,}$`)
 	if cveRegex.MatchString(ev.TemplateID) {
-		addOrMergeCVE(&cves, ev.TemplateID, nil, nil, nil, nil, nil)
+		addOrMergeCVE(&cves, ev.TemplateID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	}
 	// Pull out CWE and CVE IDs from the template classification
 	if ev.Info.Classification != nil {
@@ -206,11 +227,17 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		}
 
 		// Extract CVE fields from classification if available
+
 		var cvssMetrics *string
 		var cvssScore *float64
 		var epssScore *float64
 		var epssPercentile *float64
 		var cpe *string
+		var name *string
+		var description *string
+		var impact *string
+		var remediation *string
+		var reference []string
 		if ev.Info.Classification.CVSSMetrics != "" {
 			cvssMetrics = &ev.Info.Classification.CVSSMetrics
 		}
@@ -226,8 +253,23 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		if ev.Info.Classification.CPE != "" {
 			cpe = &ev.Info.Classification.CPE
 		}
+		if ev.Info.Name != "" {
+			name = &ev.Info.Name
+		}
+		if ev.Info.Description != "" {
+			description = &ev.Info.Description
+		}
+		if ev.Info.Impact != "" {
+			impact = &ev.Info.Impact
+		}
+		if ev.Info.Remediation != "" {
+			remediation = &ev.Info.Remediation
+		}
+		if ev.Info.Reference != nil {
+			reference = ev.Info.Reference.ToSlice()
+		}
 		for _, cveID := range ev.Info.Classification.CVEID.ToSlice() {
-			addOrMergeCVE(&cves, cveID, cvssMetrics, cvssScore, epssScore, epssPercentile, cpe)
+			addOrMergeCVE(&cves, cveID, cvssMetrics, cvssScore, epssScore, epssPercentile, cpe, name, description, impact, remediation, reference)
 		}
 	}
 	classificationDetails = &nuclei.ClassificationDetails{


### PR DESCRIPTION
### TL;DR

Enhanced CVE details in Nuclei reports with additional vulnerability information fields.

### What changed?

- Added new optional fields to the `CveDetails` type in the Fern definition:
  - `name`
  - `description`
  - `impact`
  - `remediation`
  - `reference` (list of strings)

- Updated the `addOrMergeCVE` function to:
  - Accept and handle the new fields
  - Properly merge these fields when combining CVE records
  - Include the new fields when creating new CVE records

- Modified the `Consume` method to extract and pass additional vulnerability information from template data to the CVE records

### How to test?

1. Run Nuclei scans with templates that contain CVE information
2. Verify that the generated reports include the new fields when available
3. Check that when multiple templates reference the same CVE, the information is properly merged

### Why make this change?

This enhancement provides more comprehensive vulnerability information in Nuclei reports. By including details like vulnerability names, descriptions, impact assessments, remediation steps, and references, the reports become more valuable for security teams to understand and address the identified vulnerabilities without needing to look up this information separately.