### PR TITLE
Fix Greedy Matcher in Regex Application Template patterns

### DIFF
--- a/utils/nuclei/templates/discover/application/cms/ghost.yaml
+++ b/utils/nuclei/templates/discover/application/cms/ghost.yaml
@@ -32,5 +32,5 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)ghost.*?version.*?[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)ghost\\s+version\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
           - "(?i)content=\"ghost\\s+[0-9]+\\.[0-9]+\""

--- a/utils/nuclei/templates/discover/application/cms/joomla.yaml
+++ b/utils/nuclei/templates/discover/application/cms/joomla.yaml
@@ -42,5 +42,5 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)joomla!?.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)generator.*?joomla!?\\s+[0-9]+\\.[0-9]+"
+          - "(?i)joomla!?\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)generator\"\\s*content=\"joomla!?\\s+[0-9]+\\.[0-9]+"

--- a/utils/nuclei/templates/discover/application/cms/modx.yaml
+++ b/utils/nuclei/templates/discover/application/cms/modx.yaml
@@ -42,6 +42,6 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)modx.*?revolution.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)generator.*?modx.*?[0-9]+\\.[0-9]+"
+          - "(?i)modx\\s+revolution\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)generator\"\\s*content=\"modx\\s*[0-9]+\\.[0-9]+"
           - "(?i)modx_[a-zA-Z0-9_]+_url"

--- a/utils/nuclei/templates/discover/application/vdiapplication/vmware-horizon.yaml
+++ b/utils/nuclei/templates/discover/application/vdiapplication/vmware-horizon.yaml
@@ -28,7 +28,7 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)vmware.*?horizon"
-          - "(?i)horizon.*?view.*?[0-9]+\\.[0-9]+"
-          - "(?i)horizon.*?(connection|workspace).*?server"
-          - "(?i)blast.*?secure.*?gateway"
+          - "(?i)vmware\\s+horizon"
+          - "(?i)horizon\\s+view\\s+[0-9]+\\.[0-9]+"
+          - "(?i)horizon\\s+(connection|workspace)\\s+server"
+          - "(?i)blast\\s+secure\\s+gateway"

--- a/utils/nuclei/templates/discover/application/webserver/abyss.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/abyss.yaml
@@ -38,9 +38,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)abyss.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)abyss.*?(x1|x2).*?[0-9]+\\.[0-9]+"
-          - "(?i)aprelium.*?abyss"
+          - "(?i)abyss\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)abyss\\s+(x1|x2)\\s*[0-9]+\\.[0-9]+"
+          - "(?i)aprelium\\s+abyss"
           - "(?i)abyss/x[0-9]+\\.[0-9]+"
           - "(?i)~abyssws/"
-          - "(?i)abyss.*?console"
+          - "(?i)abyss\\s+console"

--- a/utils/nuclei/templates/discover/application/webserver/caddy.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/caddy.yaml
@@ -33,9 +33,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)caddy.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)caddy.*?v[0-9]+\\.[0-9]+"
-          - "(?i)caddy.*?server.*?[0-9]+\\.[0-9]+"
-          - "(?i)powered.*?by.*?caddy"
-          - "(?i)caddyfile.*?config"
-          - "(?i)caddy.*?automatic.*?https"
+          - "(?i)caddy\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)caddy\\s*v[0-9]+\\.[0-9]+"
+          - "(?i)caddy\\s+server\\s+[0-9]+\\.[0-9]+"
+          - "(?i)powered\\s+by\\s+caddy"
+          - "(?i)caddyfile\\s+config"
+          - "(?i)caddy\\s+automatic\\s+https"

--- a/utils/nuclei/templates/discover/application/webserver/cherokee.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/cherokee.yaml
@@ -29,9 +29,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)cherokee.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)cherokee.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)cherokee.*?server.*?[0-9]+\\.[0-9]+"
-          - "(?i)powered.*?by.*?cherokee"
-          - "(?i)cherokee.*?admin"
-          - "(?i)cherokee.*?configuration"
+          - "(?i)cherokee\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)cherokee\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)cherokee\\s+server\\s+[0-9]+\\.[0-9]+"
+          - "(?i)powered\\s+by\\s+cherokee"
+          - "(?i)cherokee\\s+admin"
+          - "(?i)cherokee\\s+configuration"

--- a/utils/nuclei/templates/discover/application/webserver/jetty.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/jetty.yaml
@@ -32,9 +32,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)jetty.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)jetty.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)jetty.*?server.*?[0-9]+\\.[0-9]+"
-          - "(?i)eclipse.*?jetty.*?[0-9]+\\.[0-9]+"
-          - "(?i)powered.*?by.*?jetty"
-          - "(?i)mortbay.*?jetty"
+          - "(?i)jetty\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)jetty\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)jetty\\s+server\\s+[0-9]+\\.[0-9]+"
+          - "(?i)eclipse\\s+jetty\\s*[0-9]+\\.[0-9]+"
+          - "(?i)powered\\s+by\\s+jetty"
+          - "(?i)mortbay\\s+jetty"

