### PR TITLE
Add Time for Headless Requests

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -50,6 +50,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 	// SETUP
 	// =========================================================================================
 	log := svc1log.FromContext(ctx)
+
 	report := common.HttpRequestResponse{Request: config.Request}
 
 	constructedURL, err := standardhelpers.ConstructURL(ctx, config.Request)
@@ -87,6 +88,10 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		browserErr      error
 		statusCode      int
 	)
+
+	// Set the request sent timestamp
+	sentAt := time.Now()
+	config.Request.SentAt = sentAt
 
 	if err := rod.Try(func() {
 		// Create new page


### PR DESCRIPTION
### TL;DR

Added timestamp tracking for headless browser requests.

### What changed?

Added code to record the timestamp when a request is sent in the headless browser requester. The implementation sets a `sentAt` variable with the current time and assigns it to `config.Request.SentAt` before the request is executed.

### How to test?

1. Use the headless browser requester to send a request
2. Verify that the `SentAt` field in the request object is populated with the correct timestamp
3. Confirm the timestamp is set immediately before the request is executed

### Why make this change?

This change enables accurate tracking of when requests are sent, which is important for performance monitoring, debugging, and analyzing request latency. Having precise timing information helps with troubleshooting issues and optimizing request handling.