### PR TITLE
Update Static Asset Command

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -659,11 +659,6 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			fingerprints := pentestroute.GrabStaticAssetTakeOverFingerprints(fingerprintPaths)
-			if len(fingerprints) == 0 {
-				a.OutputSignal.AddError(fmt.Errorf("no fingerprints found"))
-				return
-			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -698,7 +693,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprints, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprintPaths, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -935,7 +930,7 @@ func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, succes
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
@@ -952,9 +947,9 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprints []*pen
 	}
 	// Create Static Asset Takeover Config with nested route capture config
 	config := pentestroutefern.PentestRouteStaticAssetTakeoverConfig{
-		RouteCaptureConfig: routeCaptureConfig,
-		Fingerprints:       fingerprints,
-		SuccessfulOnly:     successfulOnly,
+		RouteCaptureConfig:   routeCaptureConfig,
+		FingerprintFilePaths: fingerprintFilePaths,
+		SuccessfulOnly:       successfulOnly,
 	}
 
 	return config

--- a/fern/definition/pentest/route/staticassettakeover.yml
+++ b/fern/definition/pentest/route/staticassettakeover.yml
@@ -7,7 +7,7 @@ types:
     properties:
       routeCaptureConfig: route.DiscoverRouteConfig
       successfulOnly: boolean
-      fingerprints: list<StaticAssetTakeoverFingerprint>
+      fingerprintFilePaths: list<string>
   # Fingerprint File Struct
   StaticAssetTakeoverFingerprint:
     properties:
@@ -18,17 +18,23 @@ types:
   # Report Struct
   StaticAssetTakeoverVulnerableDetails:
     properties:
-      fingerprint: StaticAssetTakeoverFingerprint
+      fingerprint: optional<StaticAssetTakeoverFingerprint>
       vulnerable: boolean
-  StaticAssetTakeoverAttempt:
+  StaticAssetTakeoverStaticRequest:
     properties:
       staticAsset: string
       request: http.HttpRequestResponse
-      fingerprints: list<StaticAssetTakeoverVulnerableDetails>
-  PentestRouteStaticAssetTakeoverReport:
+      vulnerableDetails: optional<StaticAssetTakeoverVulnerableDetails>
+  StaticAssetTakeoverTest:
     properties:
       target: string
       baseRequest: optional<http.HttpRequestResponse>
