### PR TITLE
Update all Non-CVE Templates

### DIFF
--- a/fern/definition/common/nuclei/report.yml
+++ b/fern/definition/common/nuclei/report.yml
@@ -21,6 +21,7 @@ types:
   NucleiFindingInfo:
     properties:
       name: optional<string>
+      softwareWeakness: optional<string> # Name to use to create Software Weakness Objects
       description: optional<string>
       impact: optional<string>
       remediation: optional<string>

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -263,7 +263,6 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		}
 
 		// Extract CVE fields from classification if available
-
 		var cvssMetrics *string
 		var cvssScore *float64
 		var epssScore *float64
@@ -316,17 +315,22 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	if ev.Info.Reference != nil {
 		reference = ev.Info.Reference.ToSlice()
 	}
+	var softwareWeakness string
+	if ev.Info.Metadata["method-software-weakness-name"] != nil {
+		softwareWeakness = ev.Info.Metadata["method-software-weakness-name"].(string)
+	}
 
 	attemptInfo.Finding = &nuclei.NucleiFindingInfo{
-		Name:           name,
-		Description:    description,
-		Impact:         impact,
-		Remediation:    remediation,
-		Reference:      reference,
-		Classification: classificationDetails,
-		Severity:       &severity,
-		Finding:        ev.MatcherStatus,
-		Probe:          probe,
+		Name:             name,
+		SoftwareWeakness: &softwareWeakness,
+		Description:      description,
+		Impact:           impact,
+		Remediation:      remediation,
+		Reference:        reference,
+		Classification:   classificationDetails,
+		Severity:         &severity,
+		Finding:          ev.MatcherStatus,
+		Probe:            probe,
 	}
 
 	// Always add the attempt to the report, even if there was an error parsing the request/response

--- a/utils/nuclei/templates/pentest/dast/cmdi/python-code-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/cmdi/python-code-injection.yaml
@@ -4,8 +4,8 @@ info:
   name: Python - Code Injection
   author: ritikchaddha
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-77
+  metadata:
+    method-software-weakness-name: CMDI Injection # Added by method-security
   tags: python,dast,injection,cmdi
 
 variables:

--- a/utils/nuclei/templates/pentest/dast/cmdi/time_based-cmdi.yaml
+++ b/utils/nuclei/templates/pentest/dast/cmdi/time_based-cmdi.yaml
@@ -4,9 +4,8 @@ info:
   name: Time Based Command Injection
   author: method-security
   severity: critical
-  classification: # Added by method-security
-    cwe-id: CWE-77
-
+  metadata:
+    method-software-weakness-name: CMDI Injection # Added by method-security
 http:
   - payloads:
       injections:

--- a/utils/nuclei/templates/pentest/dast/crlf/crlf-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/crlf/crlf-injection.yaml
@@ -4,9 +4,8 @@ info:
   name: CRLF Injection
   author: pdteam
   severity: low
-  classification: # Added by method-security
-    cwe-id: CWE-93
   metadata:
+    method-software-weakness-name: CRLF Injection # Added by method-security
     max-request: 41
   tags: crlf,dast
 

--- a/utils/nuclei/templates/pentest/dast/crlf/parameter_based-cookie-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/crlf/parameter_based-cookie-injection.yaml
@@ -4,12 +4,11 @@ info:
   name: Parameter Based Cookie Injection
   author: pdteam
   severity: info
-  classification:
-    cwe-id: CWE-93
   reference:
     - https://www.invicti.com/blog/web-security/understanding-cookie-poisoning-attacks/
     - https://docs.imperva.com/bundle/on-premises-knowledgebase-reference-guide/page/cookie_injection.htm
   metadata:
+    method-software-weakness-name: CRLF Injection # Added by method-security
     max-request: 1
   tags: reflected,dast,cookie,injection
 

--- a/utils/nuclei/templates/pentest/dast/lfi/bypass-lfi.yaml
+++ b/utils/nuclei/templates/pentest/dast/lfi/bypass-lfi.yaml
@@ -9,6 +9,7 @@ info:
   reference:
     - https://owasp.org/www-community/attacks/Unicode_Encoding
   metadata:
+    method-software-weakness-name: LFI Injection # Added by method-security
     max-request: 25
   tags: dast,pathtraversal,lfi
 

