### PR TITLE
CMDi Template Matchers Bug Fix

### DIFF
--- a/utils/nuclei/templates/pentest/dast/cmdi/go-code-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/cmdi/go-code-injection.yaml
@@ -69,13 +69,4 @@ http:
         part: body
         regex:
           - "root:.*:0:0:"
-          - "^root:.*:0:0:"
           - "daemon:.*:1:1:"
-          - "nobody:.*:65534:65534:"
-          - "UID=\\d+\\("       # from `id` output like uid=1000(user)
-      - type: word
-        part: body
-        words:
-          - "root:x:"
-          - "uid="
-

--- a/utils/nuclei/templates/pentest/dast/cmdi/java-code-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/cmdi/java-code-injection.yaml
@@ -68,11 +68,4 @@ http:
         regex:
           # Look for /etc/passwd contents and common unix user output
           - "root:.*:0:0:"
-          - "^root:.*:0:0:" 
-          - "uid=\\d+\\("        # from `id` output like uid=1000(user)
           - "daemon:.*:1:1:"     # additional passwd pattern
-      - type: word
-        part: body
-        words:
-          - "root:x:"            # alternative passwd form
-          - "UID="                # some command output variants

--- a/utils/nuclei/templates/pentest/dast/cmdi/python-code-injection.yaml
+++ b/utils/nuclei/templates/pentest/dast/cmdi/python-code-injection.yaml
@@ -50,4 +50,6 @@ http:
         part: body
         regex:
           - "root:.*:0:0:"
+          - "daemon:.*:1:1:"     # additional passwd pattern
+          
 # digest: 490a00463044022064ced5a02135a5ba8b7c175805059e306f3733d3bbf857549147c9c0ccbd384002201c08821cca27e513e75cac1aac095d5b3a88042240da35c639097b520cc3e448:922c64590222798bb761d5b6d8e72950


### PR DESCRIPTION
### TL;DR

Refined command injection detection patterns in Go, Java, and Python code injection templates.

### What changed?

- **Go template**: Removed redundant regex patterns (`^root:.*:0:0:`, `nobody:.*:65534:65534:`, `UID=\\d+\\(`) and word-based matchers (`root:x:`, `uid=`)
- **Java template**: Removed redundant regex patterns (`^root:.*:0:0:`, `uid=\\d+\\(`) and word-based matchers (`root:x:`, `UID=`)
- **Python template**: Added a new detection pattern for `daemon:.*:1:1:` to improve detection capabilities