--- a/utils/nuclei/templates/discover/application/webserver/litespeed.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/litespeed.yaml
@@ -32,9 +32,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)litespeed.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)litespeed.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)lsws.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)openlitespeed.*?[0-9]+\\.[0-9]+"
-          - "(?i)powered.*?by.*?litespeed"
-          - "(?i)litespeed.*?(enterprise|cache|admin)"
+          - "(?i)litespeed\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)litespeed\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)lsws\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)openlitespeed\\s*[0-9]+\\.[0-9]+"
+          - "(?i)powered\\s+by\\s+litespeed"
+          - "(?i)litespeed\\s+(enterprise|cache|admin)"

--- a/utils/nuclei/templates/discover/application/webserver/openresty.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/openresty.yaml
@@ -32,9 +32,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)openresty.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)openresty.*?web.*?platform"
-          - "(?i)nginx.*?openresty"
-          - "(?i)lua.*?resty"
-          - "(?i)ngx_lua.*?[0-9]+\\.[0-9]+"
-          - "(?i)luajit.*?[0-9]+\\.[0-9]+"
+          - "(?i)openresty\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)openresty\\s+web\\s+platform"
+          - "(?i)nginx[\\s/-]+openresty"
+          - "(?i)lua[\\s_-]+resty"
+          - "(?i)ngx_lua\\s*[0-9]+\\.[0-9]+"
+          - "(?i)luajit\\s*[0-9]+\\.[0-9]+"

--- a/utils/nuclei/templates/discover/application/webserver/tengine.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tengine.yaml
@@ -33,8 +33,8 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)tengine.*?web.*?server"
-          - "(?i)tengine.*?nginx"
-          - "(?i)nginx.*?tengine"
-          - "(?i)tengine.*?taobao"
-          - "(?i)powered.*?by.*?tengine"
+          - "(?i)tengine\\s+web\\s+server"
+          - "(?i)tengine[\\s/-]+nginx"
+          - "(?i)nginx[\\s/-]+tengine"
+          - "(?i)tengine[\\s/-]+taobao"
+          - "(?i)powered\\s+by\\s+tengine"

--- a/utils/nuclei/templates/discover/application/webserver/tomcat.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tomcat.yaml
@@ -35,9 +35,9 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)apache.*?tomcat.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)tomcat.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)tomcat.*?web.*?server"
-          - "(?i)catalina.*?[0-9]+\\.[0-9]+"
-          - "(?i)coyote.*?[0-9]+\\.[0-9]+"
-          - "(?i)powered.*?by.*?tomcat"
+          - "(?i)apache\\s+tomcat\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)tomcat\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)tomcat\\s+web\\s+server"
+          - "(?i)catalina\\s*[0-9]+\\.[0-9]+"
+          - "(?i)coyote\\s*[0-9]+\\.[0-9]+"
+          - "(?i)powered\\s+by\\s+tomcat"

--- a/utils/nuclei/templates/discover/application/webserver/yaws.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/yaws.yaml
@@ -31,7 +31,7 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)yaws.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)yet.*?another.*?web.*?server"
-          - "(?i)powered.*?by.*?yaws"
-          - "(?i)erlang.*?yaws"
+          - "(?i)yaws\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)yet\\s+another\\s+web\\s+server"
+          - "(?i)powered\\s+by\\s+yaws"
+          - "(?i)erlang[\\s/-]+yaws"

--- a/utils/nuclei/templates/discover/application/webserver/zws.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/zws.yaml
@@ -33,8 +33,8 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)zope.*?web.*?server.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)zope.*?[0-9]+\\.[0-9]+\\.[0-9]+"
-          - "(?i)zserver.*?[0-9]+\\.[0-9]+"
-          - "(?i)powered.*?by.*?zope"
-          - "(?i)zope.*?(management|application).*?server"
+          - "(?i)zope\\s+web\\s+server\\s+[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)zope\\s*[0-9]+\\.[0-9]+\\.[0-9]+"
+          - "(?i)zserver\\s*[0-9]+\\.[0-9]+"
+          - "(?i)powered\\s+by\\s+zope"
+          - "(?i)zope\\s+(management|application)\\s+server"


### PR DESCRIPTION
### TL;DR

Improved regex patterns in Nuclei templates for more accurate CMS and web server detection.

### What changed?

Refined regex patterns across multiple Nuclei templates to make them more precise and reduce false positives:

- Replaced loose wildcard patterns (`.*?`) with explicit whitespace matchers (`\s+` or `\s*`)
- Added more specific boundary conditions in patterns
- Improved version detection patterns
- Enhanced patterns for detecting product names and relationships
- Added character class alternatives (`[\s/-]+`) where appropriate for better matching

Affected templates include:
- CMS detectors (Ghost, Joomla, MODX)
- VDI application detector (VMware Horizon)
- Web server detectors (Abyss, Caddy, Cherokee, Jetty, LiteSpeed, OpenResty, Tengine, Tomcat, Yaws, ZWS)
