### PR TITLE
Standarize Templates (Redirects, Content, & Whitespace) + Updates

### DIFF
--- a/utils/nuclei/templates/discover/application/apiapplication/graphql.yaml
+++ b/utils/nuclei/templates/discover/application/apiapplication/graphql.yaml
@@ -1,21 +1,13 @@
 id: graphql-detect
 info:
   name: GraphQL API Detection
-  author: method.security
+  author: method-security
   severity: info
-  description: |
-    Detects GraphQL endpoints by sending an introspection-style POST query to common
-    GraphQL paths and checking for typical GraphQL responses.
-  reference:
-    - https://graphql.org/learn/introspection/
-  classification:
-    cpe: cpe:2.3:a:graphql:graphql:*:*:*:*:*:*:*:*
+  description: Detects GraphQL endpoints by sending an introspection-style POST query to common GraphQL paths
   metadata:
     method-application-type: API_APPLICATION
     method-module-name: GRAPHQL
-    category: api
-    confidence: 90
-  tags: tech, graphql, api, introspection
+  tags: discovery,graphql,api
 http:
   - method: POST
     path:
@@ -38,10 +30,9 @@ http:
     headers:
       Content-Type: application/json
     body: '{"query": "{ __schema { queryType { name } } }"}'
-    stop-at-first-match: true
     redirects: true
-    max-redirects: 2
-    matchers-condition: or
+    max-redirects: 5
+    stop-at-first-match: true
     matchers:
       - type: word
         part: body
@@ -49,4 +40,4 @@ http:
           - "__schema"
           - "queryType"
         condition: and
-        name: graphql-introspection
+        case-insensitive: true

--- a/utils/nuclei/templates/discover/application/apiapplication/swagger.yaml
+++ b/utils/nuclei/templates/discover/application/apiapplication/swagger.yaml
@@ -1,24 +1,13 @@
 id: discover-swagger
 info:
   name: Public Swagger / OpenAPI - Detect
-  author: pdteam, c-sh0, AmirHossein Raeisi, method.security
+  author: method-security
   severity: info
-  description: |
-    Detects public Swagger / OpenAPI documentation and specification endpoints by probing
-    common UI and spec paths and checking for header or body fingerprints that indicate
-    exposed Swagger or OpenAPI definitions.
-  reference:
-    - https://swagger.io/
-  classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cwe-id: CWE-200
+  description: Detects public Swagger / OpenAPI documentation and specification endpoints
   metadata:
     method-application-type: API_APPLICATION
     method-module-name: SWAGGER
-    shodan-query: http.title:"swagger"
-    category: api
-    confidence: 85
-  tags: discovery, exposure, api, swagger, openapi
+  tags: discovery,swagger,openapi,api
 http:
   - method: GET
     path:
@@ -36,26 +25,23 @@ http:
       - "{{BaseURL}}/api-docs/swagger.yaml"
       - "{{BaseURL}}/docs"
       - "{{BaseURL}}/swagger"
-    stop-at-first-match: true
     redirects: true
-    max-redirects: 2
-    matchers-condition: or
+    max-redirects: 5
+    stop-at-first-match: true
     matchers:
       - type: regex
-        name: swagger-header-fingerprints
         part: header
         regex:
-          - '(?i)x-powered-by:\s*swagger'
-          - '(?i)x-generator:\s*(swagger codegen|openapi generator)'
-          - '(?i)server:\s*swagger'
+          - "(?i)x-powered-by:\\s*swagger"
+          - "(?i)x-generator:\\s*(swagger codegen|openapi generator)"
+          - "(?i)server:\\s*swagger"
       - type: word
-        name: swagger-body-fingerprints
         part: body
         words:
-          - '<div id="swagger-ui">'
-          - '<title>Swagger UI</title>'
-          - 'window.ui = SwaggerUIBundle'
-          - 'SwaggerUIBundle('
-          - 'swagger-ui-init.js'
-          - 'swagger-ui.css'
+          - "<div id=\"swagger-ui\">"
+          - "<title>Swagger UI</title>"
+          - "window.ui = SwaggerUIBundle"
+          - "SwaggerUIBundle("
+          - "swagger-ui-init.js"
+          - "swagger-ui.css"
         case-insensitive: true

--- a/utils/nuclei/templates/discover/application/cicd/jenkins.yaml
+++ b/utils/nuclei/templates/discover/application/cicd/jenkins.yaml
@@ -42,4 +42,3 @@ http:
     regex:
       - '(?i)<title>Jenkins(?:\s+Dashboard)?</title>'
       - '(?i)Jenkins\s*(?:Login|Dashboard|User\s*Interface)'
-      - '(?i)href=.*?/jenkins(?:/|\\b)'

--- a/utils/nuclei/templates/discover/application/cicd/jenkins.yaml
+++ b/utils/nuclei/templates/discover/application/cicd/jenkins.yaml
@@ -1,44 +1,29 @@
 id: jenkins-detect
 info:
   name: Jenkins Detection
-  author: philippdelteil,daffainfo,c-sh0,AdamCrosser 
+  author: method-security
   severity: info
-  reference:
-  - https://www.jenkins.io/doc/book/using/remote-access-api/#RemoteaccessAPI-DetectingJenkinsversion
-  - https://github.com/jenkinsci/jenkins/pull/470
-  - https://www.jenkins.io/doc/book/security/access-control/permissions/#access-granted-without-overallread
-  classification:
-    cpe: cpe:2.3:a:jenkins:jenkins:*:*:*:*:*:*:*:*
+  description: Detects Jenkins CI/CD installations by analyzing response headers and content
   metadata:
-    vendor: jenkins
-    product: jenkins
-    shodan-query:
-    - http.favicon.hash:81586312
-    - cpe:"cpe:2.3:a:jenkins:jenkins"
-    - product:"jenkins"
-    category: devops
-    fofa-query: icon_hash=81586312
-    method-application-type: CI_CD_PLATFORM
+    method-application-type: CICD
     method-module-name: JENKINS
-  tags: tech,jenkins,detect
+  tags: discovery,jenkins,cicd
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/whoAmI/'
-  host-redirects: true
-  max-redirects: 2
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - x-jenkins
-    case-insensitive: true
-  - type: regex
-    name: jenkins-body-detect
-    part: body
-    regex:
-      - '(?i)<title>Jenkins(?:\s+Dashboard)?</title>'
-      - '(?i)Jenkins\s*(?:Login|Dashboard|User\s*Interface)'
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/whoAmI/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "x-jenkins"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)<title>Jenkins(?:\\s+Dashboard)?</title>"
+          - "(?i)Jenkins\\s*(?:Login|Dashboard|User\\s*Interface)"

