### PR TITLE
fixed the broken links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ webscan is designed as a simple, easy to use web application scanning tool that 
 
 The types of scans that webscan can conduct are constantly growing. For the most up to date listing, please see the documentation [here](./docs/index.md)
 
-To learn more about webscan, please see the [Documentation site](https://method-security.github.io/webscan/) for the most detailed information.
+To learn more about webscan, please see the [Documentation site](./docs/index.md) for the most detailed information.
 
 ## Quick Start
 
 ### Get webscan
 
-For the full list of available installation options, please see the [Installation](./getting-started/installation.md) page. For convenience, here are some of the most commonly used options:
+For the full list of available installation options, please see the [Installation](./docs/getting-started/installation.md) page. For convenience, here are some of the most commonly used options:
 
 - `docker run methodsecurity/webscan`
 - `docker run ghcr.io/method-security/webscan`
 - Download the latest binary from the [Github Releases](https://github.com/Method-Security/webscan/releases/latest) page
-- [Installation documentation](./getting-started/installation.md)
+- [Installation documentation](./docs/getting-started/installation.md)
 
 ### Examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,6 @@ webscan is designed as a simple, easy to use web application scanning tool that 
 
 The types of scans that webscan can conduct are constantly growing. For the most up to date listing, please see the documentation [here](./docs/index.md)
 
-To learn more about webscan, please see the [Documentation site](https://method-security.github.io/webscan/) for the most detailed information.
-
 ## Quick Start
 
 ### Get webscan


### PR DESCRIPTION
There were broken links attached to the documentation and the README.md: 

This is the broken link - `https://method-security.github.io/webscan/`

The webscan documentation was also referring to itself, so I removed that line. 

This PR is fixing trivial documentation issues, so not associating this PR with an issue or a bug as mentioned here - `https://method-security.github.io/community/contribute/pr.html`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update README and docs index to point to local docs, correct installation paths, and remove a redundant self-referential docs line.
> 
> - **Documentation**:
>   - **README**: Update documentation link to `./docs/index.md`; fix installation links to `./docs/getting-started/installation.md`.
>   - **Docs index**: Remove redundant line linking to itself.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33819a0d3cb6f71bb5a2372a39bbd16dd42b4a3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->