### PR TITLE
Clean Up Discover Templates

### DIFF
--- a/utils/nuclei/templates/discover/application/networkcontroller/cisco_data_center_network_manager.yaml
+++ b/utils/nuclei/templates/discover/application/networkcontroller/cisco_data_center_network_manager.yaml
@@ -6,7 +6,7 @@ info:
   description: Detects Cisco DCNM web interfaces using simple title and keyword matches.
   metadata:
     method-application-type: NETWORK_CONTROLLER
-    method-module-name: CISCO_DCNM
+    method-module-name: CISCO_DATA_CENTER_NETWORK_MANAGER
   tags: discovery,cisco,dcnm,network-controller,network-management-system
 requests:
   - method: GET

--- a/utils/nuclei/templates/discover/application/networkmanagementsystem/cisco_web_management_interface.yaml
+++ b/utils/nuclei/templates/discover/application/networkmanagementsystem/cisco_web_management_interface.yaml
@@ -6,7 +6,7 @@ info:
   description: Detects Cisco router, switch, and network device management interfaces by identifying Cisco branding, admin patterns, and interface elements common across Cisco network products.
   metadata:
     method-application-type: NETWORK_MANAGEMENT_SYSTEM
-    method-module-name: CISCO_WEB_MANAGEMENT
+    method-module-name: CISCO_WEB_INTERFACE
   tags: discovery,cisco,web-management,network-management-system
 requests:
   - method: GET


### PR DESCRIPTION
### TL;DR

Updated module names for Cisco network management templates to be more consistent and descriptive.

### What changed?

- Changed `method-module-name` in Cisco DCNM template from `CISCO_DCNM` to `CISCO_DATA_CENTER_NETWORK_MANAGER`
- Changed `method-module-name` in Cisco Web Management Interface template from `CISCO_WEB_MANAGEMENT` to `CISCO_WEB_INTERFACE`

### How to test?

1. Run the updated templates against Cisco network management systems
2. Verify that the templates still correctly identify the target systems
3. Confirm that the new module names appear correctly in scan results and reports

### Why make this change?

This change standardizes the module naming convention to be more descriptive and consistent across Cisco network management templates. The full names provide better clarity about what each module detects, making it easier for users to understand the purpose of each template.