--- a/utils/nuclei/templates/discover/application/cloud/aws-s3.yaml
+++ b/utils/nuclei/templates/discover/application/cloud/aws-s3.yaml
@@ -13,22 +13,16 @@ http:
     path:
       - "{{BaseURL}}"
     stop-at-first-match: true
-    matchers-condition: or
+    matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
       - type: word
         part: header
         words:
           - "server: AmazonS3"
           - "x-amz-bucket-region"
-        case-insensitive: true
-      - type: word
-        part: body
-        words:
-          - "<Code>NoSuchBucket</Code>"
-          - "<Code>AccessDenied</Code>"
-          - "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-          - "Amazon S3"
-          - "BucketAlreadyExists"
         case-insensitive: true
 
 

--- a/utils/nuclei/templates/discover/application/cloud/aws-s3.yaml
+++ b/utils/nuclei/templates/discover/application/cloud/aws-s3.yaml
@@ -5,24 +5,25 @@ info:
   severity: info
   description: Detects AWS S3 bucket endpoints
   metadata:
-    method-application-type: CLOUD_BUCKET # Added by method-security
-    method-module-name: AWSS3 # Added by method-security
-  tags: discovery,aws,s3,cloud,bucket
+    method-application-type: CLOUD_BUCKET
+    method-module-name: AWSS3
+  tags: discovery,aws,s3,cloud
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 5
     stop-at-first-match: true
     matchers-condition: and
     matchers:
       - type: status
         status:
           - 200
+          - 403
       - type: word
         part: header
         words:
-          - "server: AmazonS3"
           - "x-amz-bucket-region"
+          - "Server: AmazonS3"
         case-insensitive: true
-
-

--- a/utils/nuclei/templates/discover/application/cloud/azure-blob.yaml
+++ b/utils/nuclei/templates/discover/application/cloud/azure-blob.yaml
@@ -13,18 +13,15 @@ http:
   path:
   - '{{BaseURL}}'
   stop-at-first-match: true
-  matchers-condition: or
+  matchers-condition: and
   matchers:
+  - type: status
+    status:
+    - 200
   - type: word
     part: header
     words:
     - 'server: blob'
     - x-ms-blob-type
     - x-ms-version
-    case-insensitive: true
-  - type: word
-    part: body
-    words:
-    - blobnotfound
-    - microsoft azure blob storage
     case-insensitive: true

--- a/utils/nuclei/templates/discover/application/cloud/azure-blob.yaml
+++ b/utils/nuclei/templates/discover/application/cloud/azure-blob.yaml
@@ -7,21 +7,24 @@ info:
   metadata:
     method-application-type: CLOUD_BUCKET
     method-module-name: AZUREBLOB
-  tags: discovery,azure,blob,cloud,storage
+  tags: discovery,azure,blob,cloud
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  stop-at-first-match: true
-  matchers-condition: and
-  matchers:
-  - type: status
-    status:
-    - 200
-  - type: word
-    part: header
-    words:
-    - 'server: blob'
-    - x-ms-blob-type
-    - x-ms-version
-    case-insensitive: true
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 403
+      - type: word
+        part: header
+        words:
+          - "server: blob"
+          - "x-ms-blob-type"
+          - "x-ms-version"
+        case-insensitive: true

--- a/utils/nuclei/templates/discover/application/cms/drupal.yaml
+++ b/utils/nuclei/templates/discover/application/cms/drupal.yaml
@@ -1,23 +1,13 @@
 id: drupal-detect
-
 info:
   name: Drupal - Detect
-  author: 1nf1n7y,pathtaga # updated by method-security
+  author: method-security
   severity: info
-  classification:
-    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
-    cwe-id: CWE-200
-    cpe: cpe:2.3:a:drupal:drupal:*:*:*:*:*:*:*:*
+  description: Detects Drupal CMS installations by analyzing response headers and content patterns
   metadata:
-    verified: true
-    vendor: drupal
-    product: drupal
-    shodan-query:
-      - http.component:"drupal"
-      - cpe:"cpe:2.3:a:drupal:drupal"
-    method-application-type: CONTENT_MANAGEMENT_SYSTEM
+    method-application-type: CMS
     method-module-name: DRUPAL
-  tags: tech,drupal
+  tags: discovery,drupal,cms
 http:
   - method: GET
     path:
@@ -25,25 +15,26 @@ http:
       - "{{BaseURL}}/CHANGELOG.txt"
       - "{{BaseURL}}/core/install.php"
       - "{{BaseURL}}/user/login"
+    redirects: true
+    max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: or
     matchers:
       - type: word
         part: body
         words:
-          - 'Initial release'
-          - 'Drupal 1.0.0'
+          - "Initial release"
+          - "Drupal 1.0.0"
         condition: and
         case-insensitive: true
       - type: word
         part: body
         words:
-          - 'content="Drupal'
+          - "content=\"Drupal"
+          - "Welcome to Drupal"
         case-insensitive: true
-      - type: regex
+      - type: word
         part: header
-        regex:
-          - '(?i)x-drupal'
-          - "(?i)x-generator: drupal"
-
-
+        words:
+          - "x-drupal"
+          - "x-generator: drupal"
+        case-insensitive: true

--- a/utils/nuclei/templates/discover/application/cms/ghost.yaml
+++ b/utils/nuclei/templates/discover/application/cms/ghost.yaml
@@ -3,37 +3,34 @@ info:
   name: Ghost CMS Detection
   author: method-security
   severity: info
-  description: Detects Ghost CMS installations by analyzing response headers, body
-    content, and common paths
-  reference: https://ghost.org/
+  description: Detects Ghost CMS installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: CONTENT_MANAGEMENT_SYSTEM
+    method-application-type: CMS
     method-module-name: GHOST
-  tags: tech,ghost,cms
+  tags: discovery,ghost,cms
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/admin'
-  - '{{BaseURL}}/ghost/api/v3/admin/'
-  - '{{BaseURL}}/content/themes/'
-  - '{{BaseURL}}/assets/ghost.js'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'x-powered-by: ghost'
-    case-insensitive: true
-  - type: word
-    part: body
-    words:
-    - /assets/ghost.js
-    - powered by ghost
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)ghost.*?version.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)content="ghost\s+[0-9]+\.[0-9]+"
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/admin"
+      - "{{BaseURL}}/ghost/api/v3/admin/"
+      - "{{BaseURL}}/content/themes/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "x-powered-by: ghost"
+        case-insensitive: true
+      - type: word
+        part: body
+        words:
+          - "powered by ghost"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)ghost.*?version.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)content=\"ghost\\s+[0-9]+\\.[0-9]+\""

--- a/utils/nuclei/templates/discover/application/cms/joomla.yaml
+++ b/utils/nuclei/templates/discover/application/cms/joomla.yaml
@@ -3,48 +3,44 @@ info:
   name: Joomla CMS Detection
   author: method-security
   severity: info
