### PR TITLE
Static Url Flag respects Base Url Flag

### DIFF
--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -242,11 +242,8 @@ func IsURLAllowed(baseURL string, targetURL string, ignoreBaseURLMatch bool, col
 		return true
 	}
 
-	baseDomain := ExtractDomain(baseURL, 2)
-	targetDomain := ExtractDomain(targetURL, 0)
-
 	// Check if targetDomain is the same as baseDomain or a subdomain
-	return IsSubdomain(baseDomain, targetDomain)
+	return IsSubdomain(baseURL, targetURL)
 }
 
 // ExtractDomain extracts the domain from a URL up to a specified domain level.
@@ -268,11 +265,14 @@ func ExtractDomain(rawURL string, maxDomainLevel int) string {
 }
 
 // IsSubdomain checks if 'sub' is a subdomain of 'base'.
-func IsSubdomain(base string, sub string) bool {
-	if base == "" || sub == "" {
+func IsSubdomain(baseURL string, targetURL string) bool {
+	baseDomain := ExtractDomain(baseURL, 2)
+	targetDomain := ExtractDomain(targetURL, 0)
+
+	if baseDomain == "" || targetDomain == "" {
 		return false
 	}
-	return sub == base || strings.HasSuffix(sub, "."+base)
+	return targetDomain == baseDomain || strings.HasSuffix(targetDomain, "."+baseDomain)
 }
 
 // IsAbsoluteURL returns true if the given URL is absolute.

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -80,36 +80,42 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		}
 	}
 
+	// Extract routes from form elements
 	log.Info("Extracting routes from form elements")
 	formRoutes, formUrls, formErrors := capturerouteextractors.ExtractFormRoutes(doc, redirectedURLBase, routeCaptureConfig)
 	routes = append(routes, formRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, formUrls)
 	processErrors("Form Elements", formErrors)
 
+	// Extract routes from anchor elements
 	log.Info("Extracting routes from anchor elements")
 	anchorRoutes, anchorUrls, anchorErrors := capturerouteextractors.ExtractAnchorRoutes(doc, redirectedURLBase, routeCaptureConfig)
 	routes = append(routes, anchorRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, anchorUrls)
 	processErrors("Anchor Elements", anchorErrors)
 
+	// Extract routes from link elements
 	log.Info("Extracting routes from link elements")
 	linkRoutes, linkUrls, linkErrors := capturerouteextractors.ExtractLinkRoutes(doc, redirectedURLBase, routeCaptureConfig)
 	routes = append(routes, linkRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, linkUrls)
 	processErrors("Link Elements", linkErrors)
 
+	// Extract routes from script elements
 	log.Info("Extracting routes from script elements")
 	scriptRoutes, scriptUrls, scriptErrors := capturerouteextractors.ExtractScriptRoutes(ctx, doc, redirectedURLBase, routeCaptureConfig)
 	routes = append(routes, scriptRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, scriptUrls)
 	errors = append(errors, scriptErrors...)
 
+	// Extract routes from inline script elements
 	log.Info("Extracting routes from inline script elements")
 	inlineScriptRoutes, inlineScriptUrls, inlineScriptErrors := capturerouteextractors.ExtractInlineScriptRoutes(ctx, doc, redirectedURLBase, routeCaptureConfig)
 	routes = append(routes, inlineScriptRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, inlineScriptUrls)
 	errors = append(errors, inlineScriptErrors...)
 
+	// Extract routes from network calls
 	// Only to be performed if requestMethod is of type Headless or Browserbase
 	if requestConfig.RequestMethod == common.RequestMethodHeadless || requestConfig.RequestMethod == common.RequestMethodBrowserbase {
 		// Set a timeout for the network route extraction
@@ -136,16 +142,17 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		errors = append(errors, networkErrors...)
 	}
 
-	log.Info("Returning results")
-
 	// Merge routes to remove duplicates
-	mergedRoutes := discoverroutehelpers.MergeWebRoutes(routes) // For uniqueness across techniques
+	mergedRoutes := discoverroutehelpers.MergeWebRoutes(routes) // Duplicate routes are removed
+	log.Info("Returning results", svc1log.SafeParam("routes", len(mergedRoutes)))
 
 	// Filter out static assets from all Route + Static Asset URLs
 	staticAssets := make(map[string]struct{})
 	for url := range urls {
 		if routeCaptureConfig.CollectStaticAssets && utils.IsStaticAsset(url) {
-			staticAssets[url] = struct{}{}
+			if discoverroutehelpers.IsSubdomain(redirectedURLBase, url) || routeCaptureConfig.IgnoreBaseUrlMatch {
+				staticAssets[url] = struct{}{}
+			}
 		}
 	}
 	staticAssetsList := discoverroutehelpers.SetToListString(staticAssets)


### PR DESCRIPTION
### TL;DR

Refactored subdomain checking logic and improved static asset filtering to respect domain boundaries.

### What changed?

- Refactored the `IsURLAllowed` function to directly use the `IsSubdomain` function with the full URLs
- Modified the `IsSubdomain` function to handle domain extraction internally rather than requiring pre-extracted domains
- Added comments to clarify the purpose of different route extraction sections
- Enhanced static asset filtering to only include assets from the same domain or subdomains of the base URL, unless `IgnoreBaseUrlMatch` is enabled
- Added logging to show the number of routes being returned