### PR TITLE
Update Web Buster

### DIFF
--- a/fern/definition/discover/directory.yml
+++ b/fern/definition/discover/directory.yml
@@ -4,13 +4,13 @@ types:
   # Wordlist Enums
   WordlistType:
     enum:
-      - directories
-      - files
+      - DIRECTORIES
+      - FILES
   WordlistSize:
     enum:
-      - small
-      - medium
-      - large
+      - SMALL
+      - MEDIUM
+      - LARGE
   # Config Struct
   DiscoverDirectoryConfig:
     properties:

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -81,7 +81,9 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 
 	// Check for timeout before starting main processing
 	if ctx.Err() != nil {
-		return nil, fmt.Errorf("directory discovery operation timed out after %d seconds", config.MaxRuntime)
+		report.Result = &result
+		report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds before processing started", config.MaxRuntime))
+		return &report, nil
 	}
 
 	// Initialize targets
@@ -90,7 +92,11 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 
 		// Check if context has expired
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("directory discovery operation timed out after %d seconds", config.MaxRuntime)
+			// Return partial results collected so far
+			result.Targets = targets
+			report.Result = &result
+			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during target processing", config.MaxRuntime))
+			return &report, nil
 		}
 
 		// Initialize target info
@@ -139,7 +145,11 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 
 		// Check if context expired during baseline setup
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("directory discovery operation timed out after %d seconds", config.MaxRuntime)
+			// Return partial results collected so far
+			result.Targets = targets
+			report.Result = &result
+			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during baseline setup", config.MaxRuntime))
+			return &report, nil
 		}
 
 		// Multi-threaded request processing
@@ -164,7 +174,16 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 				for _, method := range config.HttpMethods {
 					// Check if context has expired
 					if ctx.Err() != nil {
-						return nil, fmt.Errorf("directory discovery operation timed out after %d seconds", config.MaxRuntime)
+						// Wait for any running goroutines to complete before returning partial results
+						wg.Wait()
+						if len(attempts) > 0 {
+							targetInfo.Attempts = attempts
+							targets = append(targets, &targetInfo)
+						}
+						result.Targets = targets
+						report.Result = &result
+						report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during request processing", config.MaxRuntime))
+						return &report, nil
 					}
 
 					wg.Add(1)
@@ -224,14 +243,18 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 		// Wait for all goroutines to complete
 		wg.Wait()
 
-		// Check if context expired during processing
-		if ctx.Err() != nil {
-			return nil, fmt.Errorf("directory discovery operation timed out after %d seconds", config.MaxRuntime)
-		}
-
+		// Always add results if we have any, even if context expired
 		if len(attempts) > 0 {
 			targetInfo.Attempts = attempts
 			targets = append(targets, &targetInfo)
+		}
+
+		// Check if context expired during processing - still return partial results
+		if ctx.Err() != nil {
+			result.Targets = targets
+			report.Result = &result
+			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during processing, returning partial results", config.MaxRuntime))
+			return &report, nil
 		}
 	}
 


### PR DESCRIPTION
### TL;DR

Updated wordlist enum values to uppercase and improved timeout handling to return partial results instead of errors.

### What changed?

- Changed wordlist enum values in `directory.yml` from lowercase to uppercase:
    - `directories` → `DIRECTORIES`
    - `files` → `FILES`
    - `small` → `SMALL`
    - `medium` → `MEDIUM`
    - `large` → `LARGE`
- Modified timeout handling in `directory.go` to return partial results with error messages instead of failing completely
- Added more specific timeout error messages that indicate which stage of processing was interrupted
- Ensured that any collected data is returned to the user even when timeouts occur