### PR TITLE
Remove status code matcher from reflected SSTI template

### DIFF
--- a/utils/nuclei/templates/pentest/dast/ssti/reflected-ssti.yaml
+++ b/utils/nuclei/templates/pentest/dast/ssti/reflected-ssti.yaml
@@ -30,13 +30,8 @@ http:
         fuzz:
           - "{{injection}}"
 
-    matchers-condition: and
     matchers:
       - type: word
         part: body
         words:
           - "{{result}}"
-      - type: regex
-        part: status
-        regex:
-          - "^2[0-9]{2}$"


### PR DESCRIPTION
### TL;DR

Simplified the matcher logic in the reflected-ssti.yaml template by removing the status code check.

### What changed?

- Removed the `matchers-condition: and` line since it's no longer needed with only one matcher
- Removed the regex matcher that was checking for 2xx status codes
- Kept only the essential word matcher that verifies the presence of the expected result in the response body

### How to test?

1. Run the nuclei scanner with the updated template against a test environment
2. Verify that SSTI vulnerabilities are still properly detected without false negatives
3. Confirm that removing the status code check doesn't introduce false positives

### Why make this change?

The status code check was redundant since we're already verifying the presence of the expected payload result in the response body. This simplification makes the template more efficient while maintaining its effectiveness in detecting Server-Side Template Injection vulnerabilities.