### PR TITLE
Updated Nuclei Engine to Return all Requests from Matching Pair instead of final

### DIFF
--- a/fern/definition/common/nuclei/report.yml
+++ b/fern/definition/common/nuclei/report.yml
@@ -33,7 +33,8 @@ types:
   NucleiAttemptInfo:
     properties:
       templateId: string # Nuclei template ID
-      httpRequestResponse: http.HttpRequestResponse
+      httpRequestResponse: http.HttpRequestResponse # Primary/matching request-response
+      supportingHttpRequestResponses: optional<list<http.HttpRequestResponse>> # All requests from template execution
       finding: optional<NucleiFindingInfo>
   NucleiTargetInfo:
     properties:

--- a/utils/nuclei/report/builder.go
+++ b/utils/nuclei/report/builder.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"sync"
 	// Generated
+	common "github.com/Method-Security/webscan/generated/go/common"
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 )
 
@@ -14,13 +15,17 @@ type Builder struct {
 	targets   []*nuclei.NucleiTargetInfo
 	probeIdx  map[string]*nuclei.NucleiProbe      // template-id → Probe
 	targetIdx map[string]*nuclei.NucleiTargetInfo // host/baseURL → TargetInfo
+
+	// Request collection for templates with multiple HTTP requests
+	pendingRequests map[string][]*common.HttpRequestResponse // template-id:target → requests
 }
 
 // NewBuilder creates and returns a new Builder instance.
 func NewBuilder() *Builder {
 	return &Builder{
-		targets:   []*nuclei.NucleiTargetInfo{},
-		probeIdx:  make(map[string]*nuclei.NucleiProbe),
-		targetIdx: make(map[string]*nuclei.NucleiTargetInfo),
+		targets:         []*nuclei.NucleiTargetInfo{},
+		probeIdx:        make(map[string]*nuclei.NucleiProbe),
+		targetIdx:       make(map[string]*nuclei.NucleiTargetInfo),
+		pendingRequests: make(map[string][]*common.HttpRequestResponse),
 	}
 }

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
+	common "github.com/Method-Security/webscan/generated/go/common"
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 
+	// Utils
+	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	// External
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -239,11 +243,59 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		b.targets = append(b.targets, targetInfo)
 	}
 
-	// Build attempt information
+	// Build request-response for this event
 	httpReqResp, _ := getHTTPRequestResponse(ev)
+
+	// Create unique key for template+target combination
+	requestKey := ev.TemplateID + ":" + baseURL
+
+	// Always collect this request for potential multi-request templates
+	b.pendingRequests[requestKey] = append(b.pendingRequests[requestKey], httpReqResp)
+
+	// Only create an attempt if this is a positive match
+	if !ev.MatcherStatus {
+		return
+	}
+
+	// This is a positive match - collect all requests for this template+target
+	allRequests := b.pendingRequests[requestKey]
+
+	// Extract all HTTP requests from the metadata if available
+	// This contains all the HTTP requests from the template execution
+	var allHTTPRequestResponses []*common.HttpRequestResponse
+	if ev.Metadata != nil {
+		if allReqs, ok := ev.Metadata["all_http_requests"].([]map[string]string); ok && len(allReqs) > 0 {
+			// Convert from Nuclei format to our common format
+			for _, req := range allReqs {
+				// Parse the request and response to create our HttpRequestResponse
+				parsedReq := b.parseNucleiHTTPRequest(req, baseURL)
+				if parsedReq != nil {
+					allHTTPRequestResponses = append(allHTTPRequestResponses, parsedReq)
+				}
+			}
+		} else {
+			// Fallback to the single request we collected
+			allHTTPRequestResponses = allRequests
+		}
+	} else {
+		// Fallback to the single request we collected
+		allHTTPRequestResponses = allRequests
+	}
+
+	// Filter out the matching request from the supporting requests
+	var supportingRequests []*common.HttpRequestResponse
+	for _, req := range allHTTPRequestResponses {
+		// Compare request details to see if this is the matching request
+		if !b.isSameRequest(req, httpReqResp) {
+			supportingRequests = append(supportingRequests, req)
+		}
+	}
+
+	// Build attempt information
 	attemptInfo := &nuclei.NucleiAttemptInfo{
-		TemplateId:          ev.TemplateID,
-		HttpRequestResponse: httpReqResp,
+		TemplateId:                     ev.TemplateID,
+		HttpRequestResponse:            httpReqResp,        // The matching request
+		SupportingHttpRequestResponses: supportingRequests, // All other requests from template execution
 	}
 
 	// Extract vulnerability details from template if present
