### PR TITLE
Add Global Ratelimit Flag to Nuclei Engine + Cmds

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -82,9 +82,14 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, timeout, threads, proxy, verboseLogs)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, timeout, threads, proxy, verboseLogs, globalRateLimit)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -105,6 +110,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	discoverApplicationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
+	discoverApplicationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")
@@ -663,19 +669,20 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, timeout int, threads int, proxy string, verboseLogs bool) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
 	}
 
 	config := &discover.DiscoverApplicationConfig{
-		Targets:      targets,
-		ResourceType: &resourceEnum,
-		Timeout:      max(timeout, 0),
-		Threads:      max(threads, 0),
-		Proxy:        &proxy,
-		VerboseLogs:  verboseLogs,
+		Targets:         targets,
+		ResourceType:    &resourceEnum,
+		Timeout:         timeout,
+		Threads:         threads,
+		Proxy:           &proxy,
+		VerboseLogs:     verboseLogs,
+		GlobalRateLimit: max(0, globalRateLimit),
 	}
 	return config, nil
 }

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -129,9 +129,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, &proxy, verboseLogs)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, &proxy, verboseLogs, globalRateLimit)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -152,6 +157,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestApplicationDastCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationDastCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
+	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
 
 	// Mark Required Flags
 	_ = pentestApplicationDastCmd.MarkFlagRequired("targets")
@@ -215,9 +221,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationCveConfig(targets, years, timeout, threads, proxy, verboseLogs)
+			config := getPentestApplicationCveConfig(targets, years, timeout, threads, proxy, verboseLogs, globalRateLimit)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationCveScan(cmd.Context(), config)
@@ -235,6 +246,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationCveCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestApplicationCveCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationCveCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
+	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
 
 	// Mark Required Flags
 	_ = pentestApplicationCveCmd.MarkFlagRequired("targets")
@@ -294,9 +306,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, timeout, threads, proxy, verboseLogs)
+			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationMisconfigurationScan(cmd.Context(), config)
@@ -315,6 +332,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestApplicationMisconfigurationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationMisconfigurationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
+	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
 
 	// Mark Required Flags
 	_ = pentestApplicationMisconfigurationCmd.MarkFlagRequired("targets")
@@ -373,9 +391,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, timeout, threads, proxy, verboseLogs)
+			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationTechnologyScan(cmd.Context(), config)
@@ -394,6 +417,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestApplicationTechnologyCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationTechnologyCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
+	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
 
 	// Mark Required Flags
 	_ = pentestApplicationTechnologyCmd.MarkFlagRequired("targets")
@@ -671,9 +695,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, timeout, threads, proxy, verboseLogs)
+			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, timeout, threads, proxy, verboseLogs, globalRateLimit)
 
 			// Generate a report
 			rep, err := pentestwafdetect.RunPentestWafDetect(cmd.Context(), config)
@@ -693,6 +722,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestWafDetectCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestWafDetectCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestWafDetectCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
+	pentestWafDetectCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
 
 	// Mark Required Flags
 	_ = pentestWafDetectCmd.MarkFlagRequired("targets")
@@ -712,7 +742,7 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy *string, verboseLogs bool) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
 		Targets:           targets,
 		DastCategories:    dastCategories,
@@ -722,25 +752,27 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 		Threads:           threads,
 		Proxy:             proxy,
 		VerboseLogs:       verboseLogs,
+		GlobalRateLimit:   max(0, globalRateLimit),
 	}
 	return config
 }
 
 // getPentestApplicationCveConfig builds the config for scan pentest.
