### PR TITLE
Rename XMLRPC Tool

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -551,7 +551,7 @@ func (a *WebScan) InitPentestCommand() {
 		Long:  `Analyze WordPress to detect potential vulnerabilities.`,
 	}
 
-	pentestCmsWordpressXmlrpcFunctionAuthCmd := &cobra.Command{
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd := &cobra.Command{
 		Use:   "xmlrpc-function-auth",
 		Short: "Perform xmlrpc function authentication injection tests against a target",
 		Long:  `Perform xmlrpc function authentication injection tests against a target`,
@@ -593,10 +593,10 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Load configuration
-			config := getPentestCmsWordpressXmlrpcFunctionAuthConfig(targets, successfulOnly, verifyTLS, timeout, retries, sleep)
+			config := getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets, successfulOnly, verifyTLS, timeout, retries, sleep)
 
 			// Generate report
-			report := pentestcmswordpress.PerformWordpressXMLRPCFunctionAuthInjection(cmd.Context(), config)
+			report := pentestcmswordpress.PerformWordpressXMLRPCFunctionsExposed(cmd.Context(), config)
 			if len(report.Errors) > 0 {
 				a.OutputSignal.Status = 1
 			}
@@ -604,19 +604,19 @@ func (a *WebScan) InitPentestCommand() {
 		},
 	}
 	// Target Flags
-	pentestCmsWordpressXmlrpcFunctionAuthCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Config Flags
-	pentestCmsWordpressXmlrpcFunctionAuthCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
-	pentestCmsWordpressXmlrpcFunctionAuthCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
-	pentestCmsWordpressXmlrpcFunctionAuthCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	pentestCmsWordpressXmlrpcFunctionAuthCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
-	pentestCmsWordpressXmlrpcFunctionAuthCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 
 	// Mark Required Flags
-	_ = pentestCmsWordpressXmlrpcFunctionAuthCmd.MarkFlagRequired("targets")
+	_ = pentestCmsWordpressXmlrpcFunctionsExposedCmd.MarkFlagRequired("targets")
 
 	// Add Command to 'Wordpress' Command
-	pentestCmsWordpressCmd.AddCommand(pentestCmsWordpressXmlrpcFunctionAuthCmd)
+	pentestCmsWordpressCmd.AddCommand(pentestCmsWordpressXmlrpcFunctionsExposedCmd)
 
 	// Add Command to 'CMS' Command
 	pentestCmsCmd.AddCommand(pentestCmsWordpressCmd)
@@ -914,9 +914,9 @@ func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []p
 	return config
 }
 
