### PR TITLE
Update ENUM for Tomcat Default Page Template

### DIFF
--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -7,14 +7,11 @@ types:
     enum:
       - CMDI
       - CRLF
-      - CSTI
-      - INJECTION
       - LFI
-      - REDIRECT
       - RFI
       - SQLI
-      - SSTI
       - SSRF
+      - SSTI
       - XSS
       - XXE
   # Config Struct

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -17,17 +17,14 @@ var dastBaseTemplatePath = "pentest/dast"
 
 // dastCategoriesToPathMap maps the dast categories to the corresponding template paths.
 var dastCategoriesToPathMap = map[pentestapplicationfern.PentestApplicationDastCategory]string{
-	pentestapplicationfern.PentestApplicationDastCategoryCmdi:      fmt.Sprintf("%s/cmdi", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryCrlf:      fmt.Sprintf("%s/crlf", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryCsti:      fmt.Sprintf("%s/csti", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryInjection: fmt.Sprintf("%s/injection", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryLfi:       fmt.Sprintf("%s/lfi", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryRedirect:  fmt.Sprintf("%s/redirect", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryRfi:       fmt.Sprintf("%s/rfi", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategorySqli:      fmt.Sprintf("%s/sqli", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategorySsrf:      fmt.Sprintf("%s/ssrf", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategorySsti:      fmt.Sprintf("%s/ssti", dastBaseTemplatePath),
-	pentestapplicationfern.PentestApplicationDastCategoryXxe:       fmt.Sprintf("%s/xxe", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategoryCmdi: fmt.Sprintf("%s/cmdi", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategoryCrlf: fmt.Sprintf("%s/crlf", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategoryLfi:  fmt.Sprintf("%s/lfi", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategoryRfi:  fmt.Sprintf("%s/rfi", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategorySqli: fmt.Sprintf("%s/sqli", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategorySsrf: fmt.Sprintf("%s/ssrf", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategorySsti: fmt.Sprintf("%s/ssti", dastBaseTemplatePath),
+	pentestapplicationfern.PentestApplicationDastCategoryXxe:  fmt.Sprintf("%s/xxe", dastBaseTemplatePath),
 }
 
 // dastCategoriesToWorkflowMap maps the dast categories that have workflows to their workflow paths.

--- a/utils/nuclei/templates/discover/application/webserver/default-tomcat-manager.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/default-tomcat-manager.yaml
@@ -8,7 +8,7 @@ info:
     method-application-type: WEB_SERVER
     method-module-name: TOMCAT
     method-sub-module-name: MANAGEMENT_CONSOLE
-    method-detection-state: DEFAULT
+    method-detection-state: DEFAULT_PAGE
     cpe: cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*
   tags: discovery,tomcat,default-page,manager,misconfiguration
 http:


### PR DESCRIPTION
### TL;DR

Removed unused DAST categories and updated Tomcat template detection state

### What changed?

- Removed three DAST categories from the enum: `CSTI`, `INJECTION`, and `REDIRECT`
- Updated corresponding path mappings in the Go code to match the reduced enum
- Changed the `method-detection-state` value from `DEFAULT` to `DEFAULT_PAGE` in the default-tomcat-manager.yaml template

---

> [!NOTE]
> Aligns DAST enum and Go path mappings (removes CSTI/INJECTION/REDIRECT; keeps SSTI) and changes Tomcat template detection state to DEFAULT_PAGE.
>
> - **DAST**:
>     - **Enum (`fern/definition/pentest/application/dast.yml`)**: Remove `CSTI`, `INJECTION`, `REDIRECT`; ensure `SSTI` remains.
>     - **Path mappings (`internal/pentest/application/dast.go`)**: Drop template paths for removed categories; keep existing mappings and XSS workflow.
> - **Templates**:
>     - **Tomcat**: Update `method-detection-state` to `DEFAULT_PAGE` in `utils/nuclei/templates/discover/application/webserver/default-tomcat-manager.yaml`.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47c1d3036791a6fc6708fb81b1ef97a77e9f33b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>