### PR TITLE
Update Application Discover

### DIFF
--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -49,6 +49,7 @@ types:
     properties:
       resourceType: ApplicationResourceType
       module: string
+      subModule: optional<string>
       detectionState: optional<ApplicationDetectionState>
       cpe: optional<string>
       request: http.HttpRequestResponse

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -24,6 +24,7 @@ func convertNucleiAttemptToFingerprintAttemptStruct(nucleiAttempt *nuclei.Nuclei
 	// Extract resource type, module, detection state, and CPE from template metadata
 	var resourceTypeMetadata discover.ApplicationResourceType
 	var moduleNameFromMetadata string
+	var subModuleNameFromMetadata *string
 	var detectionStateFromMetadata *discover.ApplicationDetectionState
 	var cpeFromMetadata *string
 
@@ -39,6 +40,11 @@ func convertNucleiAttemptToFingerprintAttemptStruct(nucleiAttempt *nuclei.Nuclei
 		// Check for method-module-name in metadata
 		if moduleStr, exists := nucleiAttempt.Finding.Metadata["method-module-name"]; exists {
 			moduleNameFromMetadata = strings.ToUpper(moduleStr)
+		}
+
+		// Check for method-sub-module-name in metadata
+		if subModuleStr, exists := nucleiAttempt.Finding.Metadata["method-sub-module-name"]; exists {
+			subModuleNameFromMetadata = &subModuleStr
 		}
 
 		// Check for method-detection-state in metadata
@@ -58,6 +64,7 @@ func convertNucleiAttemptToFingerprintAttemptStruct(nucleiAttempt *nuclei.Nuclei
 	attempt := &discover.ApplicationFingerprintAttempt{
 		ResourceType:   resourceTypeMetadata,
 		Module:         moduleNameFromMetadata,
+		SubModule:      subModuleNameFromMetadata,
 		DetectionState: detectionStateFromMetadata,
 		Cpe:            cpeFromMetadata,
 		Finding:        true,

--- a/utils/nuclei/templates/discover/application/hardwaremanagementsystem/apc-ups.yaml
+++ b/utils/nuclei/templates/discover/application/hardwaremanagementsystem/apc-ups.yaml
@@ -7,7 +7,6 @@ info:
   metadata:
     method-application-type: HARDWARE_MANAGEMENT_SYSTEM
     method-module-name: APC_UPS
-    method-detection-state: MANAGEMENT_CONSOLE
     cpe: cpe:2.3:h:apc:*:*:*:*:*:*:*:*:*
   tags: discovery,apc,ups,pdu,power,hardware,management-console
 http:

--- a/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
@@ -7,7 +7,7 @@ info:
   metadata:
     method-application-type: KUBE
     method-module-name: KUBE
-    method-detection-state: MANAGEMENT_CONSOLE
+    method-sub-module-name: MANAGEMENT_CONSOLE
     cpe: cpe:2.3:a:kubernetes:kubernetes:*:*:*:*:*:*:*:*
   tags: discovery,kubernetes,k8s,dashboard,manager,enterprise,management-console
 http:

--- a/utils/nuclei/templates/discover/application/networkfirewall/zyxel-device.yaml
+++ b/utils/nuclei/templates/discover/application/networkfirewall/zyxel-device.yaml
@@ -7,7 +7,6 @@ info:
   metadata:
     method-application-type: NETWORK_FIREWALL
     method-module-name: ZYXEL_DEVICE
-    method-detection-state: MANAGEMENT_CONSOLE
     cpe: cpe:2.3:h:zyxel:*:*:*:*:*:*:*:*:*
   tags: discovery,zyxel,firewall,router,gateway,network-device,management-console
 http:
@@ -70,4 +69,4 @@ http:
           - '(contains(tolower(body), "download master") || contains(tolower(body), "main_login.asp") || contains(tolower(body), "basic_operation_mode.asp")) && contains(tolower(header), "zyxel")'
       - type: dsl
         dsl:
-          - 'contains(tolower(header), "zyxel") || contains(tolower(header), "zyx") || contains(tolower(body), "zyxel") || contains(tolower(body), "keenetic") || contains(tolower(body), "zywall")'
+          - '(contains(tolower(header), "server: zyxel") || contains(tolower(header), "www-authenticate") && contains(tolower(header), "zyxel")) && (contains(tolower(body), "login") || contains(tolower(body), "password"))'

--- a/utils/nuclei/templates/discover/application/networkmanagementsystem/barracuda-email-security-gateway.yaml
+++ b/utils/nuclei/templates/discover/application/networkmanagementsystem/barracuda-email-security-gateway.yaml
@@ -7,7 +7,6 @@ info:
   metadata:
     method-application-type: NETWORK_MANAGEMENT_SYSTEM
     method-module-name: BARRACUDA_EMAIL_SECURITY_GATEWAY
-    method-detection-state: MANAGEMENT_CONSOLE
     cpe: cpe:2.3:h:barracuda:email_security_gateway:*:*:*:*:*:*:*:*
   tags: discovery,barracuda,email,security,gateway,spam,firewall,management-console
 http:

--- a/utils/nuclei/templates/discover/application/networkmanagementsystem/generic-cisco-web-management-interface.yaml
+++ b/utils/nuclei/templates/discover/application/networkmanagementsystem/generic-cisco-web-management-interface.yaml
@@ -6,7 +6,8 @@ info:
   description: Detects Cisco network device web management interfaces by identifying specific management paths, IOS references, and administrative interface indicators.
   metadata:
     method-application-type: NETWORK_MANAGEMENT_SYSTEM
-    method-module-name: CISCO_WEB_INTERFACE
+    method-module-name: CISCO
+    method-sub-module-name: MANAGEMENT_CONSOLE
     cpe: cpe:2.3:a:cisco:ios:*:*:*:*:*:*:*:*
   tags: discovery,cisco,web-management,network-management-system
 http:

--- a/utils/nuclei/templates/discover/application/webserver/default-tomcat-manager.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/default-tomcat-manager.yaml
@@ -7,7 +7,8 @@ info:
   metadata:
     method-application-type: WEB_SERVER
     method-module-name: TOMCAT
-    method-detection-state: MANAGER_PAGE
+    method-sub-module-name: MANAGEMENT_CONSOLE
+    method-detection-state: DEFAULT
     cpe: cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*
   tags: discovery,tomcat,default-page,manager,misconfiguration
 http:


### PR DESCRIPTION
### TL;DR

Added support for application sub-modules in the discovery system to better categorize application components.

### What changed?

- Added an optional `subModule` field to the `ApplicationFingerprintAttempt` type in the Fern definition
- Updated the application engine to extract and populate the sub-module information from Nuclei template metadata
- Refactored several Nuclei templates to use the new sub-module field instead of detection state where appropriate:
    - Moved `MANAGEMENT_CONSOLE` from detection state to sub-module for Kubernetes templates
    - Updated Cisco template to use `CISCO` as the module name and `WEB_MANAGEMENT_INTERFACE` as the sub-module
    - Changed Tomcat template to use `MANAGEMENT_CONSOLE` as sub-module and `DEFAULT` as detection state
- Improved detection logic for Zyxel devices with more specific header and body matching