### PR TITLE
Add Chrome symlink and configure headless browser options for Nuclei

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Dockerfile used as distribution for the webscan CLI in Tool container format
 FROM chromedp/headless-shell:129.0.6643.2 
 
+RUN ln -s /headless-shell/headless-shell /usr/bin/chrome
+
 ARG CLI_NAME="webscan"
 ARG TARGETARCH
 

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -79,6 +79,26 @@ func buildNucleiOptions(cfg Config, tmpDir string) []nucleilib.NucleiSDKOptions 
 		nucleilib.WithTemplatesOrWorkflows(nucleilib.TemplateSources{Templates: []string{tmpDir}}),
 		nucleilib.EnableSelfContainedTemplates(),
 		nucleilib.DisableUpdateCheck(),
+		nucleilib.EnableHeadlessWithOpts(
+			&nucleilib.HeadlessOpts{
+				PageTimeout: 30,
+				ShowBrowser: false,
+				UseChrome:   true,
+				HeadlessOptions: func() []string {
+					baseOptions := []string{
+						"--no-sandbox",            // needed when running as root or in many Docker images
+						"--disable-dev-shm-usage", // avoids /dev/shm size limits in containers
+						"--disable-gpu",           // GPU isn't available in headless Linux anyway
+						"--mute-audio",
+						"--disable-background-timer-throttling",
+					}
+					if cfg.Proxy != "" {
+						baseOptions = append(baseOptions, "--proxy-server="+cfg.Proxy)
+					}
+					return baseOptions
+				}(),
+			},
+		),
 		nucleilib.WithNetworkConfig(nucleilib.NetworkConfig{
 			Timeout: cfg.Timeout,
 		}),


### PR DESCRIPTION
### TL;DR

Added Chrome binary symlink in Dockerfile and configured Nuclei headless browser options.

### What changed?

- Added a symlink from `/headless-shell/headless-shell` to `/usr/bin/chrome` in the Dockerfile to make Chrome accessible in the standard path
- Enabled headless browser functionality in Nuclei with specific configuration options:
  - Set page timeout to 30 seconds
  - Disabled browser UI visibility
  - Configured Chrome as the browser
  - Added essential Chrome flags for containerized environments:
    - `--no-sandbox`
    - `--disable-dev-shm-usage`
    - `--disable-gpu`
    - `--mute-audio`
    - `--disable-background-timer-throttling`
  - Added proxy support when configured

### How to test?

1. Build the Docker image with the updated Dockerfile
2. Run a scan that requires headless browser capabilities
3. Verify that Chrome is properly detected and used for browser-based tests
4. Test with a proxy configuration to ensure the proxy settings are correctly passed to Chrome

### Why make this change?

This change ensures proper headless browser functionality in containerized environments. The symlink makes Chrome accessible in a standard location, while the headless configuration options improve stability and performance in Docker containers. The added proxy support enables scanning through proxies when needed for security or network requirements.