-  description: Detects Joomla CMS installations by analyzing response headers, body
-    content, and common paths
-  reference: https://www.joomla.org/
+  description: Detects Joomla CMS installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: CONTENT_MANAGEMENT_SYSTEM
+    method-application-type: CMS
     method-module-name: JOOMLA
-  tags: tech,joomla,cms
+  tags: discovery,joomla,cms
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/administrator'
-  - '{{BaseURL}}/administrator/index.php'
-  - '{{BaseURL}}/language/en-GB/en-GB.xml'
-  - '{{BaseURL}}/templates/system/css/system.css'
-  - '{{BaseURL}}/media/system/js/core.js'
-  - '{{BaseURL}}/plugins/system/'
-  - '{{BaseURL}}/components/com_content/'
-  - '{{BaseURL}}/modules/mod_menu/'
-  - '{{BaseURL}}/cache/'
-  - '{{BaseURL}}/tmp/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'x-content-encoded-by: joomla'
-    - 'x-powered-by: joomla'
-    condition: or
-    case-insensitive: true
-  - type: word
-    part: body
-    words:
-    - generator" content="joomla
-    - joomla_version
-    - powered by joomla
-    condition: or
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)joomla!?.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)generator.*?joomla!?\s+[0-9]+\.[0-9]+
-    condition: or
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/administrator"
+      - "{{BaseURL}}/administrator/index.php"
+      - "{{BaseURL}}/language/en-GB/en-GB.xml"
+      - "{{BaseURL}}/templates/system/css/system.css"
+      - "{{BaseURL}}/media/system/js/core.js"
+      - "{{BaseURL}}/plugins/system/"
+      - "{{BaseURL}}/components/com_content/"
+      - "{{BaseURL}}/modules/mod_menu/"
+      - "{{BaseURL}}/cache/"
+      - "{{BaseURL}}/tmp/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "x-content-encoded-by: joomla"
+          - "x-powered-by: joomla"
+        case-insensitive: true
+      - type: word
+        part: body
+        words:
+          - "generator\" content=\"joomla"
+          - "joomla_version"
+          - "powered by joomla"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)joomla!?.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)generator.*?joomla!?\\s+[0-9]+\\.[0-9]+"

--- a/utils/nuclei/templates/discover/application/cms/modx.yaml
+++ b/utils/nuclei/templates/discover/application/cms/modx.yaml
@@ -3,46 +3,45 @@ info:
   name: MODX CMS Detection
   author: method-security
   severity: info
-  description: Detects MODX CMS installations by analyzing response headers, body
-    content, and common paths
-  reference: https://modx.com/
+  description: Detects MODX CMS installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: CONTENT_MANAGEMENT_SYSTEM
+    method-application-type: CMS
     method-module-name: MODX
-  tags: tech,modx,cms
+  tags: discovery,modx,cms
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/manager'
-  - '{{BaseURL}}/manager/index.php'
-  - '{{BaseURL}}/core/docs/changelog.txt'
-  - '{{BaseURL}}/assets/components/'
-  - '{{BaseURL}}/core/lexicon/'
-  - '{{BaseURL}}/connectors/'
-  - '{{BaseURL}}/setup/'
-  - '{{BaseURL}}/core/model/'
-  - '{{BaseURL}}/assets/templates/'
-  - '{{BaseURL}}/core/cache/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'x-powered-by: modx'
-    case-insensitive: true
-  - type: word
-    part: body
-    words:
-    - modx_assets_url
-    - modx_base_url
-    - modx_manager_url
-    - x-modx-version
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)modx.*?revolution.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)generator.*?modx.*?[0-9]+\.[0-9]+
-    - (?i)modx_[a-zA-Z0-9_]+_url
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/manager"
+      - "{{BaseURL}}/manager/index.php"
+      - "{{BaseURL}}/core/docs/changelog.txt"
+      - "{{BaseURL}}/assets/components/"
+      - "{{BaseURL}}/core/lexicon/"
+      - "{{BaseURL}}/connectors/"
+      - "{{BaseURL}}/setup/"
+      - "{{BaseURL}}/core/model/"
+      - "{{BaseURL}}/assets/templates/"
+      - "{{BaseURL}}/core/cache/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "x-powered-by: modx"
+        case-insensitive: true
+      - type: word
+        part: body
+        words:
+          - "modx_assets_url"
+          - "modx_base_url"
+          - "modx_manager_url"
+          - "x-modx-version"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)modx.*?revolution.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)generator.*?modx.*?[0-9]+\\.[0-9]+"
+          - "(?i)modx_[a-zA-Z0-9_]+_url"

--- a/utils/nuclei/templates/discover/application/cms/wordpress.yaml
+++ b/utils/nuclei/templates/discover/application/cms/wordpress.yaml
@@ -1,28 +1,13 @@
 id: wordpress-detect
-
 info:
   name: WordPress Detect
-  author: pdteam,daffainfo,ricardomaia,topscoder,AdamCrosser,method-security
+  author: method-security
   severity: info
-  classification:
-    cpe: cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*
+  description: Detects WordPress CMS installations by analyzing response headers and content patterns
   metadata:
-    verified: true
-    vendor: wordpress
-    product: wordpress
-    shodan-query:
-      - http.component:"WordPress"
-      - http.component:"wordpress"
-      - cpe:"cpe:2.3:a:wordpress:wordpress"
-    category: cms
-    method-application-type: CONTENT_MANAGEMENT_SYSTEM
+    method-application-type: CMS
     method-module-name: WORDPRESS
-  tags:
-    - tech
-    - wordpress
-    - cms
-    - wp
-
+  tags: discovery,wordpress,cms
 http:
   - method: GET
     path:
@@ -31,29 +16,32 @@ http:
       - "{{BaseURL}}/feed/"
       - "{{BaseURL}}/?feed=rss2"
     redirects: true
-    max-redirects: 2
+    max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: or
     matchers:
-      - type: regex
+      - type: word
         part: header
-        regex:
-          - '(?i)x-powered-by:\s*wordpress'
-          - '(?i)link:\s*<https?:\/\/.*\/wp-json\/>'
-          - '(?i)x-redirect-by:\s*WordPress'
+        words:
+          - "wp engine"
+          - "wordpress"
+          - "xmlrpc.php"
+        case-insensitive: true
+      - type: word
+        part: header
+        words:
+          - "wp-json"
+          - "wp engine"
+          - "wordpress"
+        case-insensitive: true
       - type: word
         part: body
         words:
