### PR TITLE
Enhance route discovery with query parameter extraction and redirect handling

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -371,8 +371,8 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Config Flags
 	discoverRouteCmd.Flags().Bool("ignore-base-url-match", false, "Add route even if it does not share the target's base URL")
 	discoverRouteCmd.Flags().Bool("collect-static-assets", false, "Collect static assets from route discovery")
-	discoverRouteCmd.Flags().Int("spider-depth", 1, "Maximum depth for route spidering")
-	discoverRouteCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
+	discoverRouteCmd.Flags().Int("spider-depth", 3, "Maximum depth for route spidering")
+	discoverRouteCmd.Flags().Int("max-redirects", 100, "Maximum number of redirects to follow")
 	discoverRouteCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverRouteCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverRouteCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -113,6 +113,19 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 		if exists && href != "" {
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, href)
 
+			// Parse the full URL to extract query parameters before removing them
+			parsedFullURL, err := url.Parse(fullURL)
+			if err != nil {
+				errors = append(errors, err.Error())
+				return
+			}
+
+			// Extract query parameters from the original URL
+			var queryParams []*discover.RouteQueryParam
+			if parsedFullURL.RawQuery != "" {
+				queryParams = discoverroutehelpers.ParseQueryParams(parsedFullURL)
+			}
+
 			// The route URL should not have query params, those are stored in QueryParams
 			urlNoQuery, err := discoverroutehelpers.URLRemoveQueryParams(fullURL)
 			if err != nil {
@@ -126,7 +139,7 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 			}
 			urls[urlNoQuery] = struct{}{}
 
-			// Get the path from the full URL
+			// Get the path from the full URL without query params
 			parsedURL, err := url.Parse(urlNoQuery)
 			if err != nil {
 				errors = append(errors, err.Error())
@@ -137,6 +150,11 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 				BaseUrl: baseURL,
 				Path:    parsedURL.Path,
 				Method:  common.HttpMethodGet.Ptr(), // Anchor links are accessed via GET
+			}
+
+			// Add query parameters if any were found
+			if len(queryParams) > 0 {
+				routeVar.QueryParams = queryParams
 			}
 
 			routes = append(routes, routeVar)

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -55,7 +55,15 @@ func MergeWebRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
 		if route.Method != nil {
 			method = string(*route.Method)
 		}
-		key := fmt.Sprintf("%s:%s%s", method, route.BaseUrl, route.Path)
+
+		// Normalize path: treat empty path "" and root path "/" as equivalent
+		// Follow existing codebase convention: root paths should be empty strings
+		normalizedPath := route.Path
+		if normalizedPath == "/" {
+			normalizedPath = ""
+		}
+
+		key := fmt.Sprintf("%s:%s%s", method, route.BaseUrl, normalizedPath)
 
 		if existingRoute, exists := routeMap[key]; exists {
 			// Merge QueryParams
@@ -65,8 +73,10 @@ func MergeWebRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
 		} else {
 			// Add new route to the map
 			// Create a copy to avoid modifying the original
-			newRoute := route
-			routeMap[key] = newRoute
+			newRoute := *route
+			// Normalize the path in the route object itself for consistent output
+			newRoute.Path = normalizedPath
+			routeMap[key] = &newRoute
 		}
 	}
 