-func getPentestApplicationCveConfig(targets []string, years []string, timeout int, threads int, proxy string, verboseLogs bool) pentestapplicationscanfern.PentestApplicationCveConfig {
+func getPentestApplicationCveConfig(targets []string, years []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) pentestapplicationscanfern.PentestApplicationCveConfig {
 	config := pentestapplicationscanfern.PentestApplicationCveConfig{
-		Targets:     targets,
-		Years:       years,
-		Timeout:     timeout,
-		Threads:     threads,
-		Proxy:       &proxy,
-		VerboseLogs: verboseLogs,
+		Targets:         targets,
+		Years:           years,
+		Timeout:         timeout,
+		Threads:         threads,
+		Proxy:           &proxy,
+		VerboseLogs:     verboseLogs,
+		GlobalRateLimit: max(0, globalRateLimit),
 	}
 	return config
 }
 
 // getPentestApplicationMisconfigurationConfig builds the config for scan pentest.
-func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, timeout int, threads int, proxy string, verboseLogs bool) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
+func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
 	config := pentestapplicationscanfern.PentestApplicationMisconfigurationConfig{
 		Targets:                    targets,
 		MisconfigurationCategories: misconfigurationCategories,
@@ -748,12 +780,13 @@ func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurat
 		Threads:                    threads,
 		Proxy:                      &proxy,
 		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
 	}
 	return config
 }
 
 // getPentestApplicationTechnologiesConfig builds the config for scan pentest.
-func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, timeout int, threads int, proxy string, verboseLogs bool) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
+func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
 	config := pentestapplicationscanfern.PentestApplicationTechnologyConfig{
 		Targets:         targets,
 		TechnologyTypes: technologyTypes,
@@ -761,6 +794,7 @@ func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []p
 		Threads:         threads,
 		Proxy:           &proxy,
 		VerboseLogs:     verboseLogs,
+		GlobalRateLimit: max(0, globalRateLimit),
 	}
 	return config
 }
@@ -806,7 +840,7 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 }
 
 // getPentestWafDetectConfig builds the config for waf detect pentest.
-func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool) waf.PentestWafDetectConfig {
+func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) waf.PentestWafDetectConfig {
 	config := waf.PentestWafDetectConfig{
 		Targets:                targets,
 		RouteRequestParameters: routeRequestParams,
@@ -815,6 +849,7 @@ func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.Re
 		Threads:                threads,
 		Proxy:                  &proxy,
 		VerboseLogs:            verboseLogs,
+		GlobalRateLimit:        max(0, globalRateLimit),
 	}
 	return config
 }

--- a/fern/definition/common/nuclei/config.yml
+++ b/fern/definition/common/nuclei/config.yml
@@ -22,4 +22,5 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
 

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -30,6 +30,7 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
   # Application Fingerprint Attempt Struct
   ApplicationFingerprintAttempt:
     properties:

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -28,6 +28,7 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
   PentestApplicationDastResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/cve.yml
+++ b/fern/definition/pentest/application/scan/cve.yml
@@ -10,6 +10,7 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
   PentestApplicationCveResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/misconfiguration.yml
+++ b/fern/definition/pentest/application/scan/misconfiguration.yml
@@ -14,6 +14,7 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
   PentestApplicationMisconfigurationResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/technology.yml
+++ b/fern/definition/pentest/application/scan/technology.yml
@@ -16,6 +16,7 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
   PentestApplicationTechnologyResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/waf/detect.yml
+++ b/fern/definition/pentest/waf/detect.yml
@@ -36,6 +36,7 @@ types:
       threads: integer
       proxy: optional<string>
       verboseLogs: boolean
+      globalRateLimit: integer
   # Detection Results
   WafRuleCategoryEnum:
     enum:

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -69,13 +69,14 @@ func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover
 		svc1log.SafeParam("threads", config.Threads))
 
 	return nuclei.NucleiConfig{
-		Targets:       config.Targets,
-		TemplatePaths: templatePaths,
-		RunMode:       nuclei.NucleiRunModeScan,
-		Timeout:       config.Timeout,
-		Threads:       config.Threads,
-		Proxy:         config.Proxy,
-		VerboseLogs:   config.VerboseLogs,
+		Targets:         config.Targets,
+		TemplatePaths:   templatePaths,
+		RunMode:         nuclei.NucleiRunModeScan,
+		Timeout:         config.Timeout,
+		Threads:         config.Threads,
+		Proxy:           config.Proxy,
+		VerboseLogs:     config.VerboseLogs,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}, nil
 }
 

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -65,10 +65,11 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 			HttpMethods:       config.HttpMethods,
 			RequestParameters: config.DastRequestParams,
 		},
