### PR TITLE
Application Discover: Add Jenkins Fingerprint

### DIFF
--- a/configs/discover/application/fingerprints.json
+++ b/configs/discover/application/fingerprints.json
@@ -56,6 +56,41 @@
       ]
     },
     {
+      "name": "CI_CD_PLATFORM",
+      "modules": [
+        {
+          "name": "JENKINS",
+          "method": "GET",
+          "paths": [
+            "/",
+            "/login",
+            "/jenkins",
+            "/view/all",
+            "/manage",
+            "/script",
+            "/computer",
+            "/user/admin",
+            "/cli"
+          ],
+          "headerIndicators": {
+            "x-jenkins": [""],
+            "x-hudson": [""],
+            "x-powered-by": ["jenkins"],
+            "server": ["jenkins"]
+          },
+          "bodyIndicators": [
+            "jenkins.model.jenkins",
+            "<title>jenkins</title>",
+            "<h1>jenkins</h1>",
+            "All Jenkins Logs",
+            "Jenkins Dashboard",
+            "Welcome to Jenkins!",
+            "Sign in to Jenkins"
+          ]
+        }
+      ]
+    },
+    {
       "name": "CLOUD_BUCKET",
       "modules": [
         {

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -8,6 +8,7 @@ types:
   ApplicationResourceType:
     enum:
       - API_APPLICATION
+      - CI_CD_PLATFORM
       - CLOUD_BUCKET
       - CONTENT_MANAGEMENT_SYSTEM
       - KUBE


### PR DESCRIPTION
### TL;DR

Added Jenkins CI/CD platform detection to application fingerprinting.

### What changed?

- Added a new `CI_CD_PLATFORM` application resource type to the enum in `application.yml`
- Created fingerprinting rules for Jenkins in `fingerprints.json` with:
  - Common Jenkins URL paths to check
  - Header indicators like `x-jenkins`, `x-hudson`, and Jenkins server headers
  - Body indicators to detect Jenkins-specific content in responses
