### PR TITLE
Update Commands to Use URLs with Query Parameters

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.16.0
+        uses: anchore/sbom-action/download-syft@v0.17.8
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -186,7 +186,9 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.17.8
+        uses: anchore/sbom-action/download-syft@v0.16.0
+        with:
+          syft-version: v1.17.0
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:

--- a/.goreleaser/goreleaser-publish.yml
+++ b/.goreleaser/goreleaser-publish.yml
@@ -3,15 +3,8 @@ version: 2
 project_name: webscan
 
 builds:
-  - id: main
-    binary: webscan
-    main: .
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    ldflags:
-      - -s -w
-      - -X github.com/method-security/webscan/main.version={{.Version}}
-    env:
-      - CGO_ENABLED=1
+  - id: prebuilt
+    builder: prebuilt
     goos:
       - linux
       - darwin
@@ -26,6 +19,9 @@ builds:
         goarch: arm64
       - goos: darwin
         goarch: amd64
+    prebuilt:
+      path: output/build-{{ .Os }}_{{ .Arch }}/webscan{{ if eq .Os "windows" }}.exe{{ end }}
+    binary: webscan
 
 archives:
   - id: archive
@@ -60,7 +56,7 @@ dockers:
     goos: linux
     goarch: amd64
     ids:
-      - main
+      - prebuilt
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=An on-rails Webscan enumeration tool"
@@ -83,7 +79,7 @@ dockers:
     goos: linux
     goarch: arm64
     ids:
-      - main
+      - prebuilt
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=An on-rails Webscan enumeration tool"
@@ -117,14 +113,9 @@ docker_manifests:
     - 'methodsecurity/webscan:{{ .Version }}-arm64'
 
 sboms:
-  - artifacts: binary
-    cmd: syft
-    args:
-      - "file:{{ .ArtifactPath }}"
-      - "--output"
-      - "spdx-json={{ .ArtifactName }}.sbom.json"
-    env:
-      - SYFT_CHECK_FOR_APP_UPDATE=false
+  - artifacts: archive
+  - id: source
+    artifacts: source
 
 signs:
   - cmd: cosign

--- a/.goreleaser/goreleaser-publish.yml
+++ b/.goreleaser/goreleaser-publish.yml
@@ -3,8 +3,15 @@ version: 2
 project_name: webscan
 
 builds:
-  - id: prebuilt
-    builder: prebuilt
+  - id: main
+    binary: webscan
+    main: .
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags:
+      - -s -w
+      - -X github.com/method-security/webscan/main.version={{.Version}}
+    env:
+      - CGO_ENABLED=1
     goos:
       - linux
       - darwin
@@ -19,9 +26,6 @@ builds:
         goarch: arm64
       - goos: darwin
         goarch: amd64
-    prebuilt:
-      path: output/build-{{ .Os }}_{{ .Arch }}/webscan{{ if eq .Os "windows" }}.exe{{ end }}
-    binary: webscan
 
 archives:
   - id: archive
@@ -56,7 +60,7 @@ dockers:
     goos: linux
     goarch: amd64
     ids:
-      - prebuilt
+      - main
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=An on-rails Webscan enumeration tool"
@@ -79,7 +83,7 @@ dockers:
     goos: linux
     goarch: arm64
     ids:
-      - prebuilt
+      - main
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=An on-rails Webscan enumeration tool"
@@ -113,9 +117,14 @@ docker_manifests:
     - 'methodsecurity/webscan:{{ .Version }}-arm64'
 
 sboms:
-  - artifacts: archive
-  - id: source
-    artifacts: source
+  - artifacts: binary
+    cmd: syft
+    args:
+      - "file:{{ .ArtifactPath }}"
+      - "--output"
+      - "spdx-json={{ .ArtifactName }}.sbom.json"
+    env:
+      - SYFT_CHECK_FOR_APP_UPDATE=false
 
 signs:
   - cmd: cosign

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -88,6 +88,9 @@ func run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 				var requestParams common.HttpRequestParams
 				if module.RequestParams != nil {
 					requestParams = *module.RequestParams
+				}
+				// Always set query parameters if they exist
+				if queryParams != nil {
 					requestParams.Query = queryParams
 				}
 

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -48,7 +48,7 @@ func run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 		return []*discover.ApplicationFingerprintAttempt{}, []string{"invalid config: no modules found for resource type"}
 	}
 
-	baseURL, parsedTargetPath, err := requesthelpers.SplitTargetURL(target)
+	baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(target)
 	if err != nil {
 		return []*discover.ApplicationFingerprintAttempt{}, []string{err.Error()}
 	}

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -48,7 +48,7 @@ func run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 		return []*discover.ApplicationFingerprintAttempt{}, []string{"invalid config: no modules found for resource type"}
 	}
 