-          - wp-content
-          - wp-includes
-          - wp-login.php
-          - xmlrpc.php
-          - wp-json
+          - "\"generator\" content=\"wordpress"
+          - "/wp-admin/load-scripts.php"
+          - "/wp-admin/admin-ajax.php"
+          - "id=\"wp-admin-bar"
+          - "wp-emoji-release.min.js"
+          - "/wp-json/"
+          - "var wpApiSettings ="
+          - "window._wpemojisettings"
         case-insensitive: true
-      - type: regex
-        part: body
-        regex:
-          - '(?i)<generator>.*wordpress\.org.*</generator>'
-          - '(?i)<!--[^>]*(Yoast|WP-Super-Cache)[^>]*-->'
-          - '/wp-content/uploads/'
-          - '(?i)yoast\.com/wordpress/plugins/seo'

--- a/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
+++ b/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
@@ -10,11 +10,6 @@ info:
     verified: true
     vendor: vmware
     product: esxi
-    shodan-query:
-      - product:"VMware ESXi"
-      - "VMware ESXi"
-      - html:"VMware Host Client"
-      - html:"esxui"
     category: hypervisor
     method-application-type: HYPERVISOR
     method-module-name: VMWARE_ESXI

--- a/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
+++ b/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
@@ -3,22 +3,11 @@ info:
   name: VMware ESXi Detection
   author: method-security
   severity: info
-  description: Detects VMware ESXi web interfaces (including UI and MOB endpoints).
-  classification:
-    cpe: cpe:2.3:o:vmware:esxi:*:*:*:*:*:*:*:*
+  description: Detects VMware ESXi web interfaces (including UI and MOB endpoints)
   metadata:
-    verified: true
-    vendor: vmware
-    product: esxi
-    category: hypervisor
     method-application-type: HYPERVISOR
     method-module-name: VMWARE_ESXI
-  tags:
-    - tech
-    - vmware
-    - esxi
-    - hypervisor
-    - virtualization
+  tags: discovery,vmware,esxi,hypervisor
 http:
   - method: GET
     path:
@@ -28,9 +17,8 @@ http:
       - "{{BaseURL}}/folder"
       - "{{BaseURL}}/folder?dcPath=ha-datacenter"
     redirects: true
-    max-redirects: 3
+    max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: or
     matchers:
       - type: word
         part: body

--- a/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
+++ b/utils/nuclei/templates/discover/application/hypervisor/vmware-esxi.yaml
@@ -1,9 +1,9 @@
 id: vmware-esxi-detect
-
 info:
-  name: VMware ESXi Detect
+  name: VMware ESXi Detection
   author: method-security
   severity: info
+  description: Detects VMware ESXi web interfaces (including UI and MOB endpoints).
   classification:
     cpe: cpe:2.3:o:vmware:esxi:*:*:*:*:*:*:*:*
   metadata:
@@ -13,8 +13,8 @@ info:
     shodan-query:
       - product:"VMware ESXi"
       - "VMware ESXi"
-      - html:"ID_EESX_Welcome"
-      - html:"ID_EESX"
+      - html:"VMware Host Client"
+      - html:"esxui"
     category: hypervisor
     method-application-type: HYPERVISOR
     method-module-name: VMWARE_ESXI
@@ -24,14 +24,13 @@ info:
     - esxi
     - hypervisor
     - virtualization
-
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
       - "{{BaseURL}}/ui/"
-      - "{{BaseURL}}/folder"
       - "{{BaseURL}}/mob/"
+      - "{{BaseURL}}/folder"
       - "{{BaseURL}}/folder?dcPath=ha-datacenter"
     redirects: true
     max-redirects: 3
@@ -42,21 +41,11 @@ http:
         part: body
         words:
           - "VMware ESXi"
-          - "ID_EESX_Welcome"
-          - "ID_EESX"
-          - "ID_ESX_VIClientDesc"
-          - "ID_DownloadHClientWin"
-          - "ID_OpenEHC"
+          - "ESXi Embedded Host Client"
         case-insensitive: true
       - type: word
         part: header
         words:
           - "VMware ESXi"
+          - "Server: VMware"
         case-insensitive: true
-      - type: regex
-        part: body
-        regex:
-          - '(?i)VMware\s+ESXi\s+is\s+virtual\s+infrastructure\s+software'
-          - '(?i)ID_ESX_VIClientDesc'
-          - '(?i)ID_VIRCLI'
-          - '(?i)VMware\s+ESXi\s+provides\s+a\s+highly\s+scalable'

--- a/utils/nuclei/templates/discover/application/kube/kubernetes.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes.yaml
@@ -19,8 +19,9 @@ http:
       - "{{BaseURL}}/metrics"
       - "{{BaseURL}}/ui"
       - "{{BaseURL}}/api/v1/namespaces"
+    redirects: true
+    max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: or
     matchers:
       - type: word
         part: header
@@ -31,14 +32,14 @@ http:
       - type: word
         part: body
         words:
-          - '"major": "'
-          - '"minor": "'
-          - '"gitVersion": "v'
+          - "\"major\": \""
+          - "\"minor\": \""
+          - "\"gitVersion\": \"v"
         condition: and
+        case-insensitive: true
       - type: word
         part: body
         words:
           - "Kubernetes Dashboard"
           - "k8s-app=kubernetes-dashboard"
         case-insensitive: true
-

--- a/utils/nuclei/templates/discover/application/vdiapplication/citrix-gateway.yaml
+++ b/utils/nuclei/templates/discover/application/vdiapplication/citrix-gateway.yaml
@@ -3,45 +3,39 @@ info:
   name: Citrix Gateway Detection
   author: method-security
   severity: info
-  description: Detects Citrix Gateway (NetScaler Gateway) installations by analyzing
-    response headers, body content, and common paths
-  reference: https://www.citrix.com/products/citrix-gateway/
+  description: Detects Citrix Gateway (NetScaler Gateway) installations by analyzing response headers, body content, and common paths
   metadata:
     method-application-type: VDI_APPLICATION
     method-module-name: CITRIX_GATEWAY
-  tags: tech,citrix,gateway,netscaler,vdi
+  tags: discovery,citrix,gateway,vdi
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/vpn/index.html'
-  - '{{BaseURL}}/xenapp/'
-  - '{{BaseURL}}/XenDesktop/'
-  - '{{BaseURL}}/vpns/'
-  - '{{BaseURL}}/logon/LogonPoint/index.html'
-  redirects: true
-  max-redirects: 5
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-    - type: word
-      part: header
-      words:
-        - "server: netscaler"
-        - "X-Citrix"
-      case-insensitive: true
-
-    - type: word
-      part: body
-      words:
-        - "Citrix Gateway"
-        - "NetScaler Gateway"
-      case-insensitive: true
-
-    - type: regex
-      part: body
-      regex:
-        - (?i)\bCitrix\s+(Access|NetScaler|ADC)?\s*Gateway\b
-        - (?i)\bNetScaler\s+(Access|ADC)?\s*Gateway\b
-        - (?i)\bNSGateway\b
-      condition: or
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/vpn/index.html"
+      - "{{BaseURL}}/xenapp/"
+      - "{{BaseURL}}/XenDesktop/"
+      - "{{BaseURL}}/vpns/"
+      - "{{BaseURL}}/logon/LogonPoint/index.html"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: netscaler"
+          - "X-Citrix"
+        case-insensitive: true
+      - type: word
+        part: body
+        words:
+          - "Citrix Gateway"
+          - "NetScaler Gateway"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)\\bCitrix\\s+(Access|NetScaler|ADC)?\\s*Gateway\\b"
+          - "(?i)\\bNetScaler\\s+(Access|ADC)?\\s*Gateway\\b"
+          - "(?i)\\bNSGateway\\b"

