### PR TITLE
Nuclei Report URL Bug Fix 

### DIFF
--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -16,15 +16,6 @@ import (
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
 
-// getBaseURL extracts the base URL from a ResultEvent.
-func getBaseURL(ev *nout.ResultEvent) string {
-	parsedURL, err := url.Parse(ev.URL)
-	if err != nil {
-		return ev.URL
-	}
-	return fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
-}
-
 // getTargetURL extracts the target URL from a ResultEvent.
 // excludes query parameters and fragment ie. https://example.com/path?query#fragment -> https://example.com/path
 func getTargetURL(ev *nout.ResultEvent) string {

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -25,6 +25,7 @@ func getTargetURL(ev *nout.ResultEvent) string {
 	}
 	parsedURL.RawQuery = ""
 	parsedURL.Fragment = ""
+	parsedURL.RawFragment = ""
 	return parsedURL.String()
 }
 

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -25,6 +25,17 @@ func getBaseURL(ev *nout.ResultEvent) string {
 	return fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
 }
 
+// getTargetURL extracts the target URL from a ResultEvent.
+func getTargetURL(ev *nout.ResultEvent) string {
+	parsedURL, err := url.Parse(ev.URL)
+	if err != nil {
+		return ev.URL
+	}
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
+	return parsedURL.String()
+}
+
 // parseRawRequest parses a raw HTTP request string into its components.
 // Returns method, path, headers, and body.
 func parseRawRequest(raw string) (method, path string, headers map[string]string, body string) {

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -26,6 +26,7 @@ func getBaseURL(ev *nout.ResultEvent) string {
 }
 
 // getTargetURL extracts the target URL from a ResultEvent.
+// excludes query parameters and fragment ie. https://example.com/path?query#fragment -> https://example.com/path
 func getTargetURL(ev *nout.ResultEvent) string {
 	parsedURL, err := url.Parse(ev.URL)
 	if err != nil {

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -3,6 +3,7 @@ package nuclei
 import (
 	// Generated
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -234,8 +235,14 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	baseURL := getBaseURL(ev)
 	targetInfo, ok := b.targetIdx[baseURL]
 	if !ok {
-		// Use the full URL (including path) for the Target field
-		targetInfo = &nuclei.NucleiTargetInfo{Target: ev.URL}
+		// Use the full URL (including path) but strip query parameters
+		targetURL := ev.URL
+		if parsedURL, err := url.Parse(ev.URL); err == nil {
+			parsedURL.RawQuery = ""
+			parsedURL.Fragment = ""
+			targetURL = parsedURL.String()
+		}
+		targetInfo = &nuclei.NucleiTargetInfo{Target: targetURL}
 		b.targetIdx[baseURL] = targetInfo
 		b.targets = append(b.targets, targetInfo)
 	}

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -234,7 +234,8 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	baseURL := getBaseURL(ev)
 	targetInfo, ok := b.targetIdx[baseURL]
 	if !ok {
-		targetInfo = &nuclei.NucleiTargetInfo{Target: baseURL}
+		// Use the full URL (including path) for the Target field
+		targetInfo = &nuclei.NucleiTargetInfo{Target: ev.URL}
 		b.targetIdx[baseURL] = targetInfo
 		b.targets = append(b.targets, targetInfo)
 	}

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -3,7 +3,6 @@ package nuclei
 import (
 	// Generated
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -232,18 +231,11 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	}
 
 	// Get or create target
-	baseURL := getBaseURL(ev)
-	targetInfo, ok := b.targetIdx[baseURL]
+	targetURL := getTargetURL(ev)
+	targetInfo, ok := b.targetIdx[targetURL]
 	if !ok {
-		// Use the full URL (including path) but strip query parameters
-		targetURL := ev.URL
-		if parsedURL, err := url.Parse(ev.URL); err == nil {
-			parsedURL.RawQuery = ""
-			parsedURL.Fragment = ""
-			targetURL = parsedURL.String()
-		}
 		targetInfo = &nuclei.NucleiTargetInfo{Target: targetURL}
-		b.targetIdx[baseURL] = targetInfo
+		b.targetIdx[targetURL] = targetInfo
 		b.targets = append(b.targets, targetInfo)
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts how targets are extracted and grouped in Nuclei reports.
> 
> - Replace `getBaseURL` with `getTargetURL` that preserves path and strips query/fragment from `ev.URL`
> - Use `targetURL` for `targetIdx` keys and `NucleiTargetInfo.Target`, shifting bucketing from host-level to path-level
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00b695e44bce081d1192bd66f3eca420f2519ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->