-// getPentestCmsWordpressXmlrpcFunctionAuthConfig builds the config for wordpress xmlrpc function auth pentest.
-func getPentestCmsWordpressXmlrpcFunctionAuthConfig(targets []string, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthConfig {
-	config := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthConfig{
+// getPentestCmsWordpressXmlrpcFunctionsExposedConfig builds the config for wordpress xmlrpc function auth pentest.
+func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig {
+	config := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig{
 		Targets:        targets,
 		SuccessfulOnly: successfulOnly,
 		VerifyTls:      verifyTLS,

--- a/fern/definition/pentest/cms/wordpress/xmlrpcfunctionsexposed.yml
+++ b/fern/definition/pentest/cms/wordpress/xmlrpcfunctionsexposed.yml
@@ -2,7 +2,7 @@ imports:
   http: ../../../common/http.yml
 types:
   # Config Struct
-  PentestCmsWordpressXmlrpcFunctionAuthConfig:
+  PentestCmsWordpressXmlrpcFunctionsExposedConfig:
     properties:
       targets: list<string>
       successfulOnly: boolean
@@ -11,21 +11,21 @@ types:
       retries: integer
       sleep: integer
   # Report Struct
-  XmlrpcFunctionAuthAttempt:
+  XmlrpcFunctionsExposedAttempt:
     properties:
       functionName: string
       request: http.HttpRequestResponse
       finding: boolean
-  XmlrpcFunctionAuthTarget:
+  XmlrpcFunctionsExposedTarget:
     properties:
       target: string
       functionGrabRequest: http.HttpRequestResponse
-      functionAuthAttempts: optional<list<XmlrpcFunctionAuthAttempt>>
-  XmlrpcFunctionAuthResult:
+      functionsExposedAttempts: optional<list<XmlrpcFunctionsExposedAttempt>>
+  XmlrpcFunctionsExposedResult:
     properties:
-      targets: optional<list<XmlrpcFunctionAuthTarget>>
-  PentestCmsWordpressXmlrpcFunctionAuthReport:
+      targets: optional<list<XmlrpcFunctionsExposedTarget>>
+  PentestCmsWordpressXmlrpcFunctionsExposedReport:
     properties:
-      result: XmlrpcFunctionAuthResult
-      config: PentestCmsWordpressXmlrpcFunctionAuthConfig
+      result: XmlrpcFunctionsExposedResult
+      config: PentestCmsWordpressXmlrpcFunctionsExposedConfig
       errors: optional<list<string>>

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -23,7 +23,7 @@ import (
 // Constants
 var xmlrpcPath = "/xmlrpc.php"
 
-func createSendHTTPRequestConfig(baseURL, path string, body string, config *pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthConfig) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, body string, config *pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig) common.SendHttpRequestConfig {
 	bodyStruct := requesthelpers.CreateResponseBody("application/xml", body)
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
@@ -43,18 +43,18 @@ func createSendHTTPRequestConfig(baseURL, path string, body string, config *pent
 	}
 }
 
-func PerformWordpressXMLRPCFunctionAuthInjection(ctx context.Context, config pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthConfig) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthReport {
+func PerformWordpressXMLRPCFunctionsExposed(ctx context.Context, config pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedReport {
 	// Initialize report
-	report := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionAuthReport{Config: &config}
-	result := pentestcmswordpressfern.XmlrpcFunctionAuthResult{}
+	report := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedReport{Config: &config}
+	result := pentestcmswordpressfern.XmlrpcFunctionsExposedResult{}
 	var errors []string
 
 	// Inilize logger
 	log := svc1log.FromContext(ctx)
 
-	var targets []*pentestcmswordpressfern.XmlrpcFunctionAuthTarget
+	var targets []*pentestcmswordpressfern.XmlrpcFunctionsExposedTarget
 	for _, target := range config.Targets {
-		targetInfo := pentestcmswordpressfern.XmlrpcFunctionAuthTarget{Target: target}
+		targetInfo := pentestcmswordpressfern.XmlrpcFunctionsExposedTarget{Target: target}
 
 		// Split target
 		baseURL, path, err := requesthelpers.SplitTargetURL(target)
@@ -86,11 +86,11 @@ func PerformWordpressXMLRPCFunctionAuthInjection(ctx context.Context, config pen
 		log.Info("XMLRPC functions", svc1log.SafeParam("function count", len(passedXMLRPCFunctions)))
 
 		// Send requests for each function
-		xmlrpcAuthRequests := []*pentestcmswordpressfern.XmlrpcFunctionAuthAttempt{}
+		xmlrpcAuthRequests := []*pentestcmswordpressfern.XmlrpcFunctionsExposedAttempt{}
 		for _, function := range passedXMLRPCFunctions {
 			for i := 0; i <= config.Retries; i++ {
 				log.Info("Sending function auth request", svc1log.SafeParam("function", function), svc1log.SafeParam("attempt", i+1))
-				attempt := pentestcmswordpressfern.XmlrpcFunctionAuthAttempt{FunctionName: function}
+				attempt := pentestcmswordpressfern.XmlrpcFunctionsExposedAttempt{FunctionName: function}
 				// Generate xmlrpc payload
 				bodyParams := generateFunctionAuthBodyInjectionParam(function)
 
@@ -120,7 +120,7 @@ func PerformWordpressXMLRPCFunctionAuthInjection(ctx context.Context, config pen
 		}
 
 		// Marshal target info
-		targetInfo.FunctionAuthAttempts = xmlrpcAuthRequests
+		targetInfo.FunctionsExposedAttempts = xmlrpcAuthRequests
 		targets = append(targets, &targetInfo)
 	}
 	// Set result

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -9,7 +9,6 @@ import (
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 
 	// External
-
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
 )


### PR DESCRIPTION
### TL;DR

Renamed WordPress XMLRPC function authentication test to more accurately reflect its purpose as a function exposure test.

### What changed?

- Renamed `pentestCmsWordpressXmlrpcFunctionAuthCmd` to `pentestCmsWordpressXmlrpcFunctionsExposedCmd`
- Renamed the corresponding function from `PerformWordpressXMLRPCFunctionAuthInjection` to `PerformWordpressXMLRPCFunctionsExposed`
- Updated all related configuration types, file names, and references to match the new naming convention
- Renamed YAML definition file from `xmlrpcfunctionauth.yml` to `xmlrpcfunctionsexposed.yml`
- Renamed Go implementation file from `xmlrpcfunctionauth.go` to `xmlrpcfunctionsexposed.go`