--- a/utils/nuclei/templates/discover/application/vdiapplication/vmware-horizon.yaml
+++ b/utils/nuclei/templates/discover/application/vdiapplication/vmware-horizon.yaml
@@ -3,28 +3,32 @@ info:
   name: VMware Horizon Detection
   author: method-security
   severity: info
-  description: Detects VMware Horizon installations by analyzing response headers,
-    body content, and common paths
-  reference: https://www.vmware.com/products/horizon.html
+  description: Detects VMware Horizon installations by analyzing response headers, body content, and common paths
   metadata:
     method-application-type: VDI_APPLICATION
     method-module-name: VMWARE_HORIZON
-  tags: tech,vmware,horizon,vdi-application
+  tags: discovery,vmware,horizon,vdi
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/portal/'
-  - '{{BaseURL}}/broker/'
-  - '{{BaseURL}}/admin/'
-  - '{{BaseURL}}/portal/webclient/index.html'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: regex
-    part: body
-    regex:
-    - (?i)vmware.*?horizon
-    - (?i)horizon.*?view.*?[0-9]+\.[0-9]+
-    - (?i)horizon.*?(connection|workspace).*?server
-    - (?i)blast.*?secure.*?gateway
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/portal/"
+      - "{{BaseURL}}/broker/"
+      - "{{BaseURL}}/admin/"
+      - "{{BaseURL}}/portal/webclient/index.html"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "VMware Horizon"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)vmware.*?horizon"
+          - "(?i)horizon.*?view.*?[0-9]+\\.[0-9]+"
+          - "(?i)horizon.*?(connection|workspace).*?server"
+          - "(?i)blast.*?secure.*?gateway"

--- a/utils/nuclei/templates/discover/application/vdiapplication/windows-rdp.yaml
+++ b/utils/nuclei/templates/discover/application/vdiapplication/windows-rdp.yaml
@@ -4,29 +4,30 @@ info:
   author: method-security
   severity: info
   description: Detects Windows RDP Gateway and Remote Desktop Web Access installations
-  reference: https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/
   metadata:
     method-application-type: VDI_APPLICATION
     method-module-name: WINDOWS_RDP
-  tags: tech,microsoft,rdp,remote-access,windows,rds
+  tags: discovery,microsoft,rdp,vdi
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/RemoteDesktop/'
-  - '{{BaseURL}}/rpc/rpcproxy.dll'
-  - '{{BaseURL}}/ts/'
-  - '{{BaseURL}}/tsweb/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-      - "X-RDWeb"
-      - "X-Ms-Rdsh-Auth"
-  - type: regex
-    part: body
-    regex:
-      - (?i)<form.*id=.*(loginForm|logonForm)
-      - (?i)RDWeb.*login\.aspx
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/RemoteDesktop/"
+      - "{{BaseURL}}/rpc/rpcproxy.dll"
+      - "{{BaseURL}}/ts/"
+      - "{{BaseURL}}/tsweb/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "X-RDWeb"
+          - "X-Ms-Rdsh-Auth"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)<form.*id=.*(loginForm|logonForm)"
+          - "(?i)RDWeb.*login\\.aspx"

--- a/utils/nuclei/templates/discover/application/virutalcompute/vmware-vsphere.yaml
+++ b/utils/nuclei/templates/discover/application/virutalcompute/vmware-vsphere.yaml
@@ -1,59 +1,39 @@
 id: vmware-vsphere-detect
-
 info:
   name: VMware vSphere Detect
   author: method-security
   severity: info
-  classification:
-    cpe: cpe:2.3:a:vmware:vcenter_server:*:*:*:*:*:*:*:*
+  description: Detects VMware vSphere/vCenter Server installations
   metadata:
-    verified: true
-    vendor: vmware
-    product: vcenter_server
-    shodan-query:
-      - product:"VMware vCenter Server"
-      - "VMware vSphere"
-      - html:"vsphere-client"
-      - html:"ID_VC_Welcome"
-    category: virtual-compute-application
     method-application-type: VIRTUAL_COMPUTE
     method-module-name: VMWARE_VSPHERE
-  tags:
-    - tech
-    - vmware
-    - vsphere
-    - vcenter
-    - virtual-compute
+  tags: discovery,vmware,vsphere,vcenter
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
-      - "{{BaseURL}}/vsphere-client/"
       - "{{BaseURL}}/ui/"
       - "{{BaseURL}}/folder"
       - "{{BaseURL}}/mob/"
     redirects: true
-    max-redirects: 3
+    max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: or
     matchers:
+      - type: word
+        part: header
+        words:
+          - "VMware vCenter Server"
+          - "vCenter Server"
+        case-insensitive: true
       - type: word
         part: body
         words:
           - "VMware vSphere"
           - "VMware vCenter Server"
-          - "ID_VC_Welcome"
           - "VMware VirtualCenter"
+          - "vsphere-client"
+          - "VMware vCenter"
+          - "vCenter Server"
+          - "ID_VC_Welcome"
+          - "VirtualCenter"
         case-insensitive: true
-      - type: word
-        part: header
-        words:
-          - "VMware vCenter Server"
-        case-insensitive: true
-      - type: regex
-        part: body
-        regex:
-          - '(?i)VMware\s+vSphere\s+\d+'
-          - '(?i)alt="VMware vSphere'
-          - '(?i)ID_LogInFlexClient'
-          - '(?i)BrowseVCDatacenters'

--- a/utils/nuclei/templates/discover/application/webserver/abyss.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/abyss.yaml
@@ -3,47 +3,44 @@ info:
   name: Abyss Web Server Detection
   author: method-security
   severity: info
