### PR TITLE
Multi Thread App Discover

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -81,6 +81,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, err := cmd.Flags().GetInt("max-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -91,14 +96,14 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			maxRedirects, err := cmd.Flags().GetInt("max-redirects")
+			threads, err := cmd.Flags().GetInt("threads")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, modules, maxRedirects, verifyTLS, timeout)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, modules, maxRedirects, verifyTLS, timeout, threads)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -116,10 +121,11 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Config Flags
 	discoverApplicationCmd.Flags().String("resource-type", "ALL", "Type of resource to fingerprint (e.g., web, api, cms)")
 	discoverApplicationCmd.Flags().StringSlice("modules", []string{}, "Specific fingerprinting modules to run")
+	discoverApplicationCmd.Flags().String("fingerprint-file", "/opt/method/webscan/var/conf/discover/application/fingerprints.json", "Path to the fingerprint definitions file")
 	discoverApplicationCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverApplicationCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverApplicationCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	discoverApplicationCmd.Flags().String("fingerprint-file", "/opt/method/webscan/var/conf/discover/application/fingerprints.json", "Path to the fingerprint definitions file")
+	discoverApplicationCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")
@@ -529,7 +535,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums []string, maxRedirects int, verifyTLS bool, timeout int) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums []string, maxRedirects int, verifyTLS bool, timeout int, threads int) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -541,6 +547,7 @@ func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums
 		MaxRedirects: maxRedirects,
 		VerifyTls:    verifyTLS,
 		Timeout:      max(timeout, 0),
+		Threads:      max(threads, 0),
 	}
 	return config, nil
 }

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -19,6 +19,16 @@ types:
     union:
       - ApplicationResourceType
       - ApplicationResourceTypeAll
+  # Config Struct
+  DiscoverApplicationConfig:
+    properties:
+      targets: list<string>
+      resourceType: ApplicationResourceConfigType
+      modules: optional<list<string>>
+      maxRedirects: integer
+      verifyTls: boolean
+      timeout: integer
+      threads: integer
   # Application Fingerprints File Struct
   ApplicationFingerprintModule:
     properties:
@@ -45,15 +55,6 @@ types:
     properties:
       target: string
       attempts: list<ApplicationFingerprintAttempt>
