### PR TITLE
Negate Route Discover flags

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -309,12 +309,12 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get Config flags
-			requireBaseURLMatch, err := cmd.Flags().GetBool("require-base-url-match")
+			noBaseURLMatch, err := cmd.Flags().GetBool("no-base-url-match")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			ignoreStaticAssets, err := cmd.Flags().GetBool("ignore-static-assets")
+			collectStaticAssets, err := cmd.Flags().GetBool("collect-static-assets")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -353,7 +353,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, requireBaseURLMatch, ignoreStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, noBaseURLMatch, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -363,8 +363,8 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverRouteCmd.Flags().String("target", "", "URL target to discover routes from")
 	// Config Flags
-	discoverRouteCmd.Flags().Bool("require-base-url-match", true, "Only scan routes sharing the target's base URL")
-	discoverRouteCmd.Flags().Bool("ignore-static-assets", true, "Exclude static assets from route discovery")
+	discoverRouteCmd.Flags().Bool("no-base-url-match", false, "Do not require routes to share the target's base URL")
+	discoverRouteCmd.Flags().Bool("collect-static-assets", false, "Collect static assets from route discovery")
 	discoverRouteCmd.Flags().Int("spider-depth", 1, "Maximum depth for route spidering")
 	discoverRouteCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverRouteCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
@@ -592,11 +592,11 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, requiredBaseURLMatch bool, ignoreStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, noBaseURLMatch bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
-		IgnoreStaticAssets:  ignoreStaticAssets,
-		RequireBaseUrlMatch: requiredBaseURLMatch,
+		CollectStaticAssets: collectStaticAssets,
+		NoBaseUrlMatch:      noBaseURLMatch,
 		SpiderDepth:         spiderDepth,
 		MaxRedirects:        maxRedirects,
 		VerifyTls:           verifyTLS,

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -309,7 +309,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get Config flags
-			noBaseURLMatch, err := cmd.Flags().GetBool("no-base-url-match")
+			ignoreBaseURLMatch, err := cmd.Flags().GetBool("ignore-base-url-match")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -353,7 +353,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, noBaseURLMatch, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, ignoreBaseURLMatch, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -363,7 +363,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverRouteCmd.Flags().String("target", "", "URL target to discover routes from")
 	// Config Flags
-	discoverRouteCmd.Flags().Bool("no-base-url-match", false, "Do not require routes to share the target's base URL")
+	discoverRouteCmd.Flags().Bool("ignore-base-url-match", false, "Ignore when routes shares the target's base URL")
 	discoverRouteCmd.Flags().Bool("collect-static-assets", false, "Collect static assets from route discovery")
 	discoverRouteCmd.Flags().Int("spider-depth", 1, "Maximum depth for route spidering")
 	discoverRouteCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
@@ -592,11 +592,11 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, noBaseURLMatch bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, ignoreBaseURLMatch bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
 		CollectStaticAssets: collectStaticAssets,
-		NoBaseUrlMatch:      noBaseURLMatch,
+		IgnoreBaseUrlMatch:  ignoreBaseURLMatch,
 		SpiderDepth:         spiderDepth,
 		MaxRedirects:        maxRedirects,
 		VerifyTls:           verifyTLS,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -658,7 +658,7 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(fmt.Errorf("no fingerprints found"))
 				return
 			}
-			requireBaseURLMatch, err := cmd.Flags().GetBool("require-base-url-match")
+			noBaseURLMatch, err := cmd.Flags().GetBool("no-base-url-match")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -697,7 +697,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, requireBaseURLMatch, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, noBaseURLMatch, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -709,7 +709,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("target", "", "URL target to analyze for static asset takeover")
 	// Config Flags
 	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json"}, "Paths to fingerprint definition files")
-	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("require-base-url-match", false, "Only scan assets sharing the target's base URL")
+	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("no-base-url-match", false, "Only scan assets sharing the target's base URL")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("successful-only", false, "Only show successful takeover attempts")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
@@ -934,12 +934,12 @@ func getPentestCmsWordpressXmlrpcFunctionAuthConfig(targets []string, successful
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, requireBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, noBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
-		IgnoreStaticAssets:  false,
-		RequireBaseUrlMatch: requireBaseURLMatch,
+		CollectStaticAssets: true,
+		NoBaseUrlMatch:      noBaseURLMatch,
 		SpiderDepth:         1,
 		VerifyTls:           verifyTLS,
 		Timeout:             max(timeout, 0),

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -658,11 +658,6 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(fmt.Errorf("no fingerprints found"))
 				return
 			}