-  description: Detects Abyss Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://www.aprelium.com/abyssws/
+  description: Detects Abyss Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: ABYSS
-  tags: tech,abyss,webserver,aprelium
+  tags: discovery,abyss,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/console/'
-  - '{{BaseURL}}/~abyssws/'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  - '{{BaseURL}}/docs/'
-  - '{{BaseURL}}/manual/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: abyss'
-    - 'server: abyssws'
-    - 'x-powered-by: abyss'
-    - 'x-served-by: abyss'
-    case-insensitive: true
-  - type: word
-    part: body
-    words:
-    - abyss console
-    - abyss web server
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)abyss.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)abyss.*?(x1|x2).*?[0-9]+\.[0-9]+
-    - (?i)aprelium.*?abyss
-    - (?i)abyss/x[0-9]+\.[0-9]+
-    - (?i)~abyssws/
-    - (?i)abyss.*?console
-    condition: or
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/console/"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/docs/"
+      - "{{BaseURL}}/manual/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: abyss"
+          - "server: abyssws"
+          - "x-powered-by: abyss"
+          - "x-served-by: abyss"
+        case-insensitive: true
+      - type: word
+        part: body
+        words:
+          - "abyss console"
+          - "abyss web server"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)abyss.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)abyss.*?(x1|x2).*?[0-9]+\\.[0-9]+"
+          - "(?i)aprelium.*?abyss"
+          - "(?i)abyss/x[0-9]+\\.[0-9]+"
+          - "(?i)~abyssws/"
+          - "(?i)abyss.*?console"

--- a/utils/nuclei/templates/discover/application/webserver/apache.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/apache.yaml
@@ -1,48 +1,31 @@
 id: apache-detect
 info:
   name: Apache Web Server Detection
-  author: philippedelteil # updated by method.security
+  author: method-security
   severity: info
-  description: |
-    Detects web servers running Apache HTTPD by analyzing response headers and common
-    response patterns. Some Apache configurations expose version information in the
-    `Server` or `Via` headers. The OpenSSL module may also reveal version details.
-  reference:
-    - https://httpd.apache.org/
-    - https://nvd.nist.gov/vuln/detail/CVE-2021-41773
-  classification:
-    cpe: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*
+  description: Detects web servers running Apache HTTPD by analyzing response headers and common response patterns
   metadata:
-    vendor: apache
-    product: httpd
-    category: web_server
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: APACHE
-    shodan-query: product:"Apache httpd"
-    fofa-query: server="Apache"
-    confidence: 90
-  tags: tech, apache, web, server, detect, fingerprint
+  tags: discovery,apache,webserver
 http:
   - method: GET
     path:
       - "{{BaseURL}}"
     redirects: true
-    max-redirects: 2
+    max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: or
     matchers:
       - type: regex
-        name: apache-header
         part: header
         regex:
-          - '(?i)server:\s*apache'
-          - '(?i)server:\s*Apache/[\d.]+'
-          - '(?i)via:\s*apache'
-          - '(?i)x-powered-by:\s*apache'
+          - "(?i)server:\\s*apache"
+          - "(?i)server:\\s*Apache/[\\d.]+"
+          - "(?i)via:\\s*apache"
+          - "(?i)x-powered-by:\\s*apache"
       - type: regex
-        name: apache-body
         part: body
         regex:
-          - '(?i)Apache Server at'
-          - '(?i)Apache/[\d.]+ \(Unix\)'
-          - '(?i)<address>Apache/[\d.]+'
+          - "(?i)Apache Server at"
+          - "(?i)Apache/[\\d.]+ \\(Unix\\)"
+          - "(?i)<address>Apache/[\\d.]+"

--- a/utils/nuclei/templates/discover/application/webserver/caddy.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/caddy.yaml
@@ -3,40 +3,39 @@ info:
   name: Caddy Web Server Detection
   author: method-security
   severity: info
-  description: Detects Caddy Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://caddyserver.com/
+  description: Detects Caddy Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: CADDY
-  tags: tech,caddy,webserver,go,https
+  tags: discovery,caddy,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/debug/vars'
-  - '{{BaseURL}}/metrics'
-  - '{{BaseURL}}/config/'
-  - '{{BaseURL}}/status'
-  - '{{BaseURL}}/health'
-  - '{{BaseURL}}/caddy/'
-  - '{{BaseURL}}/api/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: caddy'
-    - 'x-powered-by: caddy'
-    - 'x-served-by: caddy'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)caddy.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)caddy.*?v[0-9]+\.[0-9]+
-    - (?i)caddy.*?server.*?[0-9]+\.[0-9]+
-    - (?i)powered.*?by.*?caddy
-    - (?i)caddyfile.*?config
-    - (?i)caddy.*?automatic.*?https
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/debug/vars"
+      - "{{BaseURL}}/metrics"
+      - "{{BaseURL}}/config/"
+      - "{{BaseURL}}/status"
+      - "{{BaseURL}}/health"
+      - "{{BaseURL}}/caddy/"
+      - "{{BaseURL}}/api/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: caddy"
+          - "x-powered-by: caddy"
+          - "x-served-by: caddy"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)caddy.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)caddy.*?v[0-9]+\\.[0-9]+"
+          - "(?i)caddy.*?server.*?[0-9]+\\.[0-9]+"
+          - "(?i)powered.*?by.*?caddy"
+          - "(?i)caddyfile.*?config"
+          - "(?i)caddy.*?automatic.*?https"

--- a/utils/nuclei/templates/discover/application/webserver/cherokee.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/cherokee.yaml
@@ -1,38 +1,37 @@
 id: cherokee-detect
 info:
   name: Cherokee Web Server Detection
-  author: method-security 
+  author: method-security
   severity: info
-  description: Detects Cherokee Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://cherokee-project.com/
+  description: Detects Cherokee Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: CHEROKEE
-  tags: tech,cherokee,webserver
+  tags: discovery,cherokee,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  - '{{BaseURL}}/admin/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: cherokee'
-    - 'x-powered-by: cherokee'
-    - 'x-served-by: cherokee'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)cherokee.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)cherokee.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)cherokee.*?server.*?[0-9]+\.[0-9]+
-    - (?i)powered.*?by.*?cherokee
-    - (?i)cherokee.*?admin
-    - (?i)cherokee.*?configuration
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/admin/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: cherokee"
+          - "x-powered-by: cherokee"
+          - "x-served-by: cherokee"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)cherokee.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)cherokee.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)cherokee.*?server.*?[0-9]+\\.[0-9]+"
+          - "(?i)powered.*?by.*?cherokee"
+          - "(?i)cherokee.*?admin"
+          - "(?i)cherokee.*?configuration"

--- a/utils/nuclei/templates/discover/application/webserver/iis.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/iis.yaml
@@ -1,24 +1,23 @@
 id: microsoft-iis-version
 info:
   name: Microsoft IIS version detect
-  author: Wlayzz # updated by method.security
+  author: method-security
   severity: info
