### PR TITLE
Add New VMware Templates

### DIFF
--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -11,8 +11,10 @@ types:
       - CI_CD_PLATFORM
       - CLOUD_BUCKET
       - CONTENT_MANAGEMENT_SYSTEM
+      - HYPERVISOR
       - KUBE
       - VDI_APPLICATION
+      - VIRTUAL_COMPUTE
       - WEB_SERVER
   ApplicationResourceConfigType:
     discriminated: false

--- a/internal/discover/application/helpers.go
+++ b/internal/discover/application/helpers.go
@@ -16,8 +16,10 @@ func getTemplatePaths(resourceConfigType *discover.ApplicationResourceConfigType
 		discover.ApplicationResourceTypeCiCdPlatform,
 		discover.ApplicationResourceTypeCloudBucket,
 		discover.ApplicationResourceTypeContentManagementSystem,
+		discover.ApplicationResourceTypeHypervisor,
 		discover.ApplicationResourceTypeKube,
 		discover.ApplicationResourceTypeVdiApplication,
+		discover.ApplicationResourceTypeVirtualCompute,
 		discover.ApplicationResourceTypeWebServer,
 	}
 
@@ -27,8 +29,10 @@ func getTemplatePaths(resourceConfigType *discover.ApplicationResourceConfigType
 		discover.ApplicationResourceTypeCiCdPlatform:            "cicd",
 		discover.ApplicationResourceTypeCloudBucket:             "cloud",
 		discover.ApplicationResourceTypeContentManagementSystem: "cms",
+		discover.ApplicationResourceTypeHypervisor:              "hypervisor",
 		discover.ApplicationResourceTypeKube:                    "kube",
 		discover.ApplicationResourceTypeVdiApplication:          "vdiapplication",
+		discover.ApplicationResourceTypeVirtualCompute: "virutalcompute",
 		discover.ApplicationResourceTypeWebServer:               "webserver",
 	}
 

--- a/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
+++ b/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
@@ -1,0 +1,62 @@
+id: vmware-esxi-detect
+
+info:
+  name: VMware ESXi Detect
+  author: method-security
+  severity: info
+  classification:
+    cpe: cpe:2.3:o:vmware:esxi:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    vendor: vmware
+    product: esxi
+    shodan-query:
+      - product:"VMware ESXi"
+      - "VMware ESXi"
+      - html:"ID_EESX_Welcome"
+      - html:"ID_EESX"
+    category: hypervisor
+    method-application-type: HYPERVISOR
+    method-module-name: VMWARE_ESXI
+  tags:
+    - tech
+    - vmware
+    - esxi
+    - hypervisor
+    - virtualization
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/ui/"
+      - "{{BaseURL}}/folder"
+      - "{{BaseURL}}/mob/"
+      - "{{BaseURL}}/folder?dcPath=ha-datacenter"
+    redirects: true
+    max-redirects: 3
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "VMware ESXi"
+          - "ID_EESX_Welcome"
+          - "ID_EESX"
+          - "ID_ESX_VIClientDesc"
+          - "ID_DownloadHClientWin"
+          - "ID_OpenEHC"
+        case-insensitive: true
+      - type: word
+        part: header
+        words:
+          - "VMware ESXi"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - '(?i)VMware\s+ESXi\s+is\s+virtual\s+infrastructure\s+software'
+          - '(?i)ID_ESX_VIClientDesc'
+          - '(?i)ID_VIRCLI'
+          - '(?i)VMware\s+ESXi\s+provides\s+a\s+highly\s+scalable'

--- a/utils/nuclei/templates/discover/application/virutalcompute/vmware-vsphere.yaml
+++ b/utils/nuclei/templates/discover/application/virutalcompute/vmware-vsphere.yaml
@@ -1,0 +1,59 @@
+id: vmware-vsphere-detect
+
+info:
+  name: VMware vSphere Detect
+  author: method-security
+  severity: info
+  classification:
+    cpe: cpe:2.3:a:vmware:vcenter_server:*:*:*:*:*:*:*:*
+  metadata:
+    verified: true
+    vendor: vmware
+    product: vcenter_server
+    shodan-query:
+      - product:"VMware vCenter Server"
+      - "VMware vSphere"
+      - html:"vsphere-client"
+      - html:"ID_VC_Welcome"
+    category: virtual-compute-application
+    method-application-type: VIRTUAL_COMPUTE
+    method-module-name: VMWARE_VSPHERE
+  tags:
+    - tech
+    - vmware
+    - vsphere
+    - vcenter
+    - virtual-compute
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/vsphere-client/"
+      - "{{BaseURL}}/ui/"
+      - "{{BaseURL}}/folder"
+      - "{{BaseURL}}/mob/"
+    redirects: true
+    max-redirects: 3
+    stop-at-first-match: true
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "VMware vSphere"
+          - "VMware vCenter Server"
+          - "ID_VC_Welcome"
+          - "VMware VirtualCenter"
+        case-insensitive: true
+      - type: word
+        part: header
+        words:
+          - "VMware vCenter Server"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - '(?i)VMware\s+vSphere\s+\d+'
+          - '(?i)alt="VMware vSphere'
+          - '(?i)ID_LogInFlexClient'
+          - '(?i)BrowseVCDatacenters'


### PR DESCRIPTION
### TL;DR

Added support for detecting VMware ESXi hypervisor and VMware vSphere virtual compute environments.

### What changed?

- Added two new application resource types: `HYPERVISOR` and `VIRTUAL_COMPUTE` to the application definition
- Updated the template paths in the application helpers to support these new resource types
- Added two new Nuclei templates:
  - `vmware-esxi.yaml` for detecting VMware ESXi hypervisor environments
  - `vmware-vsphere.yaml` for detecting VMware vSphere virtual compute environments