@@ -335,6 +387,80 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 
 	// Always add the attempt to the report, even if there was an error parsing the request/response
 	targetInfo.Attempts = append(targetInfo.Attempts, attemptInfo)
+
+	// Clean up pending requests for this template+target since we've processed them
+	delete(b.pendingRequests, requestKey)
+}
+
+// parseNucleiHTTPRequest converts a Nuclei HttpRequestResponse to our common format
+func (b *Builder) parseNucleiHTTPRequest(nucleiReq map[string]string, baseURL string) *common.HttpRequestResponse {
+	// Parse the raw request string to extract components
+	method, path, headers, body := parseRawRequest(nucleiReq["request"])
+
+	// Create the request object
+	request := common.HttpRequest{
+		BaseUrl:     baseURL,
+		Path:        path,
+		Params:      &common.HttpRequestParams{},
+		BaseHeaders: singleToMulti(headers),
+		SentAt:      time.Now(), // We don't have the exact time, use current
+	}
+
+	// Set the HTTP method
+	if m, err := common.NewHttpMethodFromString(strings.ToUpper(method)); err == nil {
+		request.Method = m
+	}
+
+	// Parse body if present
+	if body != "" {
+		contentType := "application/x-www-form-urlencoded" // Default
+		if ct, ok := headers["Content-Type"]; ok {
+			contentType = ct
+		}
+		request.Params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
+	}
+
+	// Parse the raw response string to extract components
+	statusCode, responseHeaders, responseBody := parseRawResponse(nucleiReq["response"])
+
+	// Create the response object using the helper function
+	response := requesthelpers.CreateHTTPResponse(statusCode, nil, singleToMulti(responseHeaders), responseBody)
+
+	return &common.HttpRequestResponse{
+		Request:  &request,
+		Response: &response,
+	}
+}
+
+// isSameRequest compares two HTTP request-response pairs to see if they're the same
+func (b *Builder) isSameRequest(req1, req2 *common.HttpRequestResponse) bool {
+	if req1 == nil || req2 == nil {
+		return false
+	}
+	if req1.Request == nil || req2.Request == nil {
+		return false
+	}
+	if req1.Response == nil || req2.Response == nil {
+		return false
+	}
+
+	// Compare request path and method
+	if req1.Request.Path != req2.Request.Path {
+		return false
+	}
+	if req1.Request.Method != req2.Request.Method {
+		return false
+	}
+
+	// Compare response status code
+	if req1.Response.StatusCode == nil || req2.Response.StatusCode == nil {
+		return req1.Response.StatusCode == req2.Response.StatusCode
+	}
+	if *req1.Response.StatusCode != *req2.Response.StatusCode {
+		return false
+	}
+
+	return true
 }
 
 // Final returns the fully-populated Fern report.

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/iis/iis-shortname.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/iis/iis-shortname.yaml
@@ -272,3 +272,4 @@ http:
             (status_code_39 != 200 && status_code_40 == 200)
 
     stop-at-first-match: true
+

--- a/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/operators.go
+++ b/vendor/github.com/projectdiscovery/nuclei/v3/pkg/protocols/http/operators.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -174,6 +175,34 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 	if value, ok := wrapped.InternalEvent["analyzer_details"]; ok {
 		analyzerDetails = value.(string)
 	}