-  description: Some Microsoft IIS servers have the version on the response header.
-    Useful when you need to find specific CVEs on your targets.
+  description: Detects Microsoft IIS web servers by analyzing response headers
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: IIS
-  tags: tech,microsoft,iis
+  tags: discovery,microsoft,iis,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  host-redirects: true
-  max-redirects: 4
-  matchers-condition: and
-  matchers:
-  - type: word
-    part: header
-    words:
-    - iis
-    case-insensitive: true
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "iis"
+        case-insensitive: true

--- a/utils/nuclei/templates/discover/application/webserver/jetty.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/jetty.yaml
@@ -3,39 +3,38 @@ info:
   name: Jetty Web Server Detection
   author: method-security
   severity: info
-  description: Detects Jetty Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://www.eclipse.org/jetty/
+  description: Detects Jetty Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: JETTY
-  tags: tech,jetty,webserver,java,eclipse
+  tags: discovery,jetty,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/stats'
-  - '{{BaseURL}}/dump'
-  - '{{BaseURL}}/jmx'
-  - '{{BaseURL}}/jolokia/'
-  - '{{BaseURL}}/admin/'
-  - '{{BaseURL}}/status/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: jetty'
-    - 'x-powered-by: jetty'
-    - 'x-served-by: jetty'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)jetty.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)jetty.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)jetty.*?server.*?[0-9]+\.[0-9]+
-    - (?i)eclipse.*?jetty.*?[0-9]+\.[0-9]+
-    - (?i)powered.*?by.*?jetty
-    - (?i)mortbay.*?jetty
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/stats"
+      - "{{BaseURL}}/dump"
+      - "{{BaseURL}}/jmx"
+      - "{{BaseURL}}/jolokia/"
+      - "{{BaseURL}}/admin/"
+      - "{{BaseURL}}/status/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: jetty"
+          - "x-powered-by: jetty"
+          - "x-served-by: jetty"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)jetty.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)jetty.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)jetty.*?server.*?[0-9]+\\.[0-9]+"
+          - "(?i)eclipse.*?jetty.*?[0-9]+\\.[0-9]+"
+          - "(?i)powered.*?by.*?jetty"
+          - "(?i)mortbay.*?jetty"

--- a/utils/nuclei/templates/discover/application/webserver/litespeed.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/litespeed.yaml
@@ -3,41 +3,38 @@ info:
   name: LiteSpeed Web Server Detection
   author: method-security
   severity: info
-  description: Detects LiteSpeed Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://www.litespeedtech.com/
+  description: Detects LiteSpeed Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: LITESPEED
-  tags: tech,litespeed,webserver,lsws
+  tags: discovery,litespeed,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/lsws/'
-  - '{{BaseURL}}/lsws-admin/'
-  - '{{BaseURL}}/phpinfo.php'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  - '{{BaseURL}}/docs/'
-  - '{{BaseURL}}/manual/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: litespeed'
-    - 'server: lsws'
-    - x-lsws-server
-    - 'x-powered-by: litespeed'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)litespeed.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)litespeed.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)lsws.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)openlitespeed.*?[0-9]+\.[0-9]+
-    - (?i)powered.*?by.*?litespeed
-    - (?i)litespeed.*?(enterprise|cache|admin)
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/phpinfo.php"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/docs/"
+      - "{{BaseURL}}/manual/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: litespeed"
+          - "server: lsws"
+          - "x-lsws-server"
+          - "x-powered-by: litespeed"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)litespeed.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)litespeed.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)lsws.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)openlitespeed.*?[0-9]+\\.[0-9]+"
+          - "(?i)powered.*?by.*?litespeed"
+          - "(?i)litespeed.*?(enterprise|cache|admin)"

--- a/utils/nuclei/templates/discover/application/webserver/nginx.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/nginx.yaml
@@ -1,22 +1,23 @@
 id: nginx-version
 info:
   name: Nginx version detect
-  author: philippedelteil,daffainfo
+  author: method-security
   severity: info
-  description: Some nginx servers have the version on the response header. Useful
-    when you need to find specific CVEs on your targets.
+  description: Detects Nginx web servers by analyzing response headers
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: NGINX
-  tags: tech,nginx
+  tags: discovery,nginx,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  matchers-condition: and
-  matchers:
-  - type: word
-    part: header
-    words:
-    - nginx
-    case-insensitive: true
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "nginx"
+        case-insensitive: true

--- a/utils/nuclei/templates/discover/application/webserver/openresty.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/openresty.yaml
@@ -3,40 +3,38 @@ info:
   name: OpenResty Web Server Detection
   author: method-security
   severity: info
-  description: Detects OpenResty Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://openresty.org/
+  description: Detects OpenResty Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: OPENRESTY
-  tags: tech,openresty,webserver,nginx,lua
+  tags: discovery,openresty,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/nginx_status'
-  - '{{BaseURL}}/status'
-  - '{{BaseURL}}/luarocks/'
-  - '{{BaseURL}}/lualib/'
-  - '{{BaseURL}}/openresty/'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: openresty'
-    - 'x-powered-by: openresty'
-    - 'x-served-by: openresty'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)openresty.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)openresty.*?web.*?platform
-    - (?i)nginx.*?openresty
-    - (?i)lua.*?resty
-    - (?i)ngx_lua.*?[0-9]+\.[0-9]+
-    - (?i)luajit.*?[0-9]+\.[0-9]+
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/nginx_status"
+      - "{{BaseURL}}/status"
+      - "{{BaseURL}}/luarocks/"
+      - "{{BaseURL}}/lualib/"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: openresty"
+          - "x-powered-by: openresty"
+          - "x-served-by: openresty"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)openresty.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)openresty.*?web.*?platform"
+          - "(?i)nginx.*?openresty"
+          - "(?i)lua.*?resty"
+          - "(?i)ngx_lua.*?[0-9]+\\.[0-9]+"
+          - "(?i)luajit.*?[0-9]+\\.[0-9]+"

--- a/utils/nuclei/templates/discover/application/webserver/tengine.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tengine.yaml
@@ -3,40 +3,38 @@ info:
   name: Tengine Web Server Detection
   author: method-security
   severity: info
-  description: Detects Tengine Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://tengine.taobao.org/
+  description: Detects Tengine Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: TENGINE
-  tags: tech,tengine,webserver,nginx,taobao
+  tags: discovery,tengine,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/nginx_status'
-  - '{{BaseURL}}/reqstat'
-  - '{{BaseURL}}/status'
-  - '{{BaseURL}}/tengine/'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  - '{{BaseURL}}/upstream_status'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: tengine'
-    - 'x-powered-by: tengine'
-    - 'x-served-by: tengine'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)tengine.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)tengine.*?web.*?server
-    - (?i)tengine.*?nginx
-    - (?i)nginx.*?tengine
-    - (?i)tengine.*?taobao
-    - (?i)powered.*?by.*?tengine
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/nginx_status"
+      - "{{BaseURL}}/reqstat"
+      - "{{BaseURL}}/status"
+      - "{{BaseURL}}/tengine/"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/upstream_status"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: tengine"
+          - "x-powered-by: tengine"
+          - "x-served-by: tengine"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)tengine.*?web.*?server"
+          - "(?i)tengine.*?nginx"
+          - "(?i)nginx.*?tengine"
+          - "(?i)tengine.*?taobao"
+          - "(?i)powered.*?by.*?tengine"

