### PR TITLE
Add Forigate HTTP 1.1 Tempalte

### DIFF
--- a/utils/nuclei/templates/discover/application/firewall/fortinet_fortigate.yaml
+++ b/utils/nuclei/templates/discover/application/firewall/fortinet_fortigate.yaml
@@ -1,0 +1,49 @@
+id: fortinet-fortigate-webmanagement-detect
+
+info:
+  name: Fortinet FortiGate Web Management Interface Detection
+  author: method-security
+  severity: info
+  description: >
+    Detects Fortinet FortiGate web management interfaces by matching unique
+    HTML titles, paths, headers, and identifiers associated with FortiGate SSL
+    VPN and admin portals.
+  metadata:
+    method-application-type: FIREWALL
+    method-module-name: FORTINET_FORTIGATE
+  tags: discovery,fortinet,fortigate,firewall,ssl-vpn,webvpn,admin
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/remote/login"
+      - "{{BaseURL}}/remote/fgt_lang"
+      - "{{BaseURL}}/login"
+      - "{{BaseURL}}/admin"
+      - "{{BaseURL}}/remote/logincheck"
+    redirects: true
+    max-redirects: 5
+    stop-at-first-match: true
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '(?i)<title>.*FortiGate.*</title>'
+          - '(?i)Fortinet Technologies'
+          - '(?i)FortiGate SSL VPN'
+          - '(?i)fgtauth'
+          - '(?i)var\s+FORTIOS_LANG'
+            - type: word
+        part: header
+        words:
+          - 'set-cookie: FGTLanguage'
+          - 'Server: Fortinet'
+          - 'X-Frame-Options: SAMEORIGIN'
+        case-insensitive: true
+      - type: word
+        part: body
+        words:
+          - '<title>FortiGate Login</title>'
+          - '<title>FortiGate</title>'
+        case-insensitive: true


### PR DESCRIPTION
### TL;DR

Added a new Nuclei template to detect Fortinet FortiGate web management interfaces.

### What changed?

Added a new YAML template (`fortinet_fortigate.yaml`) that identifies Fortinet FortiGate web management interfaces by checking for:
- Distinctive HTML titles containing "FortiGate"
- Fortinet-specific cookies and headers
- Unique identifiers in the page content like "FortiGate SSL VPN" and "fgtauth"
- Fortinet-specific JavaScript variables

The template checks multiple common paths including the root path, `/remote/login`, `/remote/fgt_lang`, `/login`, `/admin`, and `/remote/logincheck`.

### How to test?

1. Run the template against known Fortinet FortiGate instances:
   ```
   nuclei -t templates/discover/application/firewall/fortinet_fortigate.yaml -u https://target-fortigate-instance/
   ```
2. Verify the template correctly identifies FortiGate instances by matching the HTML titles, headers, and content patterns.

### Why make this change?

This template enhances reconnaissance capabilities by enabling the detection of Fortinet FortiGate firewalls and SSL VPN portals. Identifying these systems is valuable for security assessments as FortiGate devices are widely deployed enterprise security appliances that may require specific testing approaches.