--- a/utils/nuclei/templates/pentest/dast/lfi/linux-lfi.yaml
+++ b/utils/nuclei/templates/pentest/dast/lfi/linux-lfi.yaml
@@ -4,12 +4,11 @@ info:
   name: Linux - Local File Inclusion
   author: DhiyaneshDK
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-22
   reference:
     - https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Directory%20Traversal/Intruder/directory_traversal.txt
     - https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/File%20Inclusion
   metadata:
+    method-software-weakness-name: LFI Injection # Added by method-security
     max-request: 46
   tags: lfi,dast,linux
 

--- a/utils/nuclei/templates/pentest/dast/lfi/windows-lfi.yaml
+++ b/utils/nuclei/templates/pentest/dast/lfi/windows-lfi.yaml
@@ -4,9 +4,8 @@ info:
   name: Windows - Local File Inclusion
   author: pussycat0x
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-22
   metadata:
+    method-software-weakness-name: LFI Injection # Added by method-security
     max-request: 39
   tags: lfi,windows,dast
 

--- a/utils/nuclei/templates/pentest/dast/rfi/rfi.yaml
+++ b/utils/nuclei/templates/pentest/dast/rfi/rfi.yaml
@@ -4,11 +4,10 @@ info:
   name: Remote File Inclusion
   author: m4lwhere
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-98
   reference:
     - https://www.invicti.com/learn/remote-file-inclusion-rfi/
   metadata:
+    method-software-weakness-name: RFI Injection # Added by method-security
     max-request: 1
   tags: rfi,dast,oast
 

--- a/utils/nuclei/templates/pentest/dast/sqli/boolean_based-sqli.yaml
+++ b/utils/nuclei/templates/pentest/dast/sqli/boolean_based-sqli.yaml
@@ -4,8 +4,8 @@ info:
   name: Boolean Based SQL Injection
   author: method-security
   severity: critical
-  classification: # Added by method-security
-    cwe-id: CWE-89
+  metadata:
+    method-software-weakness-name: SQL Injection # Added by method-security
 
 http:
   - method: GET

--- a/utils/nuclei/templates/pentest/dast/sqli/error_based-sqli.yaml
+++ b/utils/nuclei/templates/pentest/dast/sqli/error_based-sqli.yaml
@@ -8,9 +8,8 @@ info:
     Direct SQL Command Injection is a technique where an attacker creates or alters existing SQL commands to expose hidden data,
     or to override valuable ones, or even to execute dangerous system level commands on the database host.
     This is accomplished by the application taking user input and combining it with static parameters to build an SQL query .
-  classification: # Added by method-security
-    cwe-id: CWE-89
   metadata:
+    method-software-weakness-name: SQL Injection # Added by method-security
     max-request: 3
   tags: sqli,error,dast
 

--- a/utils/nuclei/templates/pentest/dast/sqli/mysql-time_based_blind-sqli.yaml
+++ b/utils/nuclei/templates/pentest/dast/sqli/mysql-time_based_blind-sqli.yaml
@@ -4,8 +4,8 @@ info:
   name: MySQL Time Based Blind SQL Injection
   author: pdteam
   severity: critical
-  classification: # Added by method-security
-    cwe-id: CWE-89
+  metadata:
+    method-software-weakness-name: SQL Injection # Added by method-security
 
 http:
   - payloads:

--- a/utils/nuclei/templates/pentest/dast/sqli/time_based_blind-sqli.yaml
+++ b/utils/nuclei/templates/pentest/dast/sqli/time_based_blind-sqli.yaml
@@ -4,10 +4,10 @@ info:
   name: Time Based Blind SQL Injection
   author: 0xKayala
   severity: critical
-  classification: # Added by method-security
-    cwe-id: CWE-89
   description: |
     This Template detects time-based Blind SQL Injection vulnerability
+  metadata:
+    method-software-weakness-name: SQL Injection # Added by method-security
   tags: time-based-sqli,sqli,dast,blind
 
 flow: http(1) && http(2)

--- a/utils/nuclei/templates/pentest/dast/ssrf/full_response-ssrf.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssrf/full_response-ssrf.yaml
@@ -4,11 +4,10 @@ info:
   name: Full Response Server Side Request Forgery
   author: pdteam,pwnhxl,j4vaovo,AmirHossein Raeisi
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-918
   reference:
     - https://github.com/bugcrowd/HUNT/blob/master/ZAP/scripts/passive/SSRF.py
   metadata:
+    method-software-weakness-name: SSRF Injection # Added by method-security
     max-request: 12
   tags: ssrf,dast
 