--- a/utils/nuclei/templates/discover/application/webserver/tomcat.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tomcat.yaml
@@ -3,42 +3,41 @@ info:
   name: Apache Tomcat Server Detection
   author: method-security
   severity: info
-  description: Detects Apache Tomcat Server installations by analyzing response headers,
-    body content, and common paths
-  reference: https://tomcat.apache.org/
+  description: Detects Apache Tomcat Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: TOMCAT
-  tags: tech,tomcat,webserver,java,apache
+  tags: discovery,tomcat,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/manager/'
-  - '{{BaseURL}}/manager/html'
-  - '{{BaseURL}}/host-manager/'
-  - '{{BaseURL}}/docs/'
-  - '{{BaseURL}}/examples/'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  - '{{BaseURL}}/favicon.ico'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: apache tomcat'
-    - 'server: apache-coyote'
-    - 'server: tomcat'
-    - 'x-powered-by: tomcat'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)apache.*?tomcat.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)tomcat.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)tomcat.*?web.*?server
-    - (?i)catalina.*?[0-9]+\.[0-9]+
-    - (?i)coyote.*?[0-9]+\.[0-9]+
-    - (?i)powered.*?by.*?tomcat
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/manager/"
+      - "{{BaseURL}}/manager/html"
+      - "{{BaseURL}}/host-manager/"
+      - "{{BaseURL}}/docs/"
+      - "{{BaseURL}}/examples/"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/favicon.ico"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: apache tomcat"
+          - "server: apache-coyote"
+          - "server: tomcat"
+          - "x-powered-by: tomcat"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)apache.*?tomcat.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)tomcat.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)tomcat.*?web.*?server"
+          - "(?i)catalina.*?[0-9]+\\.[0-9]+"
+          - "(?i)coyote.*?[0-9]+\\.[0-9]+"
+          - "(?i)powered.*?by.*?tomcat"

--- a/utils/nuclei/templates/discover/application/webserver/yaws.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/yaws.yaml
@@ -3,39 +3,35 @@ info:
   name: Yaws Web Server Detection
   author: method-security
   severity: info
-  description: Detects Yaws Web Server installations by analyzing response headers,
-    body content, and common paths
-  reference: http://yaws.hyber.org/
+  description: Detects Yaws Web Server installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: YAWS
-  tags: tech,yaws,webserver,erlang
+  tags: discovery,yaws,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/stats'
-  - '{{BaseURL}}/status'
-  - '{{BaseURL}}/yaws/'
-  - '{{BaseURL}}/server-status'
-  - '{{BaseURL}}/server-info'
-  - '{{BaseURL}}/doc/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: yaws'
-    - 'x-powered-by: yaws'
-    - 'x-served-by: yaws'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)yaws.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)yaws.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)yaws.*?http.*?server
-    - (?i)yet.*?another.*?web.*?server
-    - (?i)powered.*?by.*?yaws
-    - (?i)erlang.*?yaws
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/stats"
+      - "{{BaseURL}}/status"
+      - "{{BaseURL}}/server-status"
+      - "{{BaseURL}}/server-info"
+      - "{{BaseURL}}/doc/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: yaws"
+          - "x-powered-by: yaws"
+          - "x-served-by: yaws"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)yaws.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)yet.*?another.*?web.*?server"
+          - "(?i)powered.*?by.*?yaws"
+          - "(?i)erlang.*?yaws"

--- a/utils/nuclei/templates/discover/application/webserver/zws.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/zws.yaml
@@ -3,41 +3,38 @@ info:
   name: ZWS Web Server Detection
   author: method-security
   severity: info
-  description: Detects ZWS (Zope Web Server) installations by analyzing response headers,
-    body content, and common paths
-  reference: https://zope.org/
+  description: Detects ZWS (Zope Web Server) installations by analyzing response headers, body content, and common paths
   metadata:
-    method-application-type: WEB_SERVER
+    method-application-type: WEBSERVER
     method-module-name: ZWS
-  tags: tech,zws,zope,webserver,python
+  tags: discovery,zws,zope,webserver
 http:
-- method: GET
-  path:
-  - '{{BaseURL}}'
-  - '{{BaseURL}}/manage'
-  - '{{BaseURL}}/manage_main'
-  - '{{BaseURL}}/Control_Panel/'
-  - '{{BaseURL}}/acl_users/'
-  - '{{BaseURL}}/zope/'
-  - '{{BaseURL}}/p_/webdav/'
-  - '{{BaseURL}}/misc_/'
-  stop-at-first-match: true
-  matchers-condition: or
-  matchers:
-  - type: word
-    part: header
-    words:
-    - 'server: zope'
-    - 'server: zserver'
-    - 'server: zws'
-    - 'x-powered-by: zope'
-    case-insensitive: true
-  - type: regex
-    part: body
-    regex:
-    - (?i)zope.*?web.*?server.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)zws.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)zope.*?[0-9]+\.[0-9]+\.[0-9]+
-    - (?i)zserver.*?[0-9]+\.[0-9]+
-    - (?i)powered.*?by.*?zope
-    - (?i)zope.*?(management|application).*?server
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+      - "{{BaseURL}}/manage"
+      - "{{BaseURL}}/manage_main"
+      - "{{BaseURL}}/Control_Panel/"
+      - "{{BaseURL}}/acl_users/"
+      - "{{BaseURL}}/p_/webdav/"
+      - "{{BaseURL}}/misc_/"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "server: zope"
+          - "server: zserver"
+          - "server: zws"
+          - "x-powered-by: zope"
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)zope.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)zope.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)zserver.*?[0-9]+\\.[0-9]+"
+          - "(?i)powered.*?by.*?zope"
+          - "(?i)zope.*?(management|application).*?server"


### PR DESCRIPTION
### TL;DR

Standardized Nuclei discovery templates for improved consistency and reliability.

### What changed?

- Updated author fields to use consistent "method-security" attribution
- Standardized template metadata structure across all files
- Simplified descriptions to be more concise and focused
- Standardized tag format using discovery as the primary tag
- Added consistent redirect handling with max-redirects set to 5
- Improved matcher conditions for more accurate detection
- Removed unnecessary classification sections and references
- Standardized application type values (e.g., WEBSERVER instead of WEB_SERVER)
- Improved template formatting for better readability