### PR TITLE
Update Apache and Default Tomcat Page Templates

### DIFF
--- a/utils/nuclei/templates/discover/application/webserver/apache/apache.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/apache/apache.yaml
@@ -29,17 +29,24 @@ http:
           - "(?i)Apache/[\\d.]+ \\(Unix\\)"
           - "(?i)<address>Apache/[\\d.]+"
       - type: word
+        part: header
         words:
           - "tomcat"
-          - "apache tomcat"
-          - "apache-coyote"
           - "coyote" 
           - "catalina"
+        case-insensitive: true
+        negative: true
+      - type: word
+        part: body
+        words:
           - "Apache Tomcat"
+          - "Apache-Tomcat"
+          - "Apache Coyote"
+          - "Apache-Coyote"
+          - "Powered by Tomcat"
           - "Tomcat Web Application Manager"
           - "Tomcat Web Server"
           - "Tomcat Catalina"
           - "Tomcat Coyote"
-          - "Powered by Tomcat"
         case-insensitive: true
         negative: true

--- a/utils/nuclei/templates/discover/application/webserver/tomcat/default-tomcat-page.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tomcat/default-tomcat-page.yaml
@@ -3,7 +3,7 @@ info:
   name: Default Apache Tomcat Welcome Page Detection
   author: method-security
   severity: info
-  description: Detects the default Apache Tomcat welcome page that indicates a default installation.
+  description: Detects Apache Tomcat default pages including welcome page and documentation that indicate a default installation.
   metadata:
     method-application-type: WEB_SERVER
     method-module-name: TOMCAT
@@ -19,14 +19,16 @@ http:
     redirects: true
     max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: and
     matchers:
       - type: regex
         part: body
         regex:
+          - "(?i)<title>.*Apache\\s+Tomcat\\s+[0-9]+\\.[0-9]+.*</title>"
           - "(?i)<title>Apache\\s+Tomcat/[0-9]+\\.[0-9]+\\.[0-9]+</title>"
       - type: word
         part: body
         words:
           - "If you're seeing this, you've successfully installed Tomcat. Congratulations!"
+          - "If you're seeing this page via a web browser, it means you've setup Tomcat successfully"
+          - "As you may have guessed by now, this is the default Tomcat home page"
         case-insensitive: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances detection accuracy for Apache and Tomcat templates.
> 
> - Apache: adds header-based negative words (`tomcat`, `coyote`, `catalina`) and body negatives (e.g., `Apache-Tomcat`, `Apache Coyote`, `Powered by Tomcat`) with case-insensitive matching to reduce Tomcat-related false positives
> - Tomcat default page: updates description, adds broader `<title>` regex to match more versions, and includes additional default-page phrases; simplifies matcher config by removing `matchers-condition`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e4e98e44974f34c263c8129ffa28dd793777833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->