### PR TITLE
Improve Templates

### DIFF
--- a/utils/nuclei/templates/discover/application/hypervisor/vmware-vsphere.yaml
+++ b/utils/nuclei/templates/discover/application/hypervisor/vmware-vsphere.yaml
@@ -24,7 +24,7 @@ http:
         part: header
         words:
           - "VMware vCenter Server"
-          - "vCenter Server"
+          - "VMware-CSRF-Token"
         case-insensitive: true
       - type: word
         part: body
@@ -33,6 +33,10 @@ http:
           - "VMware vCenter Server"
           - "VMware VirtualCenter"
           - "vsphere-client"
-          - "VMware vCenter"
-          - "vCenter Server"
         case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)VMware\\s+vSphere\\s+Client"
+          - "(?i)vCenter\\s+Server\\s+[0-9]+\\.[0-9]+"
+          - "(?i)VMware.*vCenter.*Server.*[0-9]+\\.[0-9]+"

--- a/utils/nuclei/templates/discover/application/networkmanagementsystem/f5-bigip.yaml
+++ b/utils/nuclei/templates/discover/application/networkmanagementsystem/f5-bigip.yaml
@@ -3,7 +3,7 @@ info:
   name: F5 BIG-IP Configuration Utility Detection
   author: method-security
   severity: info
-  description: Detects F5 BIG-IP Configuration Utility web management interfaces by identifying login pages, authentication endpoints, and F5-specific branding elements.
+  description: Detects F5 BIG-IP Configuration Utility web management interfaces by identifying login pages and management-specific endpoints (not load balancer infrastructure).
   metadata:
     method-application-type: NETWORK_MANAGEMENT_SYSTEM
     method-module-name: F5_BIGIP
@@ -23,21 +23,14 @@ http:
       - type: regex
         part: body
         regex:
-          - '(?i)<title[^>]*>.*BIG-IP.*Configuration\s*Utility.*</title>'
+          - '(?i)<title[^>]*>.*F5.*BIG-IP.*Configuration\s*Utility.*</title>'
           - '(?i)F5\s*BIG-IP\s*(Configuration\s*Utility|Management\s*Console)'
           - '(?i)BIG-IP.*Configuration\s*Utility.*Login'
       - type: word
         part: body
         words:
-          - "BIG-IP"
-          - "tmui/login"
-        case-insensitive: true
-        condition: and
-      - type: word
-        part: body
-        words:
           - "F5 BIG-IP"
-          - "Configuration Utility"
+          - "tmui/login"
         case-insensitive: true
         condition: and
       - type: word
@@ -52,7 +45,6 @@ http:
         words:
           - "F5-TrafficShield"
         case-insensitive: true
-      - type: regex
-        part: header
-        regex:
-          - '(?i)Server:\s*BigIP'
+      - type: dsl
+        dsl:
+          - 'contains(tolower(header), "server: bigip") && (contains(tolower(body), "configuration") || contains(tolower(body), "tmui") || contains(tolower(body), "f5"))'

--- a/utils/nuclei/templates/discover/application/networkmanagementsystem/generic-cisco-web-management-interface.yaml
+++ b/utils/nuclei/templates/discover/application/networkmanagementsystem/generic-cisco-web-management-interface.yaml
@@ -3,13 +3,13 @@ info:
   name: Generic Cisco Web Management Interface Detection
   author: method-security
   severity: info
-  description: Detects Cisco router, switch, and network device management interfaces by identifying Cisco branding, admin patterns, and interface elements common across Cisco network products.
+  description: Detects Cisco network device web management interfaces by identifying specific management paths, IOS references, and administrative interface indicators.
   metadata:
     method-application-type: NETWORK_MANAGEMENT_SYSTEM
     method-module-name: CISCO_WEB_INTERFACE
     cpe: cpe:2.3:a:cisco:ios:*:*:*:*:*:*:*:*
   tags: discovery,cisco,web-management,network-management-system
-requests:
+http:
   - method: GET
     path:
       - "{{BaseURL}}"
@@ -20,27 +20,27 @@ requests:
     redirects: true
     max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: and
     matchers:
       - type: regex
         part: body
         regex:
-          - '(?i)<title[^>]*>.*Cisco.*(Management|Router|Switch|Web\s*Interface).*</title>'
-          - '(?i)cisco.*(web\s*management|router|switch)'
-          - '(?i)management.*interface.*cisco'
-          - '(?i)cisco.*(administrative|admin).*interface'
-          - '(?i)/exec/show/.*cisco'
-          - '(?i)cisco.*(ios|nx-os|iosxr)'
+          - '(?i)<title[^>]*>.*Cisco.*(Management|Configuration|Administration).*Interface.*</title>'
+          - '(?i)Cisco\s+(IOS|NX-OS|IOSXR)\s+(Configuration|Management)'
+          - '(?i)Cisco\s+(Router|Switch)\s+(Management|Configuration)\s+Interface'
       - type: word
         part: body
         words:
-          - "Cisco"
+          - "/exec/show/"
           - "Cisco IOS"
-          - "NX-OS"
-          - "IOS-XR"
-          - "IOS Software"
-          - "webcm"
-          - "cisco_logo"
-          - "/level/15/exec/"
-          - "show/log/CR"
         case-insensitive: true
+        condition: and
+      - type: word
+        part: body
+        words:
+          - "cisco_logo"
+          - "management"
+        case-insensitive: true
+        condition: and
+      - type: dsl
+        dsl:
+          - 'contains(tolower(body), "cisco") && (contains(tolower(body), "/level/15/") || contains(tolower(body), "cgi-bin/webcm") || contains(tolower(body), "exec/show"))'

--- a/utils/nuclei/templates/discover/application/vdiapplication/windows-rdp.yaml
+++ b/utils/nuclei/templates/discover/application/vdiapplication/windows-rdp.yaml
@@ -31,5 +31,15 @@ http:
       - type: regex
         part: body
         regex:
-          - "(?i)RemoteDesktopGateway"
           - "(?i)login\\.aspx.*RDWeb"
+      - type: word
+        part: body
+        words:
+          - "RemoteApp and Desktop Connection"
+          - "/RDWeb/Pages/en-US/Default.aspx"
+        condition: and
+        case-insensitive: true
+      - type: regex
+        part: body
+        regex:
+          - "(?i)microsoft.*remote.*desktop.*gateway"


### PR DESCRIPTION
### TL;DR

Enhanced detection patterns for VMware vSphere, F5 BIG-IP, Cisco Web Management, and Windows RDP interfaces.

### What changed?

- **VMware vSphere**: Replaced "vCenter Server" with "VMware-CSRF-Token" in header detection, removed redundant body matchers, and added regex patterns to detect version numbers and client references.
- **F5 BIG-IP**: Refined description to focus on management interfaces, improved title regex pattern, simplified detection logic, and replaced header regex with a more precise DSL matcher.
- **Cisco Web Management**: Converted from `requests` to `http` format, tightened regex patterns to focus on management interfaces, and added DSL matcher for more accurate detection.
- **Windows RDP**: Added new word matchers for "RemoteApp and Desktop Connection" and improved regex patterns to better identify Microsoft Remote Desktop Gateway.