-  # Config Struct
-  DiscoverApplicationConfig:
-    properties:
-      targets: list<string>
-      resourceType: ApplicationResourceConfigType
-      modules: optional<list<string>>
-      maxRedirects: integer
-      verifyTls: boolean
-      timeout: integer
   # Report Struct
   DiscoverApplicationResult:
     properties:

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -3,7 +3,9 @@ package application
 import (
 	// Standard
 	"context"
+	"runtime"
 	"strings"
+	"sync"
 
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
@@ -53,57 +55,82 @@ func run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 
 	var attempts []*discover.ApplicationFingerprintAttempt
 	var errors []string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
 
-	// Process each module separately
+	// Process each module concurrently
 	for _, module := range resourceType.Modules {
-		attempt := &discover.ApplicationFingerprintAttempt{
-			Name:    module.Name,
-			Finding: false,
-		}
+		wg.Add(1)
+		go func(module *discover.ApplicationFingerprintModule) {
+			defer wg.Done()
 
-		var allRequests []*common.HttpRequestResponse
-		for _, path := range module.Paths {
-			// Request Configuration
-			fullPath := parsedTargetPath + path
-			var method = module.Method
-
-			var requestParams common.HttpRequestParams
-			if module.RequestParams != nil {
-				requestParams = *module.RequestParams
+			attempt := &discover.ApplicationFingerprintAttempt{
+				Name:    module.Name,
+				Finding: false,
 			}
 
-			// set request config
-			requestConfig := createSendHTTPRequestConfig(baseURL, fullPath, method, requestParams, config)
-
-			// send request
-			request, err := request.SendRequest(ctx, requestConfig)
-			if err != nil {
-				errors = append(errors, err.Error())
-				continue
-			}
-			allRequests = append(allRequests, request)
-
-			if AnalyzeResponse(request, module) {
-				attempt.Finding = true
-				attempt.Fingerprints = []*discover.ApplicationResource{
-					{
-						Name:    resourceType.Name,
-						Modules: []*discover.ApplicationFingerprintModule{module},
-					},
+			var allRequests []*common.HttpRequestResponse
+			for _, path := range module.Paths {
+				// Check for context cancellation
+				select {
+				case <-ctx.Done():
+					mu.Lock()
+					errors = append(errors, "context cancelled")
+					mu.Unlock()
+					return
+				default:
 				}
-				// Only include the successful request in the results
-				attempt.Requests = []*common.HttpRequestResponse{request}
-				attempts = append(attempts, attempt)
-				break
-			}
-		}
 
-		// For unsuccessful attempts, include all requests made
-		if !attempt.Finding {
-			attempt.Requests = allRequests
-			attempts = append(attempts, attempt)
-		}
+				// Request Configuration
+				fullPath := parsedTargetPath + path
+				var method = module.Method
+
+				var requestParams common.HttpRequestParams
+				if module.RequestParams != nil {
+					requestParams = *module.RequestParams
+				}
+
+				// set request config
+				requestConfig := createSendHTTPRequestConfig(baseURL, fullPath, method, requestParams, config)
+
+				// send request
+				request, err := request.SendRequest(ctx, requestConfig)
+				if err != nil {
+					mu.Lock()
+					errors = append(errors, err.Error())
+					mu.Unlock()
+					continue
+				}
+				allRequests = append(allRequests, request)
+
+				if AnalyzeResponse(request, module) {
+					attempt.Finding = true
+					attempt.Fingerprints = []*discover.ApplicationResource{
+						{
+							Name:    resourceType.Name,
+							Modules: []*discover.ApplicationFingerprintModule{module},
+						},
+					}
+					// Only include the successful request in the results
+					attempt.Requests = []*common.HttpRequestResponse{request}
+					mu.Lock()
+					attempts = append(attempts, attempt)
+					mu.Unlock()
+					return
+				}
+			}
+
+			// For unsuccessful attempts, include all requests made
+			if !attempt.Finding {
+				attempt.Requests = allRequests
+				mu.Lock()
+				attempts = append(attempts, attempt)
+				mu.Unlock()
+			}
+		}(module)
 	}
+
+	wg.Wait()
 	return attempts, errors
 }
 
@@ -162,33 +189,93 @@ func AnalyzeResponse(httpRequestResponse *common.HttpRequestResponse, module *di
 // LaunchFingerprintEngine runs the fingerprinting engine for all targets in the config and returns a report.
 func LaunchFingerprintEngine(ctx context.Context, config *discover.DiscoverApplicationConfig, filteredFingerprints *discover.ApplicationFingerprints) (*discover.DiscoverApplicationReport, error) {
 	report := discover.DiscoverApplicationReport{Config: config}
-	errors := []string{}
+
+	// Determine number of concurrent goroutines
+	maxThreads := config.Threads
+	if maxThreads == 0 {
+		maxThreads = runtime.NumCPU()
+	}
+
+	// Create a semaphore to limit concurrent goroutines
+	semaphore := make(chan struct{}, maxThreads)
 
 	var targets []*discover.ApplicationFingerprintTarget
+	var errors []string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	// Process each target concurrently with thread limiting
 	for _, target := range config.Targets {
-		var attempts []*discover.ApplicationFingerprintAttempt
+		wg.Add(1)
 
-		// Process each resource type separately
-		for _, resourceType := range filteredFingerprints.Fingerprints {
-			attempt, errs := run(ctx, target, config, resourceType)
-			attempts = append(attempts, attempt...)
-			errors = append(errors, errs...)
-		}
+		// Acquire semaphore (blocks if maxThreads are running)
+		semaphore <- struct{}{}
 
-		filteredAttempts := []*discover.ApplicationFingerprintAttempt{}
-		for _, attempt := range attempts {
-			if attempt.Finding {
-				filteredAttempts = append(filteredAttempts, attempt)
+		go func(target string) {
+			defer wg.Done()
+			defer func() { <-semaphore }() // Release semaphore when done
+
+			// Check for context cancellation
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				errors = append(errors, "context cancelled")
+				mu.Unlock()
+				return
+			default:
 			}
-		}
-		attempts = filteredAttempts
 
-		// Only include targets that have positive findings (non-empty attempts list)
-		if len(attempts) > 0 {
-			target := discover.ApplicationFingerprintTarget{Target: target, Attempts: attempts}
-			targets = append(targets, &target)
-		}
+			var attempts []*discover.ApplicationFingerprintAttempt
+			var targetErrors []string
+			var targetMu sync.Mutex
+			var targetWg sync.WaitGroup
+
+			// Process each resource type concurrently for this target
+			for _, resourceType := range filteredFingerprints.Fingerprints {
+				targetWg.Add(1)
+				go func(resourceType *discover.ApplicationResource) {
+					defer targetWg.Done()
+
+					attempt, errs := run(ctx, target, config, resourceType)
+
+					targetMu.Lock()
+					attempts = append(attempts, attempt...)
+					targetErrors = append(targetErrors, errs...)
+					targetMu.Unlock()
+				}(resourceType)
+			}
+
+			targetWg.Wait()
+
+			// Filter to only include positive findings
+			filteredAttempts := []*discover.ApplicationFingerprintAttempt{}
+			for _, attempt := range attempts {
+				if attempt.Finding {
+					filteredAttempts = append(filteredAttempts, attempt)
+				}
+			}
+
+			// Only include targets that have positive findings (non-empty attempts list)
+			if len(filteredAttempts) > 0 {
+				targetResult := discover.ApplicationFingerprintTarget{
+					Target:   target,
+					Attempts: filteredAttempts,
+				}
+				mu.Lock()
+				targets = append(targets, &targetResult)
+				mu.Unlock()
+			}
+
+			// Add any errors from this target
+			if len(targetErrors) > 0 {
+				mu.Lock()
+				errors = append(errors, targetErrors...)
+				mu.Unlock()
+			}
+		}(target)
 	}
+
+	wg.Wait()
 
 	// Marshal Report
 	report.Result = &discover.DiscoverApplicationResult{Targets: targets}


### PR DESCRIPTION
### TL;DR

Added multi-threading support to the application discovery module to improve scanning performance.

### What changed?

- Added a new `threads` parameter to the discover application command to control concurrency
- Implemented concurrent processing of targets and fingerprinting modules using goroutines
- Added a semaphore to limit the number of concurrent scans based on the threads parameter
- Added proper synchronization with mutexes to handle concurrent access to shared data
- Reorganized flag definitions in the command for better organization
- Updated the configuration struct to include the new threads parameter