-			noBaseURLMatch, err := cmd.Flags().GetBool("no-base-url-match")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -697,7 +692,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, noBaseURLMatch, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -709,7 +704,6 @@ func (a *WebScan) InitPentestCommand() {
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("target", "", "URL target to analyze for static asset takeover")
 	// Config Flags
 	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json"}, "Paths to fingerprint definition files")
-	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("no-base-url-match", false, "Only scan assets sharing the target's base URL")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("successful-only", false, "Only show successful takeover attempts")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
@@ -934,12 +928,12 @@ func getPentestCmsWordpressXmlrpcFunctionAuthConfig(targets []string, successful
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, noBaseURLMatch bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
 		CollectStaticAssets: true,
-		NoBaseUrlMatch:      noBaseURLMatch,
+		IgnoreBaseUrlMatch:  true,
 		SpiderDepth:         1,
 		VerifyTls:           verifyTLS,
 		Timeout:             max(timeout, 0),

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -6,8 +6,8 @@ types:
   DiscoverRouteConfig:
     properties:
       target: string
-      ignoreStaticAssets: boolean
-      requireBaseUrlMatch: boolean
+      collectStaticAssets: boolean
+      noBaseUrlMatch: boolean
       spiderDepth: integer
       maxRedirects: integer
       verifyTls: boolean

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -7,7 +7,7 @@ types:
     properties:
       target: string
       collectStaticAssets: boolean
-      noBaseUrlMatch: boolean
+      ignoreBaseUrlMatch: boolean
       spiderDepth: integer
       maxRedirects: integer
       verifyTls: boolean

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -41,7 +41,7 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 		fullURL := discoverroutehelpers.ResolveURL(baseURL, action)
 
 		// Check if the URL is allowed
-		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.RequireBaseUrlMatch, routeCaptureConfig.IgnoreStaticAssets) {
+		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, !routeCaptureConfig.NoBaseUrlMatch, !routeCaptureConfig.CollectStaticAssets) {
 			return
 		}
 
@@ -121,7 +121,7 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 			}
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.RequireBaseUrlMatch, routeCaptureConfig.IgnoreStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 			urls[urlNoQuery] = struct{}{}
@@ -161,7 +161,7 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			// Skip if this is a static asset
 			if utils.IsStaticAsset(fullURL) {
 				// Only add to URLs if we're not ignoring static assets
-				if !routeCaptureConfig.IgnoreStaticAssets {
+				if routeCaptureConfig.CollectStaticAssets {
 					urls[fullURL] = struct{}{}
 				}
 				return
@@ -175,7 +175,7 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			}
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.RequireBaseUrlMatch, routeCaptureConfig.IgnoreStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -41,7 +41,7 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 		fullURL := discoverroutehelpers.ResolveURL(baseURL, action)
 
 		// Check if the URL is allowed
-		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, !routeCaptureConfig.NoBaseUrlMatch, !routeCaptureConfig.CollectStaticAssets) {
+		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 			return
 		}
 
@@ -121,7 +121,7 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 			}
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 			urls[urlNoQuery] = struct{}{}
@@ -175,7 +175,7 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			}
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -81,7 +81,7 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, urlStr)
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				continue
 			}
 
@@ -210,7 +210,7 @@ func extractScriptContentRoutes(ctx context.Context, scriptContent string, baseU
 	}
 
 	// If parsing succeeds, use AST traversal
-	ast.Walk(&visitor{routes: &routes, urls: urls, baseURL: baseURL, baseURLsOnly: routeCaptureConfig.NoBaseUrlMatch, captureStaticAssets: routeCaptureConfig.CollectStaticAssets, errors: &errors}, program)
+	ast.Walk(&visitor{routes: &routes, urls: urls, baseURL: baseURL, baseURLsOnly: routeCaptureConfig.IgnoreBaseUrlMatch, captureStaticAssets: routeCaptureConfig.CollectStaticAssets, errors: &errors}, program)
 
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
 }
@@ -335,14 +335,14 @@ func ExtractScriptRoutes(ctx context.Context, doc *goquery.Document, baseURL str
 			}
 
 			// If onlybaseURLs is set, only request script src that are relative
-			if !routeCaptureConfig.NoBaseUrlMatch && discoverroutehelpers.IsAbsoluteURL(src) {
+			if !routeCaptureConfig.IgnoreBaseUrlMatch && discoverroutehelpers.IsAbsoluteURL(src) {
 				return
 			}
 
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, src)
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -81,7 +81,7 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, urlStr)
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.RequireBaseUrlMatch, !routeCaptureConfig.IgnoreStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				continue
 			}
 
@@ -210,7 +210,7 @@ func extractScriptContentRoutes(ctx context.Context, scriptContent string, baseU
 	}
 
 	// If parsing succeeds, use AST traversal