-	baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(target)
+	baseURL, parsedTargetPath, queryParams, err := requesthelpers.SplitTargetURL(target)
 	if err != nil {
 		return []*discover.ApplicationFingerprintAttempt{}, []string{err.Error()}
 	}
@@ -88,6 +88,7 @@ func run(ctx context.Context, target string, config *discover.DiscoverApplicatio
 				var requestParams common.HttpRequestParams
 				if module.RequestParams != nil {
 					requestParams = *module.RequestParams
+					requestParams.Query = queryParams
 				}
 
 				// set request config

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -103,7 +103,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 		targetInfo := discover.DirectoryTargetInfo{Target: target, BaselineAttempts: []*common.HttpRequestResponse{}}
 
 		// Split target
-		baseURL, parsedTargetPath, err := requesthelpers.SplitTargetURL(target)
+		baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(target)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to split target url: %v", err))
 			report.Errors = errors

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -15,12 +15,14 @@ import (
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 )
 
-func getHTTPRequestConfig(baseURL string, path string, config discover.DiscoverPageConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
+func getHTTPRequestConfig(baseURL string, path string, queryParams map[string]string, config discover.DiscoverPageConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
 		Method:  common.HttpMethodGet,
-		Params:  &common.HttpRequestParams{},
+		Params: &common.HttpRequestParams{
+			Query: queryParams,
+		},
 	}
 	return common.SendHttpRequestConfig{
 		Request:            &request,
@@ -46,7 +48,7 @@ func PerformPageCapture(
 	report := discover.DiscoverPageReport{Config: &config, Result: &result}
 
 	// Split target
-	baseURL, path, err := requesthelpers.SplitTargetURL(config.Target)
+	baseURL, path, queryParams, err := requesthelpers.SplitTargetURL(config.Target)
 	if err != nil {
 		errors = append(errors, err.Error())
 		report.Errors = errors
@@ -54,7 +56,7 @@ func PerformPageCapture(
 	}
 
 	// Get request config
-	requestConfig := getHTTPRequestConfig(baseURL, path, config, browserbaseSecrets)
+	requestConfig := getHTTPRequestConfig(baseURL, path, queryParams, config, browserbaseSecrets)
 
 	// Perform screenshot capture if enabled
 	if config.Screenshot {

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -14,12 +14,14 @@ import (
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 )
 
-func createSendHTTPRequestConfig(baseURL, path string, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]string, config *discover.DiscoverProbeConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
 		Method:  common.HttpMethodGet,
-		Params:  &common.HttpRequestParams{},
+		Params: &common.HttpRequestParams{
+			Query: queryParams,
+		},
 	}
 	return common.SendHttpRequestConfig{
 		Request:            &request,
@@ -38,12 +40,12 @@ func sendRequestWithProtocol(ctx context.Context, target string, protocol string
 	sanitizedTarget := requesthelpers.RemoveScheme(target)
 	fullURL := protocol + "://" + sanitizedTarget
 
-	baseURL, path, err := requesthelpers.SplitTargetURL(fullURL)
+	baseURL, path, queryParams, err := requesthelpers.SplitTargetURL(fullURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid address %s: %v", fullURL, err)
 	}
 
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, config, browserbaseSecrets)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, config, browserbaseSecrets)
 	httpRequestResponse, err := request.SendRequest(ctx, requestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to probe %s - %s", fullURL, err)

--- a/internal/discover/saas/active/active.go
+++ b/internal/discover/saas/active/active.go
@@ -146,7 +146,7 @@ func LaunchDiscoverSaas(ctx context.Context, config discover.DiscoverSaasConfig,
 						fullURL := fmt.Sprintf("%s://%s", schema, slug)
 
 						// Construct the full URL
-						baseURL, path, err := requesthelpers.SplitTargetURL(fullURL)
+						baseURL, path, _, err := requesthelpers.SplitTargetURL(fullURL)
 						if err != nil {
 							errorsMutex.Lock()
 							errors = append(errors, fmt.Sprintf("invalid address %s: %v", fullURL, err))

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -236,7 +236,7 @@ func isLikelySpecURL(url string) bool {
 // First checks if target is a Swagger UI page, then uses headless if needed,
 // otherwise falls back to trying common endpoint paths.
 func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPath string) (string, []byte, map[string]interface{}, error) {
-	baseURL, parsedTargetPath, err := requesthelpers.SplitTargetURL(target)
+	baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(target)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to split target URL: %w", err)
 	}

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -121,7 +121,7 @@ func scanTarget(ctx context.Context, url string, config *enumeratecmswordpressfe
 	errors := []string{}
 
 	// Send initial request
-	baseURL, path, err := requesthelpers.SplitTargetURL(url)
+	baseURL, path, _, err := requesthelpers.SplitTargetURL(url)
 	if err != nil {
 		errors = append(errors, err.Error())
 		return result, errors
@@ -227,7 +227,7 @@ func checkWordPressAPI(ctx context.Context, url string, config *enumeratecmsword
 	errors := []string{}
 
 	// Check main REST API endpoint
-	baseURL, path, err := requesthelpers.SplitTargetURL(url)
+	baseURL, path, _, err := requesthelpers.SplitTargetURL(url)
 	if err != nil {
 		errors = append(errors, err.Error())
 		return pluginsList, errors
@@ -394,7 +394,7 @@ func checkReadmeFiles(ctx context.Context, url string, config *enumeratecmswordp
 
 	// Loop through plugins and check for readme.txt
 	for _, plugin := range config.Plugins {
-		baseURL, path, err := requesthelpers.SplitTargetURL(url)
+		baseURL, path, _, err := requesthelpers.SplitTargetURL(url)
 		if err != nil {
 			errors = append(errors, err.Error())
 			continue

--- a/internal/enumerate/general/ratelimit.go
+++ b/internal/enumerate/general/ratelimit.go
@@ -55,12 +55,14 @@ func getWafFingerprint(httpResponse *common.HttpResponse) *waf.WafFingerprint {
 	return wafFingerprint
 }
 
-func createRateLimitRequestConfig(baseURL, path string, config *enumerategeneralfern.EnumerateRateLimitConfig) common.SendHttpRequestConfig {
+func createRateLimitRequestConfig(baseURL, path string, queryParams map[string]string, config *enumerategeneralfern.EnumerateRateLimitConfig) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
 		Method:  common.HttpMethodGet,
-		Params:  &common.HttpRequestParams{},
+		Params: &common.HttpRequestParams{
+			Query: queryParams,
+		},
 	}
 	return common.SendHttpRequestConfig{
 		Request:            &request,
@@ -85,7 +87,7 @@ func processTarget(ctx context.Context, target string, config *enumerategeneralf
 	targetInfo := &enumerategeneralfern.RateLimitTarget{Target: target, StartTimestamp: time.Now()}
 
 	// Split target URL into base URL and path
-	baseURL, parsedTargetPath, err := requesthelpers.SplitTargetURL(target)
+	baseURL, parsedTargetPath, queryParams, err := requesthelpers.SplitTargetURL(target)
 	if err != nil {
 		errors <- err.Error()
 		return
@@ -139,7 +141,7 @@ requestLoop:
 			log.Warn("Sending ratelimit request", svc1log.SafeParam("requestNumber", reqNum), svc1log.SafeParam("target", target))
 
 			// Create Request Config
-			requestConfig := createRateLimitRequestConfig(baseURL, parsedTargetPath, config)
+			requestConfig := createRateLimitRequestConfig(baseURL, parsedTargetPath, queryParams, config)
 
 			// Send lightweight request directly
 			httpRequestResponse, err := standard.SendStandardRequest(ctx, requestConfig)

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -42,7 +42,7 @@ func PerformAppEnumerateKube(ctx context.Context, config *enumeratekubefern.Enum
 	var errors []string
 
 	// Split target URL into base URL and path
-	baseURL, parsedTargetPath, err := requesthelpers.SplitTargetURL(config.Target)
+	baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(config.Target)
 	if err != nil {
 		errors = append(errors, err.Error())
 		report.Errors = errors

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -57,7 +57,7 @@ func PerformWordpressXMLRPCFunctionsExposed(ctx context.Context, config pentestc
 		targetInfo := pentestcmswordpressfern.XmlrpcFunctionsExposedTarget{Target: target}
 
 		// Split target
-		baseURL, path, err := requesthelpers.SplitTargetURL(target)
+		baseURL, path, _, err := requesthelpers.SplitTargetURL(target)
 		if err != nil {
 			errors = append(errors, err.Error())
 			continue

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -25,12 +25,14 @@ import (
 )
 
 // createSendHTTPRequestConfig creates a request config for seeing whats returned from a static asset
-func createSendHTTPRequestConfig(targetBaseURL, targetPath string, config pentestroutefern.PentestRouteStaticAssetTakeoverConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(targetBaseURL, targetPath string, queryParams map[string]string, config pentestroutefern.PentestRouteStaticAssetTakeoverConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) common.SendHttpRequestConfig {
 	httpRequest := common.HttpRequest{
 		BaseUrl: targetBaseURL,
 		Path:    targetPath,
 		Method:  common.HttpMethodGet,
-		Params:  &common.HttpRequestParams{},
+		Params: &common.HttpRequestParams{
+			Query: queryParams,
+		},
 	}
 	requestConfig := common.SendHttpRequestConfig{
 		Request:            &httpRequest,
@@ -154,7 +156,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 
 	// Split and standardize the target
 	log.Info("Splitting and standardizing the target", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
-	targetBaseURL, targetPath, err := requesthelpers.SplitTargetURL(config.RouteCaptureConfig.Target)
+	targetBaseURL, targetPath, queryParams, err := requesthelpers.SplitTargetURL(config.RouteCaptureConfig.Target)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error splitting target: %s", err))
 		report.Errors = errors
@@ -164,7 +166,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 
 	// Send the request
 	log.Info("Sending request to the target", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
-	requestConfig := createSendHTTPRequestConfig(targetBaseURL, targetPath, config, browserbaseSecrets)
+	requestConfig := createSendHTTPRequestConfig(targetBaseURL, targetPath, queryParams, config, browserbaseSecrets)
 	httpRequestResponse, err := request.SendRequest(ctx, requestConfig)
 	if err != nil {
 		errors = append(errors, fmt.Sprintf("error performing request: %s", err))
@@ -184,7 +186,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 		StaticAssetTakeOverAttempt := pentestroutefern.StaticAssetTakeoverStaticRequest{StaticAsset: staticAsset}
 
 		// Perform Request
-		staticAssetBaseURL, staticAssetPath, err := requesthelpers.SplitTargetURL(staticAsset)
+		staticAssetBaseURL, staticAssetPath, queryParams, err := requesthelpers.SplitTargetURL(staticAsset)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("error splitting target: %s", err))
 			continue
@@ -196,7 +198,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 		config.RouteCaptureConfig.MaxRedirects = 0 // Don't follow any redirects on static asset requests
 		config.RouteCaptureConfig.HeadlessConfig = nil
 		config.RouteCaptureConfig.BrowserbaseConfig = nil
-		requestConfig := createSendHTTPRequestConfig(staticAssetBaseURL, staticAssetPath, config, nil)
+		requestConfig := createSendHTTPRequestConfig(staticAssetBaseURL, staticAssetPath, queryParams, config, nil)
 		result, err := request.SendRequest(ctx, requestConfig)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("error performing request: %s", err))

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -102,7 +102,7 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	}
 
 	// Marshal Request Struct
-	baseURL, _, err := requesthelpers.SplitTargetURL(ev.URL)
+	baseURL, _, _, err := requesthelpers.SplitTargetURL(ev.URL)
 	if err != nil {
 		// If we can't parse the URL, still include what we can
 		request.BaseUrl = ev.URL

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -24,11 +24,11 @@ func RemoveScheme(url string) string {
 	return url
 }
 
-// SplitTargetURL splits a target URL and standardizes it into its base URL and path components.
-func SplitTargetURL(target string) (string, string, error) {
+// SplitTargetURL splits a target URL and standardizes it into its base URL, path, and query parameter components.
+func SplitTargetURL(target string) (string, string, map[string]string, error) {
 	parsedURL, err := url.Parse(target)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing URL: %w", err)
+		return "", "", nil, fmt.Errorf("error parsing URL: %w", err)
 	}
 
 	// Standardize the base URL (ie. http://example.com:8080/ -> http://example.com:8080)
@@ -42,7 +42,21 @@ func SplitTargetURL(target string) (string, string, error) {
 		path = fmt.Sprintf("/%s", path)
 	}
 
-	return baseURL, path, nil
+	// Parse query parameters
+	var queryParams map[string]string
+	if parsedURL.RawQuery != "" {
+		queryParams = make(map[string]string)
+		values, err := url.ParseQuery(parsedURL.RawQuery)
+		if err == nil {
+			for key, vals := range values {
+				if len(vals) > 0 {
+					queryParams[key] = vals[0] // Use first value if multiple values exist
+				}
+			}
+		}
+	}
+
+	return baseURL, path, queryParams, nil
 }
 
 // GetHeaderValueFromHeaderMap extracts a single header value from response header map.


### PR DESCRIPTION
### TL;DR

- Enhanced URL parsing to properly handle query parameters in requests.
- Updated CI/CD

### What changed?

Updated the `SplitTargetURL` function to extract and return query parameters from URLs. The function now returns three values instead of two: base URL, path, and a map of query parameters. All calls to this function across the codebase have been updated to handle the new return value.

Modified request creation functions in various modules to include the extracted query parameters in the HTTP requests, ensuring that query parameters from the original target URLs are properly preserved when making requests.

In the CI/CD workflow, specified Syft version v1.17.0 in the reusable-build.yml file.