--- a/utils/nuclei/templates/pentest/dast/ssti/freemarker-sandbox-bypass-reflected-ssti.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssti/freemarker-sandbox-bypass-reflected-ssti.yaml
@@ -4,13 +4,12 @@ info:
   name: Freemarker Sandbox Bypass - Reflected Server Side Template Injection
   author: ritikchaddha
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-1336
   description: |
     Apache FreeMarker™ is a template engine: a Java library to generate text output (HTML web pages, e-mails, configuration files, source code, etc.) based on templates and changing data.
   reference:
     - https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Server%20Side%20Template%20Injection/Java.md#freemarker---sandbox-bypass
   metadata:
+    method-software-weakness-name: SSTI Injection # Added by method-security
     verified: true
   tags: ssti,dast,freemarker
 

--- a/utils/nuclei/templates/pentest/dast/ssti/razor-reflected-ssti.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssti/razor-reflected-ssti.yaml
@@ -4,13 +4,12 @@ info:
   name: Razor - Reflected Server Side Template Injection
   author: ritikchaddha
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-1336
   description: |
     Razor is a server-side templating engine for ASP.NET Core, it is a powerful template engine that can run pure C# code. It allows for server-side template injection by exploiting the Razor syntax.
   reference:
     - https://www.yeswehack.com/learn-bug-bounty/server-side-template-injection-exploitation
   metadata:
+    method-software-weakness-name: SSTI Injection # Added by method-security
     max-request: 1
   tags: razor,ssti,dast
 

--- a/utils/nuclei/templates/pentest/dast/ssti/reflected-ssti.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssti/reflected-ssti.yaml
@@ -4,8 +4,8 @@ info:
   name: Reflected Server Side Template Injection
   author: method-security
   severity: critical
-  classification: # Added by method-security
-    cwe-id: CWE-1336
+  metadata:
+    method-software-weakness-name: SSTI Injection # Added by method-security
 
 variables:
   first: "{{rand_int(100, 999)}}"

--- a/utils/nuclei/templates/pentest/dast/ssti/smarty-reflected-ssti.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssti/smarty-reflected-ssti.yaml
@@ -4,13 +4,12 @@ info:
   name: Smarty - Reflected Server Side Template Injection
   author: ritikchaddha
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-1336
   description: |
     In PHP template engine Smarty, template injection is possible by exploiting the passthru function combined with array_map and chr.
   reference:
     - https://www.yeswehack.com/learn-bug-bounty/server-side-template-injection-exploitation
   metadata:
+    method-software-weakness-name: SSTI Injection # Added by method-security
     max-request: 1
   tags: smarty,ssti,dast
 

--- a/utils/nuclei/templates/pentest/dast/ssti/twig-reflected-ssti.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssti/twig-reflected-ssti.yaml
@@ -4,13 +4,12 @@ info:
   name: Twig - Reflected Server Side Template Injection
   author: ritikchaddha
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-1336
   description: |
     Twig, a PHP template engine, posed significant challenges in crafting a working payload due to its built-in and default configurations, particularly in string creation. However, by utilizing the block feature and the built-in _charset variable, Attacker successfully developed a payload by nesting these elements together.
   reference:
     - https://www.yeswehack.com/learn-bug-bounty/server-side-template-injection-exploitation
   metadata:
+    method-software-weakness-name: SSTI Injection # Added by method-security
     max-request: 1
   tags: twig,ssti,dast
 

--- a/utils/nuclei/templates/pentest/dast/xss/dom-xss.yaml
+++ b/utils/nuclei/templates/pentest/dast/xss/dom-xss.yaml
@@ -4,14 +4,14 @@ info:
   name: DOM Cross Site Scripting
   author: theamanrawat,AmirHossein Raeisi,dwisiswant0
   severity: medium
-  classification: # Added by method-security
-    cwe-id: CWE-79
   description: |
     Detects DOM-based Cross Site Scripting (XSS) vulnerabilities.
   impact: |
     Allows attackers to execute malicious scripts in the victim's browser.
   remediation: |
     Sanitize and validate user input to prevent script injection.
+  metadata:
+    method-software-weakness-name: XSS Injection # Added by method-security
   tags: xss,dom,dast,headless
 
 variables:

