### PR TITLE
Update Tomcat manager detection with 401 status and header matching

### DIFF
--- a/utils/nuclei/templates/discover/application/webserver/tomcat/default-tomcat-manager.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tomcat/default-tomcat-manager.yaml
@@ -25,7 +25,6 @@ http:
     matchers:
       - type: status
         status:
-          - 200
           - 401
       - type: word
         part: header

--- a/utils/nuclei/templates/discover/application/webserver/tomcat/default-tomcat-manager.yaml
+++ b/utils/nuclei/templates/discover/application/webserver/tomcat/default-tomcat-manager.yaml
@@ -26,9 +26,10 @@ http:
       - type: status
         status:
           - 200
+          - 401
       - type: word
-        part: body
+        part: header
         words:
           - "Tomcat Web Application Manager"
-          - "Tomcat Host Manager Application"
+          - "Tomcat Manager Application"
         case-insensitive: true


### PR DESCRIPTION
### TL;DR

Enhanced Tomcat manager detection by adding 401 status code and refining search patterns.

### What changed?

- Added HTTP status code `401` to the detection matchers to identify Tomcat manager instances that require authentication
- Changed the search location from `body` to `header` for more accurate detection
- Updated the word patterns to specifically look for "Tomcat Manager Application" instead of "Tomcat Host Manager Application"

### How to test?

1. Run the updated template against known Tomcat instances
2. Verify that it correctly identifies Tomcat manager instances that return 401 responses
3. Confirm that the detection works when the identifying strings appear in headers rather than body

### Why make this change?

Tomcat manager instances often return 401 status codes when authentication is required, and the identifying strings may appear in HTTP headers rather than the response body. These changes improve detection accuracy by capturing these scenarios, reducing false negatives in the discovery process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Tomcat manager detection accuracy in `default-tomcat-manager.yaml`.
> 
> - Change status matcher to `401` to capture auth-protected manager endpoints
> - Move word matcher from `body` to `header`; update keywords to `"Tomcat Web Application Manager"` and `"Tomcat Manager Application"` (removes `"Tomcat Host Manager Application"`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9618e1b4e6ea33c0f739047141459a6bc74a6f0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->