-		Timeout:     config.Timeout,
-		Threads:     config.Threads,
-		Proxy:       config.Proxy,
-		VerboseLogs: config.VerboseLogs,
+		Timeout:         config.Timeout,
+		Threads:         config.Threads,
+		Proxy:           config.Proxy,
+		VerboseLogs:     config.VerboseLogs,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}
 }
 

--- a/internal/pentest/application/scan/cve.go
+++ b/internal/pentest/application/scan/cve.go
@@ -28,13 +28,14 @@ func createCveScanNucleiConfig(config pentestapplicationscanfern.PentestApplicat
 
 	// Return the nuclei config
 	return nuclei.NucleiConfig{
-		Targets:       config.Targets,
-		RunMode:       nuclei.NucleiRunModeScan,
-		TemplatePaths: templatePaths,
-		Timeout:       config.Timeout,
-		Threads:       config.Threads,
-		Proxy:         config.Proxy,
-		VerboseLogs:   config.VerboseLogs,
+		Targets:         config.Targets,
+		RunMode:         nuclei.NucleiRunModeScan,
+		TemplatePaths:   templatePaths,
+		Timeout:         config.Timeout,
+		Threads:         config.Threads,
+		Proxy:           config.Proxy,
+		VerboseLogs:     config.VerboseLogs,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}
 }
 

--- a/internal/pentest/application/scan/misconfiguration.go
+++ b/internal/pentest/application/scan/misconfiguration.go
@@ -32,13 +32,14 @@ func createMisconfigurationScanNucleiConfig(config pentestapplicationscanfern.Pe
 
 	// Return the nuclei config
 	return nuclei.NucleiConfig{
-		Targets:       config.Targets,
-		RunMode:       nuclei.NucleiRunModeScan,
-		TemplatePaths: templatePaths,
-		Timeout:       config.Timeout,
-		Threads:       config.Threads,
-		Proxy:         config.Proxy,
-		VerboseLogs:   config.VerboseLogs,
+		Targets:         config.Targets,
+		RunMode:         nuclei.NucleiRunModeScan,
+		TemplatePaths:   templatePaths,
+		Timeout:         config.Timeout,
+		Threads:         config.Threads,
+		Proxy:           config.Proxy,
+		VerboseLogs:     config.VerboseLogs,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}
 }
 

--- a/internal/pentest/application/scan/technology.go
+++ b/internal/pentest/application/scan/technology.go
@@ -33,13 +33,14 @@ func createTechnologyScanNucleiConfig(config pentestapplicationscanfern.PentestA
 	}
 
 	return nuclei.NucleiConfig{
-		Targets:       config.Targets,
-		RunMode:       nuclei.NucleiRunModeScan,
-		TemplatePaths: templatePaths,
-		Timeout:       config.Timeout,
-		Threads:       config.Threads,
-		Proxy:         config.Proxy,
-		VerboseLogs:   config.VerboseLogs,
+		Targets:         config.Targets,
+		RunMode:         nuclei.NucleiRunModeScan,
+		TemplatePaths:   templatePaths,
+		Timeout:         config.Timeout,
+		Threads:         config.Threads,
+		Proxy:           config.Proxy,
+		VerboseLogs:     config.VerboseLogs,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}
 }
 

--- a/internal/pentest/waf/detect/detect.go
+++ b/internal/pentest/waf/detect/detect.go
@@ -24,10 +24,11 @@ func createDastNucleiConfigForWafDetect(config waf.PentestWafDetectConfig) nucle
 			HttpMethods:       config.HttpMethods,
 			RequestParameters: config.RouteRequestParameters,
 		},
