### PR TITLE
Update Templates

### DIFF
--- a/utils/nuclei/templates/discover/application/cicdplatform/jenkins.yaml
+++ b/utils/nuclei/templates/discover/application/cicdplatform/jenkins.yaml
@@ -21,7 +21,7 @@ http:
       - type: word
         part: header
         words:
-          - "x-jenkins"
+          - "jenkins"
         case-insensitive: true
       - type: regex
         part: body

--- a/utils/nuclei/templates/discover/application/firewall/fortinet-fortigate.yaml
+++ b/utils/nuclei/templates/discover/application/firewall/fortinet-fortigate.yaml
@@ -13,7 +13,6 @@ info:
     method-module-name: FORTINET_FORTIGATE
     cpe: cpe:2.3:a:fortinet:fortigate:*:*:*:*:*:*:*:*
   tags: discovery,fortinet,fortigate,firewall,ssl-vpn,webvpn,admin
-
 requests:
   - method: GET
     path:
@@ -35,12 +34,11 @@ requests:
           - '(?i)FortiGate SSL VPN'
           - '(?i)fgtauth'
           - '(?i)var\s+FORTIOS_LANG'
-            - type: word
+      - type: word
         part: header
         words:
           - 'set-cookie: FGTLanguage'
-          - 'Server: Fortinet'
-          - 'X-Frame-Options: SAMEORIGIN'
+          - 'Fortinet'
         case-insensitive: true
       - type: word
         part: body

--- a/utils/nuclei/templates/discover/application/networkcontroller/clearpass-policy-manager.yaml
+++ b/utils/nuclei/templates/discover/application/networkcontroller/clearpass-policy-manager.yaml
@@ -34,4 +34,4 @@ http:
           - "(?i)ClearPass\\s+Policy\\s+Manager"
           - "(?i)<title>.*ClearPass"
           - "(?i)ClearPass\\s+Guest"
-          - "(?i)(?=.*clearpass)(?=.*aruba)"
+          - "(?i)clearpass.*aruba|aruba.*clearpass"


### PR DESCRIPTION
### TL;DR

Fixed detection patterns in three Nuclei templates for better application discovery.

### What changed?

- Jenkins template: Changed header detection from "x-jenkins" to "jenkins" for broader matching
- Fortinet FortiGate template: Fixed indentation of a type declaration that was causing syntax errors
- ClearPass Policy Manager template: Improved regex pattern for detecting Aruba ClearPass references