@@ -99,7 +109,20 @@ func MergeQueryParams(params1 []*discover.RouteQueryParam, params2 []*discover.R
 		if _, exists := paramMap[param.Name]; exists {
 			existingParam := paramMap[param.Name]
 			if existingParam.ExampleValues != nil && param.ExampleValues != nil {
-				existingParam.ExampleValues = append(existingParam.ExampleValues, param.ExampleValues...)
+				// Use a set to deduplicate example values
+				valueSet := make(map[string]struct{})
+				for _, val := range existingParam.ExampleValues {
+					valueSet[val] = struct{}{}
+				}
+				for _, val := range param.ExampleValues {
+					valueSet[val] = struct{}{}
+				}
+				// Convert back to slice
+				deduplicatedValues := make([]string, 0, len(valueSet))
+				for val := range valueSet {
+					deduplicatedValues = append(deduplicatedValues, val)
+				}
+				existingParam.ExampleValues = deduplicatedValues
 			} else if param.ExampleValues != nil {
 				existingParam.ExampleValues = param.ExampleValues
 			} // else existingParam.ExampleValues is already set
@@ -135,7 +158,20 @@ func MergeBodyParams(params1 []*discover.RouteBodyParam, params2 []*discover.Rou
 		if _, exists := paramMap[param.Name]; exists {
 			existingParam := paramMap[param.Name]
 			if existingParam.ExampleValues != nil && param.ExampleValues != nil {
-				existingParam.ExampleValues = append(existingParam.ExampleValues, param.ExampleValues...)
+				// Use a set to deduplicate example values
+				valueSet := make(map[string]struct{})
+				for _, val := range existingParam.ExampleValues {
+					valueSet[val] = struct{}{}
+				}
+				for _, val := range param.ExampleValues {
+					valueSet[val] = struct{}{}
+				}
+				// Convert back to slice
+				deduplicatedValues := make([]string, 0, len(valueSet))
+				for val := range valueSet {
+					deduplicatedValues = append(deduplicatedValues, val)
+				}
+				existingParam.ExampleValues = deduplicatedValues
 			} else if param.ExampleValues != nil {
 				existingParam.ExampleValues = param.ExampleValues
 			}

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"context"
 	"fmt"
+	"net/url"
 	"runtime"
 	"strings"
 	"sync"
@@ -28,12 +29,103 @@ import (
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-func createSendHTTPRequestConfig(baseURL, path string, config discover.DiscoverRouteConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
+// ExtractRedirectRoutes analyzes redirect chain URLs to extract routes with parameters
+func ExtractRedirectRoutes(redirectChain []string, baseURL string, routeCaptureConfig discover.DiscoverRouteConfig) ([]*discover.RouteDetails, []string, []string) {
+	routes := []*discover.RouteDetails{}
+	urls := make(map[string]struct{})
+	errors := []string{}
+
+	for _, redirectURL := range redirectChain {
+		// Parse the redirect URL
+		parsedURL, err := url.Parse(redirectURL)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to parse redirect URL %s: %s", redirectURL, err))
+			continue
+		}
+
+		// Only process URLs with query parameters
+		if parsedURL.RawQuery == "" {
+			continue
+		}
+
+		// Check if the URL is allowed
+		if !discoverroutehelpers.IsURLAllowed(baseURL, redirectURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			continue
+		}
+
+		// Extract query parameters
+		queryParams := discoverroutehelpers.ParseQueryParams(parsedURL)
+		if len(queryParams) == 0 {
+			continue
+		}
+
+		// Create route without query params in the URL
+		urlNoQuery, err := discoverroutehelpers.URLRemoveQueryParams(redirectURL)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to remove query params from %s: %s", redirectURL, err))
+			continue
+		}
+
+		parsedCleanURL, err := url.Parse(urlNoQuery)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to parse clean redirect URL %s: %s", urlNoQuery, err))
+			continue
+		}
+
+		urls[urlNoQuery] = struct{}{}
+
+		routeVar := &discover.RouteDetails{
+			BaseUrl:     baseURL,
+			Path:        parsedCleanURL.Path,
+			Method:      common.HttpMethodGet.Ptr(), // Redirects are typically GET
+			QueryParams: queryParams,
+		}
+
+		routes = append(routes, routeVar)
+	}
+
+	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
+}
+
+// buildAllParameterURLs creates URLs for ALL discovered parameter values (no sampling)
+func buildAllParameterURLs(route *discover.RouteDetails) []string {
+	var allURLs []string
+	baseURL := route.BaseUrl + route.Path
+
+	if route.QueryParams == nil || len(route.QueryParams) == 0 {
+		return allURLs
+	}
+
+	// Build URLs with ALL discovered parameter values - no sampling or limits
+	for _, param := range route.QueryParams {
+		if param.ExampleValues != nil && len(param.ExampleValues) > 0 {
+			// Test EVERY value for this parameter to ensure complete coverage
+			for _, value := range param.ExampleValues {
+				// For single parameter, create simple query string
+				if len(route.QueryParams) == 1 {
+					paramURL := fmt.Sprintf("%s?%s=%s", baseURL, param.Name, value)
+					allURLs = append(allURLs, paramURL)
+				} else {
+					// For multiple parameters, we'd need more complex combination logic
+					// For now, handle single parameter case which covers most scenarios
+					paramURL := fmt.Sprintf("%s?%s=%s", baseURL, param.Name, value)
+					allURLs = append(allURLs, paramURL)
+				}
+			}
+		}
+	}
+
+	return allURLs
+}
+
+func createSendHTTPRequestConfigWithQuery(baseURL, path string, queryParams map[string]string, config discover.DiscoverRouteConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
 		Method:  common.HttpMethodGet,
-		Params:  &common.HttpRequestParams{},
+		Params: &common.HttpRequestParams{
+			Query: queryParams,
+		},
 	}
 	return common.SendHttpRequestConfig{
 		Request:            &request,
@@ -65,13 +157,18 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 
 	redirectedURL := httpRequestResponse.Response.RedirectChain[len(httpRequestResponse.Response.RedirectChain)-1]
 	log.Info("Redirected URL", svc1log.SafeParam("url", redirectedURL))
-	redirectedURLBase, redirectedURLPath, err := requesthelpers.SplitTargetURL(redirectedURL)
+
+	// Parse the redirected URL to preserve query parameters
+	parsedRedirectedURL, err := url.Parse(redirectedURL)
 	if err != nil {
-		errorMsg := fmt.Sprintf("Failed to split redirected URL %s: %s", redirectedURL, err)
+		errorMsg := fmt.Sprintf("Failed to parse redirected URL %s: %s", redirectedURL, err)
 		log.Error(errorMsg)
 		errors = append(errors, errorMsg)
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
+
+	// Extract base URL (without query parameters for route extraction context)
+	redirectedURLBase := fmt.Sprintf("%s://%s", parsedRedirectedURL.Scheme, parsedRedirectedURL.Host)
 
 	// Helper function to process errors with context
 	processErrors := func(source string, newErrors []string) {
@@ -115,6 +212,13 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	urls = discoverroutehelpers.AddListToSetString(urls, inlineScriptUrls)
 	errors = append(errors, inlineScriptErrors...)
 
+	// Extract routes from redirect chain (analyze redirect URLs for parameters)
+	log.Info("Extracting routes from redirect chain")
+	redirectRoutes, redirectUrls, redirectErrors := ExtractRedirectRoutes(httpRequestResponse.Response.RedirectChain, redirectedURLBase, routeCaptureConfig)
+	routes = append(routes, redirectRoutes...)
+	urls = discoverroutehelpers.AddListToSetString(urls, redirectUrls)
+	processErrors("Redirect Chain", redirectErrors)
+
 	// Extract routes from network calls
 	// Only to be performed if requestMethod is of type Headless or Browserbase
 	if requestConfig.RequestMethod == common.RequestMethodHeadless || requestConfig.RequestMethod == common.RequestMethodBrowserbase {
@@ -135,7 +239,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 			return routes, discoverroutehelpers.SetToListString(urls), errors
 		}
 
-		fullRedirectedURL := fmt.Sprintf("%s%s", redirectedURLBase, redirectedURLPath)
+		fullRedirectedURL := redirectedURL
 		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets)
 		routes = append(routes, networkRoutes...)
 		urls = discoverroutehelpers.AddListToSetString(urls, networkUrls)
@@ -210,44 +314,62 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 		semaphore := make(chan struct{}, maxGoroutines)
 
 		// Process each URL concurrently
-		for _, currentURL := range urlsAtCurrentDepth {
+		for _, urlToProcess := range urlsAtCurrentDepth {
 			wg.Add(1)
 
 			// Acquire semaphore (blocks if maxGoroutines are running)
 			semaphore <- struct{}{}
 
-			go func(url string) {
+			go func(targetURL string) {
 				defer wg.Done()
 				defer func() { <-semaphore }() // Release semaphore when done
 
 				// Skip if already visited
 				mu.Lock()
-				if _, visited := visitedURLs[url]; visited {
+				if _, visited := visitedURLs[targetURL]; visited {
 					mu.Unlock()
 					return
 				}
-				visitedURLs[url] = struct{}{}
+				visitedURLs[targetURL] = struct{}{}
 				mu.Unlock()
 
-				// Split and standardize the current URL
-				currentBaseURL, currentPath, err := requesthelpers.SplitTargetURL(url)
+				// Parse the URL to preserve query parameters
+				parsedURL, err := url.Parse(targetURL)
 				if err != nil {
-					errChan <- fmt.Sprintf("error splitting URL %s: %s", url, err)
+					errChan <- fmt.Sprintf("error parsing URL %s: %s", targetURL, err)
 					return
 				}
 
+				// Extract base URL
+				currentBaseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+
+				// Separate path and query parameters
+				currentPath := parsedURL.Path
+				var queryParams map[string]string
+				if parsedURL.RawQuery != "" {
+					queryParams = make(map[string]string)
+					values, err := url.ParseQuery(parsedURL.RawQuery)
+					if err == nil {
+						for key, vals := range values {
+							if len(vals) > 0 {
+								queryParams[key] = vals[0] // Use first value if multiple
+							}
+						}
+					}
+				}
+
 				// Send the request
-				requestConfig := createSendHTTPRequestConfig(currentBaseURL, currentPath, config, browserbaseSecrets)
+				requestConfig := createSendHTTPRequestConfigWithQuery(currentBaseURL, currentPath, queryParams, config, browserbaseSecrets)
 				request, err := request.SendRequest(ctx, requestConfig)
 				if err != nil {
-					errChan <- fmt.Sprintf("error performing request to %s: %s", url, err)
+					errChan <- fmt.Sprintf("error performing request to %s: %s", targetURL, err)
 					return
 				}
 
 				// Extract the routes and if enabled, static assets
 				if request.Response == nil || request.Response.ResponseBody == nil {
-					log.Info("No response from", svc1log.SafeParam("url", url))
-					errChan <- fmt.Sprintf("no response from %s", url)
+					log.Info("No response from", svc1log.SafeParam("url", targetURL))
+					errChan <- fmt.Sprintf("no response from %s", targetURL)
 					return
 				}
 
@@ -262,16 +384,32 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 
 				// Collect routes to spider
 				for _, route := range routes {
-					routeURL := route.BaseUrl + route.Path
+					// Visit the base route (without parameters)
+					baseRouteURL := route.BaseUrl + route.Path
 					mu.Lock()
-					if _, visited := visitedURLs[routeURL]; !visited {
+					if _, visited := visitedURLs[baseRouteURL]; !visited {
 						nextDepthMu.Lock()
-						nextDepthUrls = append(nextDepthUrls, routeURL)
+						nextDepthUrls = append(nextDepthUrls, baseRouteURL)
 						nextDepthMu.Unlock()
 					}
 					mu.Unlock()
+
+					// Visit routes with ALL their discovered query parameter values (comprehensive testing)
+					if route.QueryParams != nil && len(route.QueryParams) > 0 {
+						// Build URLs with ALL parameter values - no sampling to ensure complete coverage
+						allParameterURLs := buildAllParameterURLs(route)
+						mu.Lock()
+						for _, paramURL := range allParameterURLs {
+							if _, visited := visitedURLs[paramURL]; !visited {
+								nextDepthMu.Lock()
+								nextDepthUrls = append(nextDepthUrls, paramURL)
+								nextDepthMu.Unlock()
+							}
+						}
+						mu.Unlock()
+					}
 				}
-			}(currentURL)
+			}(urlToProcess)
 		}
 
 		// Wait for all goroutines to complete

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -90,8 +90,44 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 	// Use a simple completion flag to prevent further event processing
 	var completed int32 // Use atomic operations for thread safety
 
-	// Set up event listeners for navigation events
+	// Enable network events to capture HTTP redirects
+	enableNetworkErr := proto.NetworkEnable{}.Call(page)
+	if enableNetworkErr != nil {
+		log.Warn("Failed to enable network tracking for redirects", svc1log.SafeParam("error", enableNetworkErr))
+	}
+
+	// Set up event listeners for navigation events and network redirects
 	go page.EachEvent(
+		// Capture HTTP redirect responses at the network level
+		func(e *proto.NetworkResponseReceived) {
+
+			// Only capture redirect responses for the main document
+			if e.Type == proto.NetworkResourceTypeDocument && e.Response.Status >= 300 && e.Response.Status < 400 {
+				// Check if request is already complete
+				if atomic.LoadInt32(&completed) == 1 {
+					return
+				}
+
+				// Extract the Location header from the redirect response
+				if location, exists := e.Response.Headers["location"]; exists && location.Str() != "" {
+					locationURL := location.Str()
+					log.Debug("Captured HTTP redirect", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL), svc1log.SafeParam("status", e.Response.Status))
+
+					// Add the redirect destination to the chain if not already present
+					exists := false
+					for _, url := range *redirectChain {
+						if url == locationURL {
+							exists = true
+							break
+						}
+					}
+					if !exists {
+						*redirectChain = append(*redirectChain, locationURL)
+						log.Debug("Added redirect URL to chain", svc1log.SafeParam("url", locationURL))
+					}
+				}
+			}
+		},
 		func(e *proto.PageFrameNavigated) {
 			// Check if request is already complete
 			if atomic.LoadInt32(&completed) == 1 {


### PR DESCRIPTION
### TL;DR

Improved route discovery with enhanced parameter handling, redirect tracking, and increased default spider depth.

### What changed?

- Increased default spider depth from 1 to 3 and max redirects from 10 to 100
- Enhanced query parameter handling in HTML anchor links extraction
- Improved route merging by normalizing root paths ("/" and "" are treated as equivalent)
- Added deduplication of example values in query and body parameters
- Implemented redirect chain analysis to extract routes with parameters
- Added comprehensive parameter URL building to test all discovered parameter values
- Improved URL parsing to preserve query parameters during route discovery
- Enhanced headless browser navigation to better capture HTTP redirects

### How to test?

1. Run route discovery with the new default settings:
   ```
   ./browserbase discover route <target>
   ```

2. Test with complex web applications that use query parameters and redirects

3. Verify that routes with query parameters are properly captured and that the spider reaches deeper into the application structure

4. Check that redirects are properly followed and their parameters are extracted

### Why make this change?

The previous implementation had limitations in discovering routes with query parameters and didn't fully analyze redirect chains. By increasing the spider depth and improving parameter handling, the tool can now discover more routes and provide better coverage of web applications. The deduplication of parameter values and normalization of paths also improves the quality of the discovered routes by eliminating redundant information.