-		Timeout:     config.Timeout,
-		Threads:     config.Threads,
-		Proxy:       config.Proxy,
-		VerboseLogs: config.VerboseLogs,
+		Timeout:         config.Timeout,
+		Threads:         config.Threads,
+		Proxy:           config.Proxy,
+		VerboseLogs:     config.VerboseLogs,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}
 }
 

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	// Generated
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
@@ -21,16 +22,17 @@ import (
 )
 
 type Config struct {
-	Targets        []string
-	RawRequests    []string // JSONL lines when fuzzing
-	TemplateFS     []fs.FS  // template sources
-	WorkflowFS     []fs.FS  // workflow sources
-	Threads        int
-	Proxy          string
-	RunMode        nuclei.NucleiRunMode
-	SuccessfulOnly *bool
-	VerboseLogs    bool
-	Timeout        int
+	Targets         []string
+	RawRequests     []string // JSONL lines when fuzzing
+	TemplateFS      []fs.FS  // template sources
+	WorkflowFS      []fs.FS  // workflow sources
+	Threads         int
+	Proxy           string
+	RunMode         nuclei.NucleiRunMode
+	SuccessfulOnly  *bool
+	VerboseLogs     bool
+	Timeout         int
+	GlobalRateLimit int
 }
 
 func validateConfig(cfg Config) error {
@@ -181,6 +183,14 @@ func buildNucleiOptions(cfg Config, templateDir, workflowDir string) []nucleilib
 			ProbeConcurrency:              cfg.Threads,
 		}),
 
+		// Set global rate limit if specified (0 means use default nuclei rate limit)
+		func() nucleilib.NucleiSDKOptions {
+			if cfg.GlobalRateLimit > 0 {
+				return nucleilib.WithGlobalRateLimit(cfg.GlobalRateLimit, time.Second)
+			}
+			return func(*nucleilib.NucleiEngine) error { return nil } // no-op, use default
+		}(),
+
 		// Explicitly set StopAtFirstMatch to false to ensure we get all requests
 		func(e *nucleilib.NucleiEngine) error {
 			e.Options().StopAtFirstMatch = false
@@ -253,14 +263,15 @@ func getProxy(config nuclei.NucleiConfig) string {
 // GetRunnerConfig returns a runner config from a nuclei config.
 func GetRunnerConfig(templateFileSystems, workflowFileSystems []fs.FS, config nuclei.NucleiConfig) Config {
 	rconfig := Config{
-		Targets:     config.Targets,
-		TemplateFS:  templateFileSystems,
-		WorkflowFS:  workflowFileSystems,
-		Threads:     config.Threads,
-		Proxy:       getProxy(config),
-		RunMode:     config.RunMode,
-		VerboseLogs: config.VerboseLogs,
-		Timeout:     config.Timeout,
+		Targets:         config.Targets,
+		TemplateFS:      templateFileSystems,
+		WorkflowFS:      workflowFileSystems,
+		Threads:         config.Threads,
+		Proxy:           getProxy(config),
+		RunMode:         config.RunMode,
+		VerboseLogs:     config.VerboseLogs,
+		Timeout:         config.Timeout,
+		GlobalRateLimit: config.GlobalRateLimit,
 	}
 	return rconfig
 }


### PR DESCRIPTION
### TL;DR

Added a global rate limit option to all scan commands to control request frequency.

### What changed?

- Added a new `--global-rate-limit` flag to all discover and pentest commands
- The flag accepts an integer value representing requests per second (0 = no limit)
- Updated all configuration structs to include the new `globalRateLimit` parameter
- Modified the Nuclei runner to apply the rate limit when specified

### How to test?

1. Run any scan command with the new flag:
2. Verify that requests are being sent at the specified rate (10 per second in this example)
3. Test with different rate limit values to observe the impact on scan speed and target load

### Why make this change?

This change provides users with more control over scan behavior, allowing them to:

- Reduce load on target systems by limiting request frequency
- Avoid triggering rate limiting or anti-DoS protections on target applications
- Balance between scan speed and target impact based on specific requirements
- Comply with target system policies that may restrict scanning rates