### PR TITLE
Update IIS Shortname Detection Template

### DIFF
--- a/utils/nuclei/templates/pentest/scan/technology/webserver/iis/iis-shortname.yaml
+++ b/utils/nuclei/templates/pentest/scan/technology/webserver/iis/iis-shortname.yaml
@@ -1,174 +1,75 @@
 id: iis-shortname
+
 info:
-  name: IIS - Short Name Detect (expanded canonical-first, full 40 reqs)
-  author: nodauf # Updated by method-security
+  name: IIS - Short Name (8.3) Disclosure Detection
+  author: nodauf # updated by method-security
   severity: info
   description: >
-    Detect IIS short-name (8.3) disclosure using tilde (~) short-name probes.
-    Each test is sent as a pair: a canonical (non-tilde) request followed immediately by
-    the likely short-name (~) counterpart. The matcher flags when the canonical variant
-    fails but the tilde variant succeeds (or has a larger body), indicating a likely disclosure.
+    Detects IIS short-name (8.3) disclosure using paired canonical and short-name
+    requests. Each test sends a non-tilde canonical path followed by its likely
+    short-name (~1) variant. Detection is based on differing response behavior
+    (status code and content-length deltas), indicating short-name enumeration.
   reference:
     - https://github.com/lijiejie/IIS_shortname_Scanner
     - https://www.exploit-db.com/exploits/19525
     - http://soroush.secproject.com/blog/2012/06/microsoft-iis-tilde-character-vulnerabilityfeature-short-filefolder-name-disclosure/
   classification:
-    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
   metadata:
     method-software-weakness-name: IIS_SHORT_NAME_DISCLOSURE # Added by method-security
-    max-request: 40
-  tags: iis,edb,fuzzing,shortname
+    max-request: 24
+  tags: iis,shortname,tilde,disclosure
 variables:
   Hostname: "{{Hostname}}"
-  BaseURL: "{{BaseURL}}"
-  AcceptHeader: "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8"
+  AcceptHeader: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 http:
   - raw:
-      # Pair 1: non-existent canonical vs shortname
+      # Pair 1: Non-existent baseline
       - |
         GET /N0t4xist/.rem HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /N0t4xist~1/.rem HTTP/1.1
+        GET /N0t4x~1/.rem HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 2: Program Files index
+      # Pair 2: Encoded tilde
       - |
-        GET /Program%20Files/index.html HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /PROGRA~1/index.html HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 3: Program Files dir
-      - |
-        GET /Program%20Files/ HTTP/1.1
+        GET /N0t4xist/.rem HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /PROGRA~1/ HTTP/1.1
+        GET /N0t4xist%7E1/.rem HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 4: Documents dir
+      # Pair 3: Double-encoded tilde
       - |
-        GET /Documents/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /DOCUME~1/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 5: secret.txt
-      - |
-        GET /secret.txt HTTP/1.1
+        GET /N0t4xist/.rem HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /secret~1.txt HTTP/1.1
+        GET /N0t4xist%257E1/.rem HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 6: config
-      - |
-        GET /config/.rem HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /config~1/.rem HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 7: nonexistent .asp
+      # Pair 4: Non-existent ASP
       - |
         GET /N0t4xist.asp HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /N0t4xist~1/.asp HTTP/1.1
+        GET /N0t4x~1.asp HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 8: URL-encoded tilde
+      # Pair 5: Directory-style probe
       - |
-        GET /N0t4xist/.rem HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /%7EN0t4xist~1/.rem HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 9: index
-      - |
-        GET /index/.rem HTTP/1.1
+        GET /N0t4xist/ HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /~1index/.rem HTTP/1.1
+        GET /N0t4x~1/ HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 10: Microsoft dir
-      - |
-        GET /Microsoft/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /MICROS~1/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 11: WebDAV
-      - |
-        GET /WebDAV_Publishing/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /WEBDAV~1/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 12: Double-encoded tilde
-      - |
-        GET /N0t4xist/.rem HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /%257EN0t4xist~1/.rem HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 13: Trailing dot
-      - |
-        GET /Documents/. HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /DOCUME~1./ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 14: Mixed casing
-      - |
-        GET /Program%20Files/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /ProGra~1/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 15: Private notes docx
-      - |
-        GET /private_notes_2024.docx HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /PRIVAT~1.DOC HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 16: Sensitive xlsx
-      - |
-        GET /sensitive_user_information.xlsx HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /SENSIT~1.XLS HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 17: aspnet_client
+      # Pair 6: aspnet_client (confirmation probe)
       - |
         GET /aspnet_client/ HTTP/1.1
         Host: {{Hostname}}
@@ -177,31 +78,22 @@ http:
         GET /ASPNET~1/ HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 18: test.aspx
+      # Pair 7: Web.config-style filename
       - |
