### PR TITLE
Take Screenshots on SaaS Applications

### DIFF
--- a/fern/definition/discover/saas.yml
+++ b/fern/definition/discover/saas.yml
@@ -36,6 +36,7 @@ types:
   SaasActiveRequest:
     properties:
       request: http.HttpRequestResponse
+      screenshot: optional<base64>
       findings: optional<SaasActiveFinding>
   SaasActiveCompany:
     properties:

--- a/internal/discover/saas/active/active.go
+++ b/internal/discover/saas/active/active.go
@@ -13,7 +13,9 @@ import (
 	discover "github.com/Method-Security/webscan/generated/go/discover"
 
 	// Internal
+	discoverpage "github.com/Method-Security/webscan/internal/discover/page/helpers"
 	discoversaashelpers "github.com/Method-Security/webscan/internal/discover/saas/active/helpers"
+
 	// Utils
 	request "github.com/Method-Security/webscan/utils/request"
 	"github.com/Method-Security/webscan/utils/request/headless"
@@ -170,6 +172,26 @@ func LaunchDiscoverSaas(ctx context.Context, config discover.DiscoverSaasConfig,
 
 						// Add request if company or sso page is found (Positive hit)
 						if discoversaashelpers.ShouldAddRequest(saasRequest) {
+							// Capture screenshot for positive hits if using headless method
+							if config.RequestMethod == common.RequestMethodHeadless && sharedBrowser != nil {
+								log.Info("Capturing screenshot for positive hit", svc1log.SafeParam("url", fullURL))
+
+								// Create a headless requester with the shared browser for screenshot
+								screenshotRequester := &headless.Requester{
+									Browser:                    sharedBrowser,
+									TimeoutSeconds:             config.Timeout,
+									MinDOMStabalizeTimeSeconds: config.HeadlessConfig.MinDomStabalizeTime,
+								}
+
+								screenshotBytes, err := discoverpage.CaptureScreenshot(ctx, screenshotRequester, &httpConfig)
+								if err != nil {
+									log.Warn("Failed to capture screenshot", svc1log.SafeParam("url", fullURL), svc1log.SafeParam("error", err.Error()))
+								} else {
+									saasRequest.Screenshot = &screenshotBytes
+									log.Info("Screenshot captured successfully", svc1log.SafeParam("url", fullURL))
+								}
+							}
+
 							requestsChan <- saasRequest
 						}
 					}(domainSlug, schema)

--- a/internal/discover/saas/active/active.go
+++ b/internal/discover/saas/active/active.go
@@ -13,7 +13,7 @@ import (
 	discover "github.com/Method-Security/webscan/generated/go/discover"
 
 	// Internal
-	discoverpage "github.com/Method-Security/webscan/internal/discover/page/helpers"
+	pagehelpers "github.com/Method-Security/webscan/internal/discover/page/helpers"
 	discoversaashelpers "github.com/Method-Security/webscan/internal/discover/saas/active/helpers"
 
 	// Utils
@@ -183,7 +183,7 @@ func LaunchDiscoverSaas(ctx context.Context, config discover.DiscoverSaasConfig,
 									MinDOMStabalizeTimeSeconds: config.HeadlessConfig.MinDomStabalizeTime,
 								}
 
-								screenshotBytes, err := discoverpage.CaptureScreenshot(ctx, screenshotRequester, &httpConfig)
+								screenshotBytes, err := pagehelpers.CaptureScreenshot(ctx, screenshotRequester, &httpConfig)
 								if err != nil {
 									log.Warn("Failed to capture screenshot", svc1log.SafeParam("url", fullURL), svc1log.SafeParam("error", err.Error()))
 								} else {


### PR DESCRIPTION
### TL;DR

Added screenshot capture capability for positive SaaS discovery hits when using headless browser mode.

### What changed?

- Added an optional `screenshot` field of type `base64` to the `SaasActiveRequest` type in the API definition
- Implemented screenshot capture functionality for positive SaaS discovery hits when using the headless browser method
- The screenshot is only captured when a company or SSO page is found (positive hit) and the request method is set to headless
- Added error handling for screenshot capture failures
