### PR TITLE
GraphQL Signal Bug Fix

### DIFF
--- a/fern/definition/enumerate/apiapplication/graphql.yml
+++ b/fern/definition/enumerate/apiapplication/graphql.yml
@@ -27,7 +27,7 @@ types:
   EnumerateGraphqlConfig:
     properties:
       target: string
-  EnumerateGraphqlResult:
+  EnumerateGraphqlData:
     properties:
       apiType: common.ApiType
       baseEndpointUrl: string
@@ -38,6 +38,9 @@ types:
       security: optional<list<common.SecurityRequirement>>
       queries: optional<list<GraphQlQuery>>
       raw: string
+  EnumerateGraphqlResult:
+    properties:
+      data: optional<EnumerateGraphqlData>
   EnumerateGraphqlReport:
     properties:
       config: EnumerateGraphqlConfig

--- a/internal/enumerate/apiapplication/graphql.go
+++ b/internal/enumerate/apiapplication/graphql.go
@@ -20,6 +20,7 @@ import (
 func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapiapplicationfern.EnumerateGraphqlReport {
 	report := enumerateapiapplicationfern.EnumerateGraphqlReport{Config: &enumerateapiapplicationfern.EnumerateGraphqlConfig{Target: target}}
 	report.Result = &enumerateapiapplicationfern.EnumerateGraphqlResult{}
+	data := &enumerateapiapplicationfern.EnumerateGraphqlData{}
 
 	body, err := fetchGraphQLSchema(target)
 	if err != nil {
@@ -42,15 +43,17 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapi
 		return report
 	}
 
-	// Set result data after all functions succeed
-	report.Result.BaseEndpointUrl = target
-	report.Result.ApiType = enumerateapiapplicationfern.ApiTypeGraphQl
-	report.Result.Raw = base64.StdEncoding.EncodeToString(body)
+	// Set data after all functions succeed
+	data.BaseEndpointUrl = target
+	data.ApiType = enumerateapiapplicationfern.ApiTypeGraphQl
+	data.Raw = base64.StdEncoding.EncodeToString(body)
 
 	typeFields := extractTypeFields(schema)
 
-	populateReportWithQueries(report.Result, schema, typeFields)
+	populateReportWithQueries(data, schema, typeFields)
 
+	// Marshal Report data
+	report.Result.Data = data
 	return report
 }
 
@@ -74,7 +77,7 @@ func fetchGraphQLSchema(target string) ([]byte, error) {
 	// Check if the response looks like HTML instead of JSON
 	bodyStr := strings.TrimSpace(string(body))
 	if strings.HasPrefix(bodyStr, "<") {
-		return nil, fmt.Errorf("endpoint returned HTML instead of JSON (status: %d). This may not be a GraphQL endpoint or it may be at a different path (try /graphql, /api/graphql, /v1/graphql, etc.)", resp.StatusCode)
+		return nil, fmt.Errorf("endpoint returned HTML instead of JSON (status: %d)", resp.StatusCode)
 	}
 
 	// Check for common non-GraphQL responses
@@ -112,7 +115,7 @@ func extractTypeFields(schema enumerateapiapplicationfern.GraphQlSchema) map[str
 	return typeFields
 }
 
-func populateReportWithQueries(report *enumerateapiapplicationfern.EnumerateGraphqlResult, schema enumerateapiapplicationfern.GraphQlSchema, typeFields map[string][]string) {
+func populateReportWithQueries(data *enumerateapiapplicationfern.EnumerateGraphqlData, schema enumerateapiapplicationfern.GraphQlSchema, typeFields map[string][]string) {
 	// Add nil checks to prevent panic
 	if schema.Data == nil || schema.Data.Schema == nil || schema.Data.Schema.Types == nil {
 		return
@@ -126,7 +129,7 @@ func populateReportWithQueries(report *enumerateapiapplicationfern.EnumerateGrap
 						Type:   field.Name,
 						Fields: typeFields[strings.ToLower(field.Name)],
 					}
-					report.Queries = append(report.Queries, &query)
+					data.Queries = append(data.Queries, &query)
 				}
 			}
 		}

--- a/internal/enumerate/apiapplication/graphql.go
+++ b/internal/enumerate/apiapplication/graphql.go
@@ -19,6 +19,7 @@ import (
 // PerformAppEnumerateGraphQL performs a GraphQL scan against a target URL and returns the report.
 func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapiapplicationfern.EnumerateGraphqlReport {
 	report := enumerateapiapplicationfern.EnumerateGraphqlReport{Config: &enumerateapiapplicationfern.EnumerateGraphqlConfig{Target: target}}
+	report.Result = &enumerateapiapplicationfern.EnumerateGraphqlResult{}
 
 	body, err := fetchGraphQLSchema(target)
 	if err != nil {
@@ -34,27 +35,21 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapi
 		return report
 	}
 
-	// Only create the result object if we have valid GraphQL content
-	result := enumerateapiapplicationfern.EnumerateGraphqlResult{
-		BaseEndpointUrl: target,
-		ApiType:         enumerateapiapplicationfern.ApiTypeGraphQl,
-	}
-	report.Result = &result
-
-	result.Raw = base64.StdEncoding.EncodeToString(body)
-
 	var schema enumerateapiapplicationfern.GraphQlSchema
 	if err := json.Unmarshal(body, &schema); err != nil {
 		errMsg := fmt.Errorf("failed to unmarshal schema: %v", err)
 		report.Errors = append(report.Errors, errMsg.Error())
-		// Remove the result since schema parsing failed
-		report.Result = nil
 		return report
 	}
 
+	// Set result data after all functions succeed
+	report.Result.BaseEndpointUrl = target
+	report.Result.ApiType = enumerateapiapplicationfern.ApiTypeGraphQl
+	report.Result.Raw = base64.StdEncoding.EncodeToString(body)
+
 	typeFields := extractTypeFields(schema)
 
-	populateReportWithQueries(&result, schema, typeFields)
+	populateReportWithQueries(report.Result, schema, typeFields)
 
 	return report
 }
@@ -75,7 +70,27 @@ func fetchGraphQLSchema(target string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
+
+	// Check if the response looks like HTML instead of JSON
+	bodyStr := strings.TrimSpace(string(body))
+	if strings.HasPrefix(bodyStr, "<") {
+		return nil, fmt.Errorf("endpoint returned HTML instead of JSON (status: %d). This may not be a GraphQL endpoint or it may be at a different path (try /graphql, /api/graphql, /v1/graphql, etc.)", resp.StatusCode)
+	}
+
+	// Check for common non-GraphQL responses
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("endpoint returned status %d: %s. Response: %s", resp.StatusCode, resp.Status, string(body[:min(len(body), 200)]))
+	}
+
 	return body, nil
+}
+
+// Helper function to get minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func extractTypeFields(schema enumerateapiapplicationfern.GraphQlSchema) map[string][]string {


### PR DESCRIPTION
### TL;DR

Improved GraphQL enumeration with better error handling and response validation.

### What changed?

- Initialize the result object early in the process to avoid nil pointer issues
- Added validation to detect HTML responses instead of JSON when fetching GraphQL schemas
- Added status code checking with more descriptive error messages
- Improved error handling to provide better feedback when an endpoint is not a valid GraphQL endpoint
- Added a helper function `min()` to safely truncate error messages
- Restructured the code to set result data only after successful operations

### How to test?

1. Test the GraphQL enumeration against various endpoints:
   - Valid GraphQL endpoints
   - Endpoints that return HTML instead of JSON
   - Endpoints that return non-200 status codes
   - Endpoints with malformed responses

2. Verify that appropriate error messages are displayed when:
   - The endpoint returns HTML
   - The endpoint returns a non-200 status code
   - The schema cannot be parsed

### Why make this change?

This change improves the robustness of the GraphQL enumeration process by providing clearer error messages when an endpoint is not a valid GraphQL endpoint. It also prevents nil pointer exceptions by initializing the result object early and maintains it throughout the process. The improved validation helps users identify when they might need to try alternative paths for GraphQL endpoints.