+	// Extract numbered request/response data and add to metadata
+	metadata := wrapped.OperatorsResult.PayloadValues
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+
+	// Look for numbered request/response pairs in the internal event
+	var allHttpRequests []map[string]string
+	for i := 1; i <= 100; i++ { // Check up to 100 requests
+		requestKey := fmt.Sprintf("request_%d", i)
+		responseKey := fmt.Sprintf("response_%d", i)
+
+		if request, hasRequest := wrapped.InternalEvent[requestKey]; hasRequest {
+			if response, hasResponse := wrapped.InternalEvent[responseKey]; hasResponse {
+				allHttpRequests = append(allHttpRequests, map[string]string{
+					"request":  types.ToString(request),
+					"response": types.ToString(response),
+				})
+			}
+		} else {
+			break // No more numbered requests
+		}
+	}
+
+	if len(allHttpRequests) > 0 {
+		metadata["all_http_requests"] = allHttpRequests
+	}
+
 	data := &output.ResultEvent{
 		TemplateID:       types.ToString(wrapped.InternalEvent["template-id"]),
 		TemplatePath:     types.ToString(wrapped.InternalEvent["template-path"]),
@@ -186,7 +215,7 @@ func (request *Request) MakeResultEventItem(wrapped *output.InternalWrappedEvent
 		URL:              fields.URL,
 		Path:             fields.Path,
 		Matched:          types.ToString(wrapped.InternalEvent["matched"]),
-		Metadata:         wrapped.OperatorsResult.PayloadValues,
+		Metadata:         metadata,
 		ExtractedResults: wrapped.OperatorsResult.OutputExtracts,
 		Timestamp:        time.Now(),
 		MatcherStatus:    true,


### PR DESCRIPTION
## TLDR;

Implemented a custom Nuclei Output Module to return all requests. Updated fern to support  
  
\-------- **I THINK WE SHOULD FORK THIS REPO INSTEAD OF DOING A QUICK PATCH** ----------

## Data Example

```

{
    "content": {
        "result": {
            "report": [
                {
                    "target": "http://127.0.0.1:8080",
                    "attempts": [
                        {
                            "templateId": "iis-shortname",
                            "httpRequestResponse": {
                                "request": {
                                    "baseUrl": "http://127.0.0.1:8080",
                                    "path": "/N0t4xist~1/.rem",
                                    "method": "GET",
                                    "baseHeaders": {
                                        "Accept": [
                                            "text/html",
                                            "application/xhtml+xml",
                                            "application/xml;q=0.9",
                                            "image/webp",
                                            "image/apng",
                                            "*/*;q=0.8"
                                        ],
                                        "Accept-Encoding": [
                                            "gzip"
                                        ],
                                        "Connection": [
                                            "close"
                                        ],
                                        "Content-Type": [
                                            "text/plain; charset=utf-8"
                                        ],
                                        "Host": [
                                            "127.0.0.1:8080"
                                        ],
                                        "User-Agent": [
                                            "Mozilla/5.0 (Knoppix; Linux x86_64) AppleWebKit/537.36 (KHTML",
                                            "like Gecko) Chrome/133.0.0.0 Safari/537.36"
                                        ]
                                    },
                                    "params": {},
                                    "sentAt": "2025-09-30T14:16:36-04:00"
                                },
                                "response": {
                                    "statusCode": 200,
                                    "responseHeaders": {
                                        "Connection": [
                                            "close"
                                        ],
                                        "Content-Length": [
                                            "41"
                                        ],
                                        "Content-Type": [
                                            "text/plain; charset=utf-8"
                                        ],
                                        "Date": [
                                            "Tue",
                                            "30 Sep 2025 18:16:36 GMT"
                                        ],
                                        "Server": [
                                            "Werkzeug/3.1.3 Python/3.12.10"
                                        ]
                                    },
                                    "responseBody": {
                                        "value": "VULN-SHORTNAME: matched /N0t4xist~1/.rem\n",
                                        "mimeType": "text/plain",
                                        "kind": "text"
                                    },
                                    "sizeBytes": 41,
                                    "receivedAt": "2025-09-30T14:16:36-04:00"
                                }
                            },
                            "supportingHttpRequestResponses": [
                                {
                                    "request": {
                                        "baseUrl": "http://127.0.0.1:8080",
                                        "path": "/N0t4xist/.rem",
                                        "method": "GET",
                                        "baseHeaders": {
                                            "Accept": [
                                                "text/html",
                                                "application/xhtml+xml",
                                                "application/xml;q=0.9",
                                                "image/webp",
                                                "image/apng",
                                                "*/*;q=0.8"
                                            ],
                                            "Accept-Encoding": [
                                                "gzip"
                                            ],
                                            "Connection": [
                                                "close"
                                            ],
                                            "Host": [
                                                "127.0.0.1:8080"
                                            ],
                                            "User-Agent": [
                                                "Mozilla/5.0 (Knoppix; Linux x86_64) AppleWebKit/537.36 (KHTML",
                                                "like Gecko) Chrome/133.0.0.0 Safari/537.36"
                                            ]
                                        },
                                        "params": {},
                                        "sentAt": "2025-09-30T14:16:36-04:00"
                                    },
                                    "response": {
                                        "statusCode": 404,
                                        "responseHeaders": {
                                            "Connection": [
                                                "close"
                                            ],
                                            "Content-Length": [
                                                "10"
                                            ],
                                            "Content-Type": [
                                                "text/plain; charset=utf-8"
                                            ],
                                            "Date": [
                                                "Tue",
                                                "30 Sep 2025 18:16:36 GMT"
                                            ],
                                            "Server": [
                                                "Werkzeug/3.1.3 Python/3.12.10"
                                            ]
                                        },
                                        "responseBody": {
                                            "value": "Not found\n",
                                            "mimeType": "text/plain",
                                            "kind": "text"
                                        },
                                        "sizeBytes": 10,
                                        "receivedAt": "2025-09-30T14:16:36-04:00"
                                    }
                                }
                            ],
                            "finding": {
                                "name": "IIS - Short Name Detect (expanded canonical-first, full 40 reqs)",
                                "softwareWeakness": "IIS Short Name Disclosure",
                                "description": "Detect IIS short-name (8.3) disclosure using tilde (~) short-name probes. Each test is sent as a pair: a canonical (non-tilde) request followed immediately by the likely short-name (~) counterpart. The matcher flags when the canonical variant fails but the tilde variant succeeds (or has a larger body), indicating a likely disclosure.\n",
                                "reference": [
                                    "https://github.com/lijiejie/IIS_shortname_Scanner",
                                    "https://www.exploit-db.com/exploits/19525",
                                    "http://soroush.secproject.com/blog/2012/06/microsoft-iis-tilde-character-vulnerabilityfeature-short-filefolder-name-disclosure/"
                                ],
                                "classification": {},
                                "severity": "info",
                                "finding": true,
                                "probe": {
                                    "matcherDetails": {
                                        "matcherCondition": "OR",
                                        "matchers": [
                                            {
                                                "type": "dsl",
                                                "part": "",
                                                "values": [
                                                    "(status_code_1 != 200 && status_code_2 == 200) || (body_length_2 > body_length_1)\n",
                                                    "(status_code_3 != 200 && status_code_4 == 200) || (body_length_4 > body_length_3)\n",
                                                    "(status_code_5 != 200 && status_code_6 == 200) || (body_length_6 > body_length_5)\n",
                                                    "(status_code_7 != 200 && status_code_8 == 200) || (body_length_8 > body_length_7)\n",
                                                    "(status_code_9 != 200 && status_code_10 == 200) || (body_length_10 > body_length_9)\n",
                                                    "(status_code_11 != 200 && status_code_12 == 200) || (body_length_12 > body_length_11)\n",
                                                    "(status_code_13 != 200 && status_code_14 == 200) || (body_length_14 > body_length_13)\n",
                                                    "(status_code_15 != 200 && status_code_16 == 200) || (body_length_16 > body_length_15)\n",
                                                    "(status_code_17 != 200 && status_code_18 == 200) || (body_length_18 > body_length_17)\n",
                                                    "(status_code_19 != 200 && status_code_20 == 200) || (body_length_20 > body_length_19)\n",
                                                    "(status_code_21 != 200 && status_code_22 == 200) || (body_length_22 > body_length_21)\n",
                                                    "(status_code_23 != 200 && status_code_24 == 200) || (body_length_24 > body_length_23)\n",
                                                    "(status_code_25 != 200 && status_code_26 == 200) || (body_length_26 > body_length_25)\n",
                                                    "(status_code_27 != 200 && status_code_28 == 200) || (body_length_28 > body_length_27)\n",
                                                    "(status_code_29 != 200 && status_code_30 == 200) || (body_length_30 > body_length_29)\n",
                                                    "(status_code_31 != 200 && status_code_32 == 200) || (body_length_32 > body_length_31)\n",
                                                    "(status_code_33 != 200 && status_code_34 == 200) || (body_length_34 > body_length_33)\n",
                                                    "(status_code_35 != 200 && status_code_36 == 200) || (body_length_36 > body_length_35)\n",
                                                    "(status_code_37 != 200 && status_code_38 == 200) || (body_length_38 > body_length_37)\n",
                                                    "(status_code_39 != 200 && status_code_40 == 200) || (body_length_40 > body_length_39)\n"
                                                ]
                                            }
                                        ]
                                    }
                                }
                            }
                        }
                    ]
                }
            ]
        },
        "config": {
            "targets": [
                "http://127.0.0.1:8080"
            ],
            "technologyTypes": [
                "IIS"
            ],
            "timeout": 30,
            "threads": 10,
            "proxy": "",
            "verboseLogs": true
        }
    },
    "started_at": "2025-09-30T14:16:35.687886-04:00",
    "completed_at": "2025-09-30T14:16:37.505539-04:00",
    "status": 0
}
```