### PR TITLE
Remove Modules Flag as not Implemented

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -58,11 +58,6 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			modules, err := cmd.Flags().GetStringSlice("modules")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			timeout, err := cmd.Flags().GetInt("timeout")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -89,7 +84,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, modules, timeout, threads, proxy, verboseLogs)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, timeout, threads, proxy, verboseLogs)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -106,7 +101,6 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().StringSlice("targets", []string{}, "URL targets to perform fingerprinting against")
 	// Config Flags
 	discoverApplicationCmd.Flags().String("resource-type", "ALL", "Type of resource to fingerprint (e.g., web, api, cms)")
-	discoverApplicationCmd.Flags().StringSlice("modules", []string{}, "Specific fingerprinting modules to run")
 	discoverApplicationCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverApplicationCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
@@ -669,7 +663,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums []string, timeout int, threads int, proxy string, verboseLogs bool) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, timeout int, threads int, proxy string, verboseLogs bool) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -678,7 +672,6 @@ func getDiscoverApplicationConfig(targets []string, resource string, moduleEnums
 	config := &discover.DiscoverApplicationConfig{
 		Targets:      targets,
 		ResourceType: &resourceEnum,
-		Modules:      moduleEnums,
 		Timeout:      max(timeout, 0),
 		Threads:      max(threads, 0),
 		Proxy:        &proxy,

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -24,7 +24,6 @@ types:
     properties:
       targets: list<string>
       resourceType: ApplicationResourceConfigType
-      modules: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -55,7 +55,7 @@ func convertNucleiAttemptToFingerprintAttemptStruct(nucleiAttempt *nuclei.Nuclei
 func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover.DiscoverApplicationConfig) (nuclei.NucleiConfig, error) {
 	log := svc1log.FromContext(ctx)
 
-	// Get template paths based on resource type, modules, and request methods
+	// Get template paths based on resource type
 	templatePaths, err := getTemplatePaths(config.ResourceType)
 	if err != nil {
 		log.Error("Failed to get template paths", svc1log.SafeParam("error", err.Error()))
@@ -87,7 +87,10 @@ func LaunchFingerprintEngine(ctx context.Context, config *discover.DiscoverAppli
 	log.Info("Starting application fingerprinting engine",
 		svc1log.SafeParam("targets", config.Targets),
 		svc1log.SafeParam("resourceType", config.ResourceType),
-		svc1log.SafeParam("modules", config.Modules))
+		svc1log.SafeParam("timeout", config.Timeout),
+		svc1log.SafeParam("threads", config.Threads),
+		svc1log.SafeParam("proxy", config.Proxy),
+		svc1log.SafeParam("verboseLogs", config.VerboseLogs))
 
 	// Create the nuclei config
 	nucleiConfig, err := createDiscoverApplicationNucleiConfig(ctx, config)

--- a/internal/discover/application/helpers.go
+++ b/internal/discover/application/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Method-Security/webscan/generated/go/discover"
 )
 
-// getTemplatePaths creates template paths for Nuclei scanning based on resource type, modules, and request methods
+// getTemplatePaths creates template paths for Nuclei scanning based on resource type
 // This replaces the old fingerprints.json approach with direct template path selection
 func getTemplatePaths(resourceConfigType *discover.ApplicationResourceConfigType) ([]string, error) {
 	// Get all supported resource types


### PR DESCRIPTION
### TL;DR

Removed the unused `modules` parameter from the application discovery functionality.

### What changed?

- Removed the `modules` flag from the discover command
- Removed the `modules` parameter from the `getDiscoverApplicationConfig` function
- Removed the `modules` field from the `DiscoverApplicationConfig` type in the Fern definition
- Updated function documentation to remove references to modules
- Enhanced logging in the `LaunchFingerprintEngine` function to include more configuration details