--- a/utils/nuclei/templates/pentest/dast/xss/reflected_stored-xss.yaml
+++ b/utils/nuclei/templates/pentest/dast/xss/reflected_stored-xss.yaml
@@ -4,9 +4,8 @@ info:
   name: Reflected/Stored Cross Site Scripting
   author: method-security
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-79
-
+  metadata:
+    method-software-weakness-name: XSS Injection # Added by method-security
 http:
   - payloads:
       injection:

--- a/utils/nuclei/templates/pentest/dast/xxe/xinclude-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/xxe/xinclude-injection.yaml
@@ -4,12 +4,12 @@ info:
   name: XInclude Injection
   author: DhiyaneshDK,ritikchaddha
   severity: high
-  classification: # Added by method-security
-    cwe-id: CWE-611
   description: |
     XInclude is a part of the XML specification that allows an XML document to be built from sub-documents. You can place an XInclude attack within any data value in an XML document, so the attack can be performed in situations where you only control a single item of data that is placed into a server-side XML document.
   reference:
     - https://d0pt3x.gitbook.io/passion/webapp-security/xxe-attacks/xinclude-attacks
+  metadata:
+    method-software-weakness-name: XXE Injection # Added by method-security
   tags: dast,xxe,xinclude
 
 http:

--- a/utils/nuclei/templates/pentest/dast/xxe/xxe-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/xxe/xxe-injection.yaml
@@ -4,11 +4,10 @@ info:
   name: XML External Entity Injection
   author: pwnhxl,AmirHossein Raeisi
   severity: medium
-  classification: # Added by method-security
-    cwe-id: CWE-611
   reference:
     - https://github.com/andresriancho/w3af/blob/master/w3af/plugins/audit/xxe.py
   metadata:
+    method-software-weakness-name: XXE Injection # Added by method-security
     max-request: 2
   tags: dast,xxe
 

--- a/utils/nuclei/templates/pentest/scan/misconfiguration/header/http-missing-security-headers.yaml
+++ b/utils/nuclei/templates/pentest/scan/misconfiguration/header/http-missing-security-headers.yaml
@@ -9,6 +9,7 @@ info:
   classification:
     cwe-id: CWE-16
   metadata:
+    method-software-weakness-name: HTTP Missing Security Headers
     max-request: 1
   tags: misconfig,headers,generic
 

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/apache/apache-modfile-rce.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/apache/apache-modfile-rce.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   classification:
     cwe-id: CWE-77
+  metadata:
+    method-software-weakness-name: Apache mod_file RCE
 
 http:
   - raw:

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/apache/apache-optionsbleed.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/apache/apache-optionsbleed.yaml
@@ -6,6 +6,8 @@ info:
   severity: medium
   classification:
     cve-id: CVE-2017-9798
+  metadata:
+    method-software-weakness-name: Apache Options Bleed
   tags: apache,optionsbleed,cve-2017-9798,bleed
 
 http:

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/iis/iis-shortname.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/iis/iis-shortname.yaml
@@ -14,6 +14,7 @@ info:
     cvss-score: 0
     cwe-id: CWE-200
   metadata:
+    method-software-weakness-name: IIS Short Name
     max-request: 4
   tags: iis,edb,fuzzing
 

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/nginx/nginx-buffer-overflow.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/nginx/nginx-buffer-overflow.yaml
@@ -6,6 +6,8 @@ info:
   severity: high
   classification:
     cwe-id: CWE-120
+  metadata:
+    method-software-weakness-name: Nginx Header Buffer Overflow
 # Use Flow so we can run JS before the HTTP request
 flow: |
   // build a “A” payload at runtime

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/nginx/nginx-query-reverse-proxy.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/nginx/nginx-query-reverse-proxy.yaml
@@ -6,7 +6,8 @@ info:
   severity: medium
   classification:
     cwe-id: CWE-601
-
+  metadata:
+    method-software-weakness-name: Nginx Query Reverse-Proxy Redirect
 variables:
   redirect: "https://attacker.com"
 


### PR DESCRIPTION
### TL;DR

Added support for Software Weakness Objects in Nuclei findings by introducing a new `softwareWeakness` field and updating templates to use a standardized naming convention.

### What changed?

- Added a new `softwareWeakness` optional field to the `NucleiFindingInfo` type in the Fern definition
- Updated the Nuclei report builder to extract and populate the software weakness name from template metadata
- Refactored all pentest templates to use a consistent `method-software-weakness-name` metadata field instead of CWE IDs in the classification section
- Standardized weakness names across similar vulnerability types (e.g., "SQL Injection", "XSS Injection", etc.)