### PR TITLE
Nginx OR + Stale Asset Bug Fix

### DIFF
--- a/configs/pentest/route/static_asset_takeover.json
+++ b/configs/pentest/route/static_asset_takeover.json
@@ -28,6 +28,7 @@
         "name": "CloudFront",
         "description": "Domain is pointing to an AWS CloudFront distribution that has been deleted or is misconfigured.",
         "responseBody": ["the request could not be satisfied"],
+        "excludeResponseBody": ["request blocked"],
         "statusCode": 403
       }
     ]

--- a/fern/definition/pentest/route/staticassettakeover.yml
+++ b/fern/definition/pentest/route/staticassettakeover.yml
@@ -15,6 +15,7 @@ types:
       name: string
       description: string
       responseBody: optional<list<string>>
+      excludeResponseBody: optional<list<string>>
       statusCode: integer
   # Report Struct
   StaticAssetTakeoverVulnerableDetails:

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -83,7 +83,7 @@ func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePat
 		fingerprints = append(fingerprints, config.Fingerprints...)
 	}
 
-	log.Info("Grabbed static asset take over fingerprints", svc1log.SafeParam("fingerprint_length", len(fingerprints)))
+	log.Info("Grabbed static asset take over fingerprints", svc1log.SafeParam("num_of_fingerprints", len(fingerprints)))
 	return fingerprints
 }
 
@@ -108,6 +108,12 @@ func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.Http
 	instance := pentestroutefern.StaticAssetTakeoverVulnerableDetails{}
 	for _, fingerprint := range fingerprints {
 
+		// Does response body contain any of the exclude response bodies
+		for _, excludeResponseBody := range fingerprint.ExcludeResponseBody {
+			if strings.Contains(lowerResponseBody, excludeResponseBody) {
+				return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
+			}
+		}
 		// Does the status code and response body of the request match the fingerprint
 		for _, fingerprintBody := range fingerprint.ResponseBody {
 			if *httpRequestResponse.Response.StatusCode == fingerprint.StatusCode && strings.Contains(lowerResponseBody, fingerprintBody) {

--- a/utils/nuclei/templates/pentest/scan/technology/webserver/nginx/nginx-query-reverse-proxy.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/nginx/nginx-query-reverse-proxy.yaml
@@ -26,7 +26,10 @@ http:
           - 303
           - 307
           - 308
-      - type: word
+      - type: regex
         part: header
-        words:
-          - "attacker.com"
+        regex:
+          # Match Location headers that redirect to attacker.com domain
+          # Simple pattern that works - attacker.com must appear after protocol
+          # False positives that won't match: Location: https://site.com/?url=https%3A%2F%2Fattacker.com
+          - 'Location:\s*https?://attacker\.com'


### PR DESCRIPTION
### TL;DR

Added support for excluding specific response bodies in static asset takeover detection and improved the nginx query reverse proxy template to reduce false positives.

### What changed?

- Added `excludeResponseBody` field to the static asset takeover fingerprint configuration to filter out false positives
- Implemented logic to check for excluded response bodies before determining if a domain is vulnerable
- Updated the CloudFront fingerprint to exclude responses containing "request blocked"
- Improved the nginx query reverse proxy template by replacing simple word matching with regex pattern matching for more accurate detection
- Added a test nginx configuration file for validating the detection logic
- Renamed a log parameter from "fingerprint_length" to "num_of_fingerprints" for clarity

### How to test?

1. Run static asset takeover tests against CloudFront domains that return "request blocked" messages to verify they're properly excluded
2. Use the new nginx-test.conf to validate that the nginx query reverse proxy template correctly identifies true positives while avoiding false positives
3. Verify that domains matching fingerprint status codes and response bodies but also containing excluded response bodies are not flagged as vulnerable

### Why make this change?

The previous implementation was generating false positives for CloudFront domains that were actually properly configured but returning "request blocked" messages. The nginx query reverse proxy template was also too simplistic, flagging legitimate redirects that happened to mention "attacker.com" in parameters or paths. These changes improve detection accuracy by filtering out known false positive patterns.