-        GET /test.aspx HTTP/1.1
+        GET /web.config HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /TEST~1.ASP HTTP/1.1
+        GET /WEB~1.CON HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
-      # Pair 19: admin_panel
+      # Pair 8: Randomized filename
       - |
-        GET /admin_panel/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      - |
-        GET /ADMIN_~1/ HTTP/1.1
-        Host: {{Hostname}}
-        Accept: {{AcceptHeader}}
-      # Pair 20: secret_documents
-      - |
-        GET /secret_documents/ HTTP/1.1
+        GET /xYz12345.txt HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
       - |
-        GET /SECRET~1/ HTTP/1.1
+        GET /XYZ12~1.TXT HTTP/1.1
         Host: {{Hostname}}
         Accept: {{AcceptHeader}}
     stop-at-first-match: true
@@ -209,42 +101,42 @@ http:
       - type: dsl
         dsl:
           - >
-            (status_code_1 != 200 && status_code_2 == 200)
+            status_code_2 != status_code_1 &&
+            status_code_2 >= 200 &&
+            status_code_2 < 500 &&
+            (len(body_2) - len(body_1) > 10 || len(body_1) - len(body_2) > 10)
           - >
-            (status_code_3 != 200 && status_code_4 == 200)
+            status_code_4 != status_code_3 &&
+            status_code_4 >= 200 &&
+            status_code_4 < 500 &&
+            (len(body_4) - len(body_3) > 10 || len(body_3) - len(body_4) > 10)
           - >
-            (status_code_5 != 200 && status_code_6 == 200)
+            status_code_6 != status_code_5 &&
+            status_code_6 >= 200 &&
+            status_code_6 < 500 &&
+            (len(body_6) - len(body_5) > 10 || len(body_5) - len(body_6) > 10)
           - >
-            (status_code_7 != 200 && status_code_8 == 200)
+            status_code_8 != status_code_7 &&
+            status_code_8 >= 200 &&
+            status_code_8 < 500 &&
+            (len(body_8) - len(body_7) > 10 || len(body_7) - len(body_8) > 10)
           - >
-            (status_code_9 != 200 && status_code_10 == 200)
+            status_code_10 != status_code_9 &&
+            status_code_10 >= 200 &&
+            status_code_10 < 500 &&
+            (len(body_10) - len(body_9) > 10 || len(body_9) - len(body_10) > 10)
           - >
-            (status_code_11 != 200 && status_code_12 == 200)
+            status_code_12 != status_code_11 &&
+            status_code_12 >= 200 &&
+            status_code_12 < 500 &&
+            (len(body_12) - len(body_11) > 10 || len(body_11) - len(body_12) > 10)
           - >
-            (status_code_13 != 200 && status_code_14 == 200)
+            status_code_14 != status_code_13 &&
+            status_code_14 >= 200 &&
+            status_code_14 < 500 &&
+            (len(body_14) - len(body_13) > 10 || len(body_13) - len(body_14) > 10)
           - >
-            (status_code_15 != 200 && status_code_16 == 200)
-          - >
-            (status_code_17 != 200 && status_code_18 == 200)
-          - >
-            (status_code_19 != 200 && status_code_20 == 200)
-          - >
-            (status_code_21 != 200 && status_code_22 == 200)
-          - >
-            (status_code_23 != 200 && status_code_24 == 200)
-          - >
-            (status_code_25 != 200 && status_code_26 == 200)
-          - >
-            (status_code_27 != 200 && status_code_28 == 200)
-          - >
-            (status_code_29 != 200 && status_code_30 == 200)
-          - >
-            (status_code_31 != 200 && status_code_32 == 200)
-          - >
-            (status_code_33 != 200 && status_code_34 == 200)
-          - >
-            (status_code_35 != 200 && status_code_36 == 200)
-          - >
-            (status_code_37 != 200 && status_code_38 == 200)
-          - >
-            (status_code_39 != 200 && status_code_40 == 200)
+            status_code_16 != status_code_15 &&
+            status_code_16 >= 200 &&
+            status_code_16 < 500 &&
+            (len(body_16) - len(body_15) > 10 || len(body_15) - len(body_16) > 10)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes and streamlines the IIS short-name (8.3) detection template.
> 
> - Replaces the prior 40-request approach with 8 targeted request pairs (24 max requests) covering encoded/double-encoded tilde variants, directory/file ASP patterns, `aspnet_client`, `web.config`, and a randomized filename; `stop-at-first-match` retained
> - Shifts matchers to per-pair behavioral checks using status-code and body-length deltas, replacing strict 200-response comparisons
> - Updates `info`/`classification` (CVSS confidentiality impact), `metadata` (`max-request`), and `tags`; removes `BaseURL` and simplifies `Accept` header
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5de2951bdd7130b363349058d82514ee87f406f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->