-	ast.Walk(&visitor{routes: &routes, urls: urls, baseURL: baseURL, baseURLsOnly: routeCaptureConfig.RequireBaseUrlMatch, captureStaticAssets: !routeCaptureConfig.IgnoreStaticAssets, errors: &errors}, program)
+	ast.Walk(&visitor{routes: &routes, urls: urls, baseURL: baseURL, baseURLsOnly: routeCaptureConfig.NoBaseUrlMatch, captureStaticAssets: routeCaptureConfig.CollectStaticAssets, errors: &errors}, program)
 
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
 }
@@ -335,14 +335,14 @@ func ExtractScriptRoutes(ctx context.Context, doc *goquery.Document, baseURL str
 			}
 
 			// If onlybaseURLs is set, only request script src that are relative
-			if routeCaptureConfig.RequireBaseUrlMatch && discoverroutehelpers.IsAbsoluteURL(src) {
+			if !routeCaptureConfig.NoBaseUrlMatch && discoverroutehelpers.IsAbsoluteURL(src) {
 				return
 			}
 
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, src)
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.RequireBaseUrlMatch, !routeCaptureConfig.IgnoreStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -230,15 +230,15 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 }
 
 // IsURLAllowed checks if a target URL is allowed based on base URL, static asset rules, and domain matching.
-func IsURLAllowed(baseURL string, targetURL string, requireBaseURLMatch bool, ignoreStaticAssets bool) bool {
+func IsURLAllowed(baseURL string, targetURL string, noBaseURLMatch bool, collectStaticAssets bool) bool {
 	// First check to see if the targetURL is a static asset type
-	if !ignoreStaticAssets {
+	if collectStaticAssets {
 		if utils.IsStaticAsset(targetURL) {
 			return true // Allow static assets when ignoreStaticAssets is false
 		}
 	}
 
-	if !requireBaseURLMatch {
+	if noBaseURLMatch {
 		return true
 	}
 

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -230,7 +230,7 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 }
 
 // IsURLAllowed checks if a target URL is allowed based on base URL, static asset rules, and domain matching.
-func IsURLAllowed(baseURL string, targetURL string, noBaseURLMatch bool, collectStaticAssets bool) bool {
+func IsURLAllowed(baseURL string, targetURL string, ignoreBaseURLMatch bool, collectStaticAssets bool) bool {
 	// First check to see if the targetURL is a static asset type
 	if collectStaticAssets {
 		if utils.IsStaticAsset(targetURL) {
@@ -238,7 +238,7 @@ func IsURLAllowed(baseURL string, targetURL string, noBaseURLMatch bool, collect
 		}
 	}
 
-	if noBaseURLMatch {
+	if ignoreBaseURLMatch {
 		return true
 	}
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -130,7 +130,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		}
 
 		fullRedirectedURL := fmt.Sprintf("%s%s", redirectedURLBase, redirectedURLPath)
-		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets)
+		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets)
 		routes = append(routes, networkRoutes...)
 		urls = discoverroutehelpers.AddListToSetString(urls, networkUrls)
 		errors = append(errors, networkErrors...)

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -130,7 +130,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		}
 
 		fullRedirectedURL := fmt.Sprintf("%s%s", redirectedURLBase, redirectedURLPath)
-		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.RequireBaseUrlMatch, !routeCaptureConfig.IgnoreStaticAssets)
+		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.NoBaseUrlMatch, routeCaptureConfig.CollectStaticAssets)
 		routes = append(routes, networkRoutes...)
 		urls = discoverroutehelpers.AddListToSetString(urls, networkUrls)
 		errors = append(errors, networkErrors...)
@@ -144,7 +144,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	// Filter out static assets from all Route + Static Asset URLs
 	staticAssets := make(map[string]struct{})
 	for url := range urls {
-		if !routeCaptureConfig.IgnoreStaticAssets && utils.IsStaticAsset(url) {
+		if routeCaptureConfig.CollectStaticAssets && utils.IsStaticAsset(url) {
 			staticAssets[url] = struct{}{}
 		}
 	}


### PR DESCRIPTION
### TL;DR

Renamed CLI flags for route discovery to better reflect their functionality with more intuitive naming.

### What changed?

- Renamed `--require-base-url-match` flag to `--ignore-base-url-match` with inverted logic
- Renamed `--ignore-static-assets` flag to `--collect-static-assets` with inverted logic
- Updated corresponding configuration properties in the codebase:
  - `RequireBaseUrlMatch` → `IgnoreBaseUrlMatch`
  - `IgnoreStaticAssets` → `CollectStaticAssets`
- Updated all related function calls and logic to maintain the same behavior with the new naming
- Removed redundant `--require-base-url-match` flag from the static asset takeover command