### PR TITLE
Update Templates

### DIFF
--- a/utils/nuclei/templates/discover/application/distributedcomputingplatform/anyscale-ray.yaml
+++ b/utils/nuclei/templates/discover/application/distributedcomputingplatform/anyscale-ray.yaml
@@ -34,14 +34,13 @@ http:
         part: body
         regex:
           - '(?i)<title[^>]*>.*Ray.*Dashboard.*</title>'
-          - '(?i)<title[^>]*>.*Anyscale.*</title>'
+          - '(?i)<title[^>]*>.*Anyscale.*(Dashboard|Console|Platform).*</title>'
           - '(?i)Ray.*Cluster.*Dashboard'
           - '(?i)Anyscale.*Ray.*Platform'
       - type: word
         part: body
         words:
           - "Redirecting to Anyscale to authenticate"
-          - "Ray cluster"
         case-insensitive: true
       - type: word
         part: header
@@ -53,10 +52,8 @@ http:
       - type: regex
         part: body
         regex:
-          - '(?i)ray.*serve.*dashboard'
-          - '(?i)ray.*jobs.*dashboard'
-          - '(?i)ray.*cluster.*status'
-          - '(?i)ray.*actor.*dashboard'
+          - '(?i)ray\\s+(serve|jobs|actor)\\s+dashboard'
+          - '(?i)ray\\s+cluster\\s+(status|dashboard)'
       - type: word
         part: body
         words:
@@ -68,7 +65,7 @@ http:
         case-insensitive: true
       - type: dsl
         dsl:
-          - 'contains(tolower(body), "anyscale") && (contains(tolower(body), "ray") || contains(tolower(body), "cluster") || contains(tolower(body), "dashboard")) && (contains(tolower(body), "authenticating") || contains(tolower(body), "redirecting"))'
+          - 'contains(tolower(body), "anyscale") && contains(tolower(body), "ray") && (contains(tolower(body), "dashboard") || contains(tolower(body), "cluster")) && (contains(tolower(body), "authenticating") || contains(tolower(body), "redirecting") || contains(tolower(body), "login"))'
       - type: dsl
         dsl:
-          - 'contains(tolower(header), "x-anyscale") && (contains(tolower(body), "api") || contains(tolower(body), "v1") || contains(tolower(body), "meta"))'
+          - 'contains(tolower(header), "x-anyscale") && (contains(tolower(body), "ray") || contains(tolower(body), "cluster") || contains(tolower(body), "dashboard"))'

--- a/utils/nuclei/templates/discover/application/networkfirewall/zyxel-device.yaml
+++ b/utils/nuclei/templates/discover/application/networkfirewall/zyxel-device.yaml
@@ -33,7 +33,7 @@ http:
         regex:
           - '(?i)Server:\s*ZyXEL-RomPager\/[\d\.]+'
           - '(?i)Server:\s*Zyxel\s+USG\s+FLEX\s+\d+'
-          - '(?i)Server:\s*Zyxel.*'
+          - '(?i)Server:\s*Zyxel\s+(USG|ZyWALL|Keenetic)'
       - type: regex
         part: header
         regex:
@@ -45,8 +45,6 @@ http:
         words:
           - "ZyXEL Communications Corp."
           - "ZyXEL Technology Corporation"
-          - "Zyxel Communications"
-          - "www.zyxel.com"
         case-insensitive: true
       - type: regex
         part: body
@@ -57,13 +55,11 @@ http:
           - '(?i)zyxel.*vdsl.*router'
       - type: dsl
         dsl:
-          - '(contains(tolower(body), "keenetic") || contains(tolower(body), "zywall") || contains(tolower(body), "usg flex") || contains(tolower(body), "nebula")) && contains(tolower(body), "zyxel")'
+          - '(contains(tolower(body), "keenetic") || contains(tolower(body), "zywall") || contains(tolower(body), "usg flex")) && contains(tolower(body), "zyxel") && (contains(tolower(body), "login") || contains(tolower(body), "management") || contains(tolower(body), "configuration"))'
       - type: regex
         part: body
         regex:
-          - '(?i)<title[^>]*>.*zyxel.*</title>'
-          - '(?i)<title[^>]*>.*keenetic.*</title>'
-          - '(?i)<title[^>]*>.*zywall.*</title>'
+          - '(?i)<title[^>]*>.*(Zyxel|ZyWALL).*(Login|Management|Configuration).*</title>'
       - type: dsl
         dsl:
           - '(contains(tolower(body), "download master") || contains(tolower(body), "main_login.asp") || contains(tolower(body), "basic_operation_mode.asp")) && contains(tolower(header), "zyxel")'


### PR DESCRIPTION
### TL;DR

Improved detection patterns for Anyscale Ray and ZyXEL devices by optimizing regex patterns and refining matching criteria.

### What changed?

For Anyscale Ray template:
- Enhanced title detection by adding "Console" and "Platform" to the Anyscale title regex
- Removed "Ray cluster" from word matchers as it's redundant
- Consolidated multiple regex patterns into more efficient patterns using alternation
- Improved DSL conditions to be more specific and include "login" as a potential indicator
- Updated the header detection logic to be more accurate

For ZyXEL device template:
- Refined the server header regex to be more specific with device types (USG, ZyWALL, Keenetic)
- Removed redundant word matchers
- Enhanced DSL conditions to require login/management/configuration context
- Consolidated title regex patterns into a more efficient single pattern