-      attempts: optional<list<StaticAssetTakeoverAttempt>>
+      staticRequests: optional<list<StaticAssetTakeoverStaticRequest>>
+  PentestRouteStaticAssetTakeoverResult:
+    properties:
+      test: optional<StaticAssetTakeoverTest>
+  PentestRouteStaticAssetTakeoverReport:
+    properties:
+      result: PentestRouteStaticAssetTakeoverResult
       config: PentestRouteStaticAssetTakeoverConfig
       errors: optional<list<string>>

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -16,6 +16,8 @@ import (
 
 	// Internal
 	discoverroute "github.com/Method-Security/webscan/internal/discover/route"
+	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
 	request "github.com/Method-Security/webscan/utils/request"
@@ -45,7 +47,10 @@ func createSendHTTPRequestConfig(targetBaseURL, targetPath string, config pentes
 }
 
 // GrabStaticAssetTakeOverFingerprints grabs the fingerprints from the given file paths
-func GrabStaticAssetTakeOverFingerprints(fingerprintFilePaths []string) []*pentestroutefern.StaticAssetTakeoverFingerprint {
+func GrabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePaths []string) []*pentestroutefern.StaticAssetTakeoverFingerprint {
+	log := svc1log.FromContext(ctx)
+	log.Info("Grabbing static asset take over fingerprints", svc1log.SafeParam("fingerprint_file_paths", fingerprintFilePaths))
+
 	fingerprints := []*pentestroutefern.StaticAssetTakeoverFingerprint{}
 
 	for _, path := range fingerprintFilePaths {
@@ -63,103 +68,120 @@ func GrabStaticAssetTakeOverFingerprints(fingerprintFilePaths []string) []*pente
 		if err != nil {
 			continue
 		}
-
 		var config struct {
 			Fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint
 		}
-
 		if err := json.Unmarshal(data, &config); err != nil {
 			continue
 		}
-
 		err = file.Close()
 		if err != nil {
 			continue
 		}
-
 		fingerprints = append(fingerprints, config.Fingerprints...)
 	}
 
+	log.Info("Grabbed static asset take over fingerprints", svc1log.SafeParam("fingerprint_length", len(fingerprints)))
 	return fingerprints
 }
 
 // isStaticAssetTakeOver checks if the request is vulnerable to static asset take over
-func isStaticAssetTakeOver(httpRequestResponse *common.HttpRequestResponse, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, successfulOnly bool) []*pentestroutefern.StaticAssetTakeoverVulnerableDetails {
-	info := []*pentestroutefern.StaticAssetTakeoverVulnerableDetails{}
+func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.HttpRequestResponse, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint) pentestroutefern.StaticAssetTakeoverVulnerableDetails {
+	log := svc1log.FromContext(ctx)
+	log.Info("Checking if static asset is vulnerable to take over", svc1log.SafeParam("fingerprint_length", len(fingerprints)))
 
+	// Create the info struct
 	if httpRequestResponse.Response == nil {
-		return info
+		return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
 	}
 
+	// Get the response body string
 	responseBodyString := requesthelpers.GetResponseBodyStringFromBodyStruct(httpRequestResponse.Response.ResponseBody)
 	if responseBodyString == nil {
-		return info
+		return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
 	}
 	lowerResponseBody := strings.ToLower(*responseBodyString)
 
+	// Check each fingerprint
+	instance := pentestroutefern.StaticAssetTakeoverVulnerableDetails{}
 	for _, fingerprint := range fingerprints {
-		instance := pentestroutefern.StaticAssetTakeoverVulnerableDetails{
-			Fingerprint: fingerprint,
-			Vulnerable:  false,
-		}
 
 		// Does the status code and response body of the request match the fingerprint
 		for _, fingerprintBody := range fingerprint.ResponseBody {
 			if *httpRequestResponse.Response.StatusCode == fingerprint.StatusCode && strings.Contains(lowerResponseBody, fingerprintBody) {
 				instance.Vulnerable = true
-				break
+				instance.Fingerprint = fingerprint
+				return instance
 			}
-		}
-
-		if instance.Vulnerable || !successfulOnly {
-			info = append(info, &instance)
 		}
 	}
 
-	return info
+	// Return false if we havent detected a fingerprint hit
+	return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
 }
 
 func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.PentestRouteStaticAssetTakeoverConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) pentestroutefern.PentestRouteStaticAssetTakeoverReport {
-	// Create Report
-	report := pentestroutefern.PentestRouteStaticAssetTakeoverReport{
-		Target: config.RouteCaptureConfig.Target,
-		Config: &config,
+	// Initialize report
+	report := pentestroutefern.PentestRouteStaticAssetTakeoverReport{Config: &config}
+	result := pentestroutefern.PentestRouteStaticAssetTakeoverResult{}
+	var errors []string
+
+	log := svc1log.FromContext(ctx)
+	log.Info("Detecting static asset takeovers", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
+
+	fingerprints := GrabStaticAssetTakeOverFingerprints(ctx, config.FingerprintFilePaths)
+	if len(fingerprints) == 0 {
+		errors = append(errors, "no fingerprints found")
+		report.Errors = errors
+		report.Result = &result
+		return report
 	}
-	errors := []string{}
 
 	// Perform Route Capture
+	log.Info("Performing route capture", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
 	captureRouteReport := discoverroute.PerformRouteCapture(ctx, *config.RouteCaptureConfig, browserbaseSecrets)
 	if len(captureRouteReport.Result.StaticAssets) == 0 {
 		errors = append(errors, "no static assets found")
 		report.Errors = errors
+		report.Result = &result
 		return report
 	}
 
+	// Initialize the result
+	attempt := pentestroutefern.StaticAssetTakeoverTest{
+		Target: config.RouteCaptureConfig.Target,
+	}
+
 	// Split and standardize the target
+	log.Info("Splitting and standardizing the target", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
 	targetBaseURL, targetPath, err := requesthelpers.SplitTargetURL(config.RouteCaptureConfig.Target)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error splitting target: %s", err))
 		report.Errors = errors
+		report.Result = &result
 		return report
 	}
 
 	// Send the request
+	log.Info("Sending request to the target", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
 	requestConfig := createSendHTTPRequestConfig(targetBaseURL, targetPath, config, browserbaseSecrets)
 	httpRequestResponse, err := request.SendRequest(ctx, requestConfig)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error performing request: %s", err))
 		report.Errors = errors
+		report.Result = &result
 		return report
 	}
-	report.BaseRequest = httpRequestResponse
+	attempt.BaseRequest = httpRequestResponse
 
 	// Static Asset Take Over Attempts
-	StaticAssetTakeOverAttempts := []*pentestroutefern.StaticAssetTakeoverAttempt{}
+	StaticAssetTakeOverAttempts := []*pentestroutefern.StaticAssetTakeoverStaticRequest{}
 	for _, staticAsset := range captureRouteReport.Result.StaticAssets {
 		if !utils.IsStaticAsset(staticAsset) {
 			continue
 		}
-		StaticAssetTakeOverAttempt := pentestroutefern.StaticAssetTakeoverAttempt{StaticAsset: staticAsset}
+		log.Info("Found a static asset", svc1log.SafeParam("static_asset", staticAsset))
+		StaticAssetTakeOverAttempt := pentestroutefern.StaticAssetTakeoverStaticRequest{StaticAsset: staticAsset}
 
 		// Perform Request
 		staticAssetBaseURL, staticAssetPath, err := requesthelpers.SplitTargetURL(staticAsset)
@@ -168,8 +190,8 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 			continue
 		}
 
-		// Set the request method to 'STANDARD' even when original request was HEADLESS as HEADLESS is too slow to
-		// perform the static asset request
+		// Set the request method to 'STANDARD' even when original request was HEADLESS since its not required to
+		// pull in the static asset and has higher overhead
 		config.RouteCaptureConfig.RequestMethod = common.RequestMethodStandard
 		config.RouteCaptureConfig.MaxRedirects = 0 // Don't follow any redirects on static asset requests
 		config.RouteCaptureConfig.HeadlessConfig = nil
@@ -183,14 +205,23 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 		StaticAssetTakeOverAttempt.Request = result
 
 		// Check if the request is vulnerable
-		info := isStaticAssetTakeOver(result, config.Fingerprints, config.SuccessfulOnly)
-		if len(info) > 0 {
-			StaticAssetTakeOverAttempt.Fingerprints = info
+		log.Info("Performing static asset take over check", svc1log.SafeParam("static_asset", staticAsset))
+		info := isStaticAssetTakeOver(ctx, result, fingerprints)
+		if info.Vulnerable || !config.SuccessfulOnly {
+			StaticAssetTakeOverAttempt.VulnerableDetails = &info
 			StaticAssetTakeOverAttempts = append(StaticAssetTakeOverAttempts, &StaticAssetTakeOverAttempt)
 		}
 	}
 
-	report.Attempts = StaticAssetTakeOverAttempts
+	// Marshal the result, only include if we have valid attempts
+	if len(StaticAssetTakeOverAttempts) > 0 {
+		attempt.StaticRequests = StaticAssetTakeOverAttempts
+		result.Test = &attempt
+
+	}
+
+	// Marshal the report
+	report.Result = &result
 	report.Errors = errors
 	return report
 }


### PR DESCRIPTION
### TL;DR

Refactored the static asset takeover detection to improve performance and structure.

### What changed?

- Moved fingerprint loading from command execution to the detection function
- Restructured the data model in the Fern definition:
    - Renamed `StaticAssetTakeoverAttempt` to `StaticAssetTakeoverStaticRequest`
    - Added a new `StaticAssetTakeoverTest` type to better organize results
    - Created a `PentestRouteStaticAssetTakeoverResult` to wrap test results
- Changed fingerprint handling to pass file paths instead of loaded fingerprints
- Improved vulnerability detection logic to return early when a match is found
- Added logging throughout the detection process for better observability
- Simplified the vulnerability details structure to only include fingerprint data when relevant