### PR TITLE
Static Asset: Detect 404 Flag

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -523,6 +523,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			detect404Responses, err := cmd.Flags().GetBool("detect-404-responses")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			successfulOnly, err := cmd.Flags().GetBool("successful-only")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -557,7 +562,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprintPaths, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprintPaths, detect404Responses, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -569,6 +574,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("target", "", "URL target to analyze for static asset takeover")
 	// Config Flags
 	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json"}, "Paths to fingerprint definition files")
+	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("detect-404-responses", false, "Detect 404 responses as potential takeover responses")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("successful-only", false, "Only show successful takeover attempts")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
@@ -773,7 +779,7 @@ func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, succes
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, detect404Responses bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
@@ -792,6 +798,7 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 	config := pentestroutefern.PentestRouteStaticAssetTakeoverConfig{
 		RouteCaptureConfig:   routeCaptureConfig,
 		FingerprintFilePaths: fingerprintFilePaths,
+		Detect404Responses:   detect404Responses,
 		SuccessfulOnly:       successfulOnly,
 	}
 

--- a/configs/pentest/route/static_asset_takeover.json
+++ b/configs/pentest/route/static_asset_takeover.json
@@ -3,31 +3,31 @@
       {
         "name": "Amazon S3",
         "description": "DNS record points to an Amazon S3 bucket that no longer exists.",
-        "responseBody": ["NoSuchBucket", "The specified bucket does not exist"],
+        "responseBody": ["nosuchbucket", "the specified bucket does not exist"],
         "statusCode": 404
       },
       {
         "name": "Azure Blob Storage",
         "description": "DNS record points to an Azure Blob Storage container that has been deleted or never created.",
-        "responseBody": ["ResourceNotFound", "The specified resource does not exist."],
+        "responseBody": ["resourcenotfound", "the specified resource does not exist."],
         "statusCode": 404
       },
       {
         "name": "Azure Edge CDN",
         "description": "DNS record points to an Azure Edge CDN (Azure Front Door) that has been deleted or never created.",
-        "responseBody": ["The resource you are looking for has been removed, had its name changed, or is temporarily unavailable."],
+        "responseBody": ["the resource you are looking for has been removed, had its name changed, or is temporarily unavailable."],
         "statusCode": 404
       },
       {
         "name": "GitHub Pages",
         "description": "Domain is configured for a GitHub Pages site that does not exist or has been removed.",
-        "responseBody": ["This is not the web page you are looking for", "There isn't a GitHub Pages site here"],
+        "responseBody": ["this is not the web page you are looking for", "there isn't a github pages site here"],
         "statusCode": 404
       },
       {
         "name": "CloudFront",
         "description": "Domain is pointing to an AWS CloudFront distribution that has been deleted or is misconfigured.",
-        "responseBody": ["The request could not be satisfied"],
+        "responseBody": ["the request could not be satisfied"],
         "statusCode": 403
       }
     ]

--- a/fern/definition/pentest/route/staticassettakeover.yml
+++ b/fern/definition/pentest/route/staticassettakeover.yml
@@ -8,12 +8,13 @@ types:
       routeCaptureConfig: route.DiscoverRouteConfig
       successfulOnly: boolean
       fingerprintFilePaths: list<string>
+      detect404Responses: boolean
   # Fingerprint File Struct
   StaticAssetTakeoverFingerprint:
     properties:
       name: string
       description: string
-      responseBody: list<string>
+      responseBody: optional<list<string>>
       statusCode: integer
   # Report Struct
   StaticAssetTakeoverVulnerableDetails:

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -48,8 +48,8 @@ func createSendHTTPRequestConfig(targetBaseURL, targetPath string, queryParams m
 	return requestConfig
 }
 
-// GrabStaticAssetTakeOverFingerprints grabs the fingerprints from the given file paths
-func GrabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePaths []string) []*pentestroutefern.StaticAssetTakeoverFingerprint {
+// grabStaticAssetTakeOverFingerprints grabs the fingerprints from the given file paths
+func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePaths []string) []*pentestroutefern.StaticAssetTakeoverFingerprint {
 	log := svc1log.FromContext(ctx)
 	log.Info("Grabbing static asset take over fingerprints", svc1log.SafeParam("fingerprint_file_paths", fingerprintFilePaths))
 
@@ -88,7 +88,7 @@ func GrabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePat
 }
 
 // isStaticAssetTakeOver checks if the request is vulnerable to static asset take over
-func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.HttpRequestResponse, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint) pentestroutefern.StaticAssetTakeoverVulnerableDetails {
+func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.HttpRequestResponse, fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint, detect404Responses bool) pentestroutefern.StaticAssetTakeoverVulnerableDetails {
 	log := svc1log.FromContext(ctx)
 	log.Info("Checking if static asset is vulnerable to take over", svc1log.SafeParam("fingerprint_length", len(fingerprints)))
 
@@ -118,6 +118,17 @@ func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.Http
 		}
 	}
 
+	// Check if we should detect 404 responses
+	if detect404Responses && *httpRequestResponse.Response.StatusCode == 404 {
+		instance.Vulnerable = true
+		instance.Fingerprint = &pentestroutefern.StaticAssetTakeoverFingerprint{
+			Name:        "404 Response",
+			Description: "404 response detected",
+			StatusCode:  404,
+		}
+		return instance
+	}
+
 	// Return false if we havent detected a fingerprint hit
 	return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
 }
@@ -131,7 +142,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 	log := svc1log.FromContext(ctx)
 	log.Info("Detecting static asset takeovers", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
 
-	fingerprints := GrabStaticAssetTakeOverFingerprints(ctx, config.FingerprintFilePaths)
+	fingerprints := grabStaticAssetTakeOverFingerprints(ctx, config.FingerprintFilePaths)
 	if len(fingerprints) == 0 {
 		errors = append(errors, "no fingerprints found")
 		report.Errors = errors
@@ -148,6 +159,8 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 		report.Result = &result
 		return report
 	}
+
+	log.Info("Detect 404 responses", svc1log.SafeParam("detect_404_responses", config.Detect404Responses))
 
 	// Initialize the result
 	attempt := pentestroutefern.StaticAssetTakeoverTest{
@@ -208,7 +221,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 
 		// Check if the request is vulnerable
 		log.Info("Performing static asset take over check", svc1log.SafeParam("static_asset", staticAsset))
-		info := isStaticAssetTakeOver(ctx, result, fingerprints)
+		info := isStaticAssetTakeOver(ctx, result, fingerprints, config.Detect404Responses)
 		if info.Vulnerable || !config.SuccessfulOnly {
 			StaticAssetTakeOverAttempt.VulnerableDetails = &info
 			StaticAssetTakeOverAttempts = append(StaticAssetTakeOverAttempts, &StaticAssetTakeOverAttempt)


### PR DESCRIPTION
### TL;DR

Added a new feature to detect 404 responses as potential static asset takeover vulnerabilities.

### What changed?

- Added a new `--detect-404-responses` flag to the static asset takeover command
- Updated the `PentestRouteStaticAssetTakeoverConfig` struct to include the new `Detect404Responses` boolean field
- Modified the `isStaticAssetTakeOver` function to check for 404 responses when the flag is enabled
- Made the `responseBody` field optional in the `StaticAssetTakeoverFingerprint` struct
- Renamed `GrabStaticAssetTakeOverFingerprints` to `grabStaticAssetTakeOverFingerprints` to make it a private function