### PR TITLE
Fix Media type content encoding

### DIFF
--- a/fern/definition/common/http.yml
+++ b/fern/definition/common/http.yml
@@ -29,7 +29,7 @@ types:
       mimeType: optional<string>
   BinaryBody:
     properties:
-      base64: base64
+      base64: string
       mimeType: optional<string>
   MultipartPart:
     properties:

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -3,16 +3,17 @@ package discoverpage
 import (
 	// Standard
 	"context"
+
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	"github.com/Method-Security/webscan/generated/go/discover"
 	"github.com/Method-Security/webscan/utils"
 
-	// Utils
-	headless "github.com/Method-Security/webscan/utils/request/headless"
 	// Internal
 	pagehelpers "github.com/Method-Security/webscan/internal/discover/page/helpers"
+
 	//Utils
+	headless "github.com/Method-Security/webscan/utils/request/headless"
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 )
 

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -24,7 +24,7 @@ import (
 var xmlrpcPath = "/xmlrpc.php"
 
 func createSendHTTPRequestConfig(baseURL, path string, body string, config *pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig) common.SendHttpRequestConfig {
-	bodyStruct := requesthelpers.CreateResponseBody("application/xml", body)
+	bodyStruct := requesthelpers.CreateBodyFromBytes("application/xml", []byte(body))
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -3,6 +3,7 @@ package nuclei
 import (
 	// Standard
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -111,7 +112,7 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 
 	method, path, requestHeaders, body := parseRawRequest(ev.Request)
 	request.Path = path
-	contentType := requesthelpers.DetectContentType(body)
+	contentType := http.DetectContentType([]byte(body))
 	if m, err := common.NewHttpMethodFromString(strings.ToUpper(method)); err == nil {
 		request.Method = m
 	}
@@ -124,7 +125,7 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 		Query: map[string]string{},
 	}
 	if body != "" {
-		params.Body = requesthelpers.CreateResponseBody("", body)
+		params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
 	}
 	if u2, err := url.Parse(path); err == nil {
 		for k, vs := range u2.Query() {
@@ -144,7 +145,7 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 
 	// If there was an error in the response, add it to the response body
 	if ev.Error != "" {
-		response.ResponseBody = requesthelpers.CreateResponseBody("text/plain", fmt.Sprintf("Error: %s", ev.Error))
+		response.ResponseBody = requesthelpers.CreateBodyFromBytes("text/plain", []byte(fmt.Sprintf("Error: %s", ev.Error)))
 	}
 
 	// Return HttpRequestResponse

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -259,7 +259,6 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 				responseBody = htmlContent
 			}
 		}
-
 		// Build final response
 		response := requesthelpers.CreateHTTPResponse(
 			statusCode,

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -70,7 +70,7 @@ func GetResponseBodyStringFromBodyStruct(body *common.Body) *string {
 	switch body.Kind {
 	case "binary":
 		if body.Binary != nil {
-			str := string(body.Binary.Base64)
+			str := body.Binary.Base64
 			return &str
 		}
 	case "form":
@@ -92,7 +92,7 @@ func GetResponseBodyStringFromBodyStruct(body *common.Body) *string {
 			var parts []string
 			for _, part := range body.Multipart.Parts {
 				if part.Content != nil {
-					decoded, err := base64.StdEncoding.DecodeString(string(part.Content.Base64))
+					decoded, err := base64.StdEncoding.DecodeString(part.Content.Base64)
 					if err != nil {
 						continue
 					}

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -3,8 +3,8 @@ package request
 import (
 	// Standard
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -113,19 +113,8 @@ func GetResponseBodyStringFromBodyStruct(body *common.Body) *string {
 	return nil
 }
 
-// CreateResponseBody creates a Body struct based on content type and response data
-func CreateResponseBody(contentType string, responseBody string) *common.Body {
-	// If no content type or empty content type, default to text
-	if contentType == "" {
-		return &common.Body{
-			Kind: "text",
-			Text: &common.TextBody{
-				Value: responseBody,
-			},
-		}
-	}
-
-	// Trim any whitespace and split on semicolon to handle charset and other parameters
+// CreateBodyFromBytes creates a Body struct based on content type and body data as bytes
+func CreateBodyFromBytes(contentType string, bodyData []byte) *common.Body {
 	ct := strings.TrimSpace(strings.Split(contentType, ";")[0])
 
 	switch {
@@ -133,13 +122,14 @@ func CreateResponseBody(contentType string, responseBody string) *common.Body {
 		return &common.Body{
 			Kind: "json",
 			Json: &common.JsonBody{
-				Data:     responseBody,
+				Data:     string(bodyData),
 				MimeType: &ct,
 			},
 		}
 	case strings.Contains(ct, "application/x-www-form-urlencoded"):
 		fields := make(map[string]string)
-		for _, pair := range strings.Split(responseBody, "&") {
+		bodyStr := string(bodyData)
+		for _, pair := range strings.Split(bodyStr, "&") {
 			kv := strings.Split(pair, "=")
 			if len(kv) == 2 {
 				fields[kv[0]] = kv[1]
@@ -152,11 +142,19 @@ func CreateResponseBody(contentType string, responseBody string) *common.Body {
 				MimeType: &ct,
 			},
 		}
-	case strings.Contains(ct, "multipart/form-data"):
+	case strings.HasPrefix(ct, "image/"),
+		strings.Contains(ct, "application/octet-stream"),
+		strings.Contains(ct, "application/pdf"),
+		strings.Contains(ct, "application/zip"),
+		strings.Contains(ct, "application/gzip"),
+		strings.HasPrefix(ct, "video/"),
+		strings.HasPrefix(ct, "audio/"):
+		// Handle binary content types
+		base64Data := base64.StdEncoding.EncodeToString(bodyData)
 		return &common.Body{
-			Kind: "text",
-			Text: &common.TextBody{
-				Value:    responseBody,
+			Kind: "binary",
+			Binary: &common.BinaryBody{
+				Base64:   base64Data,
 				MimeType: &ct,
 			},
 		}
@@ -164,40 +162,15 @@ func CreateResponseBody(contentType string, responseBody string) *common.Body {
 		return &common.Body{
 			Kind: "text",
 			Text: &common.TextBody{
-				Value:    responseBody,
+				Value:    string(bodyData),
 				MimeType: &ct,
 			},
 		}
 	}
 }
 
-// DetectContentType attempts to detect the content type from the response body
-func DetectContentType(body string) string {
-	// Try to detect JSON
-	if strings.TrimSpace(body) != "" {
-		var jsonCheck interface{}
-		if err := json.Unmarshal([]byte(body), &jsonCheck); err == nil {
-			return "application/json"
-		}
-	}
-
-	// Check for HTML
-	if strings.Contains(strings.ToLower(body), "<!doctype html") ||
-		strings.Contains(strings.ToLower(body), "<html") {
-		return "text/html"
-	}
-
-	// Check for XML
-	if strings.HasPrefix(strings.TrimSpace(body), "<?xml") {
-		return "application/xml"
-	}
-
-	// Default to text/plain
-	return "text/plain"
-}
-
-// CreateHTTPResponse creates an HttpResponse struct from HttpResponse data
-func CreateHTTPResponse(statusCode int, redirectChain []string, headers map[string][]string, responseBody string) common.HttpResponse {
+// CreateHTTPResponseFromBytes creates an HttpResponse struct from HttpResponse data using byte array
+func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers map[string][]string, responseBody []byte) common.HttpResponse {
 	// Process headers to split comma-delimited values
 	processedHeaders := make(map[string][]string)
 	for key, values := range headers {
@@ -218,13 +191,13 @@ func CreateHTTPResponse(statusCode int, redirectChain []string, headers map[stri
 		contentType = ct[0]
 	}
 
-	// If no content type is provided, try to detect it
+	// If no content type is provided, try to detect it from string representation
 	if contentType == "" {
-		contentType = DetectContentType(responseBody)
+		contentType = http.DetectContentType(responseBody)
 	}
 
 	// Create the response body based on content type
-	bodyStruct := CreateResponseBody(contentType, responseBody)
+	bodyStruct := CreateBodyFromBytes(contentType, responseBody)
 
 	// Get current time for received timestamp
 	receivedAt := time.Now()
@@ -238,4 +211,10 @@ func CreateHTTPResponse(statusCode int, redirectChain []string, headers map[stri
 		ReceivedAt:      &receivedAt,
 		SizeBytes:       &sizeBytes,
 	}
+}
+
+// CreateHTTPResponse creates an HttpResponse struct from HttpResponse data (string version)
+// This is a compatibility wrapper that converts string to bytes
+func CreateHTTPResponse(statusCode int, redirectChain []string, headers map[string][]string, responseBody string) common.HttpResponse {
+	return CreateHTTPResponseFromBytes(statusCode, redirectChain, headers, []byte(responseBody))
 }

--- a/utils/request/standard/helpers/prepare.go
+++ b/utils/request/standard/helpers/prepare.go
@@ -122,7 +122,7 @@ func PrepareRequestBody(ctx context.Context, request *common.HttpRequest) (io.Re
 			}
 
 			// Decode base64 content
-			content, err := base64.StdEncoding.DecodeString(string(part.Content.Base64))
+			content, err := base64.StdEncoding.DecodeString(part.Content.Base64)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode base64 content: %v", err)
 			}
@@ -180,7 +180,7 @@ func PrepareRequestBody(ctx context.Context, request *common.HttpRequest) (io.Re
 		return strings.NewReader(body.Text.Value), nil
 
 	case "binary":
-		content, err := base64.StdEncoding.DecodeString(string(body.Binary.Base64))
+		content, err := base64.StdEncoding.DecodeString(body.Binary.Base64)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode base64 content: %v", err)
 		}

--- a/utils/request/standard/standard.go
+++ b/utils/request/standard/standard.go
@@ -54,8 +54,7 @@ func SendStandardRequest(ctx context.Context, config common.SendHttpRequestConfi
 	if err != nil {
 		return common.HttpRequestResponse{Request: request}, fmt.Errorf("failed to read response body: %v", err)
 	}
-	bodyStr := string(bodyBytes)
-	response := requesthelpers.CreateHTTPResponse(resp.StatusCode, redirectChain, resp.Header, bodyStr)
+	response := requesthelpers.CreateHTTPResponseFromBytes(resp.StatusCode, redirectChain, resp.Header, bodyBytes)
 	err = resp.Body.Close()
 	if err != nil {
 		return common.HttpRequestResponse{Request: request}, fmt.Errorf("failed to close response body: %v", err)


### PR DESCRIPTION
### TL;DR

* Wasnt setting images as body content type
* Was double encoding Images so switch to string

### What changed?

- Changed `BinaryBody.base64` type from `base64` to `string` in the Fern definition
- Created a new `CreateBodyFromBytes` function that properly handles binary data and various content types
- Replaced `DetectContentType` with the standard library's `http.DetectContentType` for more reliable content type detection
- Added a new `CreateHTTPResponseFromBytes` function that works with byte arrays directly instead of strings
- Updated all references to the old functions to use the new implementations
- Improved binary content type detection for images, videos, PDFs, and other binary formats

### How to test?

1. Test sending and receiving binary data (images, PDFs, etc.) through the API
2. Verify that content types are correctly detected for various response types
3. Check that binary data is properly encoded and decoded in base64 format
4. Ensure that the WordPress XML-RPC functionality still works correctly

### Why make this change?

The previous implementation had limitations when handling binary data, as it was primarily string-based. This change improves the handling of binary content by working with byte arrays directly and properly detecting content types. It also standardizes the approach to content type detection by using the Go standard library's implementation, which is more robust and maintained.