### PR TITLE
Fix Nuclei Report Full URL Parsing Bug

### DIFF
--- a/internal/enumerate/apiapplication/graphql.go
+++ b/internal/enumerate/apiapplication/graphql.go
@@ -8,21 +8,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 
 	// Generated
 	enumerateapiapplicationfern "github.com/Method-Security/webscan/generated/go/enumerate/apiapplication"
+
+	// External
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // PerformAppEnumerateGraphQL performs a GraphQL scan against a target URL and returns the report.
 func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapiapplicationfern.EnumerateGraphqlReport {
+	log := svc1log.FromContext(ctx)
+	log.Info("Performing GraphQL scan", svc1log.SafeParam("target", target))
+
 	report := enumerateapiapplicationfern.EnumerateGraphqlReport{Config: &enumerateapiapplicationfern.EnumerateGraphqlConfig{Target: target}}
 	report.Result = &enumerateapiapplicationfern.EnumerateGraphqlResult{}
 	data := &enumerateapiapplicationfern.EnumerateGraphqlData{}
 
-	body, err := fetchGraphQLSchema(target)
+	body, err := fetchGraphQLSchema(ctx, target)
 	if err != nil {
 		report.Errors = append(report.Errors, err.Error())
 		return report
@@ -57,15 +62,18 @@ func PerformAppEnumerateGraphQL(ctx context.Context, target string) enumerateapi
 	return report
 }
 
-func fetchGraphQLSchema(target string) ([]byte, error) {
+func fetchGraphQLSchema(ctx context.Context, target string) ([]byte, error) {
+	log := svc1log.FromContext(ctx)
+
 	query := `{"query":"{ __schema { types { name kind description fields { name } } } }"}`
 	resp, err := http.Post(target, "application/json", bytes.NewBuffer([]byte(query)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch GraphQL schema: %v", err)
+		log.Error("Failed to fetch GraphQL schema", svc1log.SafeParam("error", err))
+		return nil, err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Println("Error closing response body:", err)
+			log.Error("Error closing response body", svc1log.SafeParam("error", err))
 		}
 	}()
 

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -30,7 +30,11 @@ func getTargetURL(ev *nout.ResultEvent) string {
 	if ev.Request != "" {
 		_, requestPath, _, _ := parseRawRequest(ev.Request)
 		// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
-		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+		if requestPath != "" {
+			// Clean the request path by removing the leading / if it exists and adding it back
+			requestPath = strings.TrimPrefix(requestPath, "/")
+			requestPath = "/" + requestPath
+
 			// The requestPath may include query string (e.g., /api/users?query=test)
 			// We need to split it to avoid URL encoding the ? character
 			if idx := strings.Index(requestPath, "?"); idx != -1 {
@@ -146,7 +150,10 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	// Use the path from the raw request if available and valid
 	// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
 	var rawRequestQueryString string
-	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+	if requestPath != "" {
+		requestPath = strings.TrimPrefix(requestPath, "/")
+		requestPath = "/" + requestPath
+
 		// The requestPath may include query string (e.g., /api/users?query=test)
 		// We need to split it properly
 		if idx := strings.Index(requestPath, "?"); idx != -1 {
@@ -172,13 +179,13 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	if body != "" {
 		params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
 	}
-	
+
 	// Parse query parameters - prefer raw request query string if available, otherwise use finalURL
 	queryStringToParse := rawRequestQueryString
 	if queryStringToParse == "" && finalURL != nil && finalURL.RawQuery != "" {
 		queryStringToParse = finalURL.RawQuery
 	}
-	
+
 	if queryStringToParse != "" {
 		if parsedQuery, err := url.ParseQuery(queryStringToParse); err == nil {
 			for k, vs := range parsedQuery {

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -30,16 +30,10 @@ func getTargetURL(ev *nout.ResultEvent) string {
 	if ev.Request != "" {
 		_, requestPath, _, _ := parseRawRequest(ev.Request)
 		// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
-		if requestPath != "" {
-			// Clean the request path by removing the leading / if it exists and adding it back
-			requestPath = strings.TrimPrefix(requestPath, "/")
-			requestPath = "/" + requestPath
-
-			// The requestPath may include query string (e.g., /api/users?query=test)
-			// We need to split it to avoid URL encoding the ? character
+		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+			// Strip query string if present to avoid URL encoding issues
 			if idx := strings.Index(requestPath, "?"); idx != -1 {
 				parsedURL.Path = requestPath[:idx]
-				parsedURL.RawQuery = requestPath[idx+1:]
 			} else {
 				parsedURL.Path = requestPath
 			}
@@ -148,17 +142,10 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	method, requestPath, requestHeaders, body := parseRawRequest(ev.Request)
 
 	// Use the path from the raw request if available and valid
-	// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
-	var rawRequestQueryString string
-	if requestPath != "" {
-		requestPath = strings.TrimPrefix(requestPath, "/")
-		requestPath = "/" + requestPath
-
-		// The requestPath may include query string (e.g., /api/users?query=test)
-		// We need to split it properly
+	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+		// Strip query string if present
 		if idx := strings.Index(requestPath, "?"); idx != -1 {
 			request.Path = requestPath[:idx]
-			rawRequestQueryString = requestPath[idx+1:]
 		} else {
 			request.Path = requestPath
 		}
@@ -179,19 +166,11 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	if body != "" {
 		params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
 	}
-
-	// Parse query parameters - prefer raw request query string if available, otherwise use finalURL
-	queryStringToParse := rawRequestQueryString
-	if queryStringToParse == "" && finalURL != nil && finalURL.RawQuery != "" {
-		queryStringToParse = finalURL.RawQuery
-	}
-
-	if queryStringToParse != "" {
-		if parsedQuery, err := url.ParseQuery(queryStringToParse); err == nil {
-			for k, vs := range parsedQuery {
-				if len(vs) > 0 {
-					params.Query[k] = vs[0]
-				}
+	// Parse query parameters from the final URL
+	if finalURL != nil && finalURL.RawQuery != "" {
+		for k, vs := range finalURL.Query() {
+			if len(vs) > 0 {
+				params.Query[k] = vs[0]
 			}
 		}
 	}

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -30,13 +30,9 @@ func getTargetURL(ev *nout.ResultEvent) string {
 	if ev.Request != "" {
 		_, requestPath, _, _ := parseRawRequest(ev.Request)
 		// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
-		if requestPath != "" {
-			// Clean Request Path
-			requestPath = strings.TrimPrefix(requestPath, "/")
-			requestPath = "/" + requestPath
-
-			// Strip query string if present to avoid URL encoding issues
-			if idx := strings.Index(requestPath, "?"); idx != -1 {
+		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+			// Strip query string and fragment if present to avoid URL encoding issues
+			if idx := strings.IndexAny(requestPath, "?#"); idx != -1 {
 				parsedURL.Path = requestPath[:idx]
 			} else {
 				parsedURL.Path = requestPath
@@ -146,13 +142,9 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	method, requestPath, requestHeaders, body := parseRawRequest(ev.Request)
 
 	// Use the path from the raw request if available and valid
-	if requestPath != "" {
-		// Clean Request Path
-		requestPath = strings.TrimPrefix(requestPath, "/")
-		requestPath = "/" + requestPath
-
-		// Strip query string if present
-		if idx := strings.Index(requestPath, "?"); idx != -1 {
+	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+		// Strip query string and fragment if present
+		if idx := strings.IndexAny(requestPath, "?#"); idx != -1 {
 			request.Path = requestPath[:idx]
 		} else {
 			request.Path = requestPath

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -18,11 +18,22 @@ import (
 
 // getTargetURL extracts the target URL from a ResultEvent.
 // excludes query parameters and fragment ie. https://example.com/path?query#fragment -> https://example.com/path
+// Uses the path from the raw HTTP request if available, as ev.URL may not contain the tested path
 func getTargetURL(ev *nout.ResultEvent) string {
 	parsedURL, err := url.Parse(ev.URL)
 	if err != nil {
 		return ev.URL
 	}
+
+	// Extract the actual path from the raw HTTP request
+	// This is necessary because ev.URL might not contain the tested path when using path fuzzing
+	if ev.Request != "" {
+		_, requestPath, _, _ := parseRawRequest(ev.Request)
+		if requestPath != "" {
+			parsedURL.Path = requestPath
+		}
+	}
+
 	parsedURL.RawQuery = ""
 	parsedURL.Fragment = ""
 	parsedURL.RawFragment = ""
@@ -120,7 +131,14 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 		}
 	}
 
-	method, _, requestHeaders, body := parseRawRequest(ev.Request)
+	// Parse the raw request to get the actual method, path, headers, and body
+	// The path from the raw request is the actual tested path, not from ev.URL
+	method, requestPath, requestHeaders, body := parseRawRequest(ev.Request)
+
+	// Use the path from the raw request if available
+	if requestPath != "" {
+		request.Path = requestPath
+	}
 	contentType := http.DetectContentType([]byte(body))
 	if m, err := common.NewHttpMethodFromString(strings.ToUpper(method)); err == nil {
 		request.Method = m

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -30,7 +30,11 @@ func getTargetURL(ev *nout.ResultEvent) string {
 	if ev.Request != "" {
 		_, requestPath, _, _ := parseRawRequest(ev.Request)
 		// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
-		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+		if requestPath != "" {
+			// Clean Request Path
+			requestPath = strings.TrimPrefix(requestPath, "/")
+			requestPath = "/" + requestPath
+
 			// Strip query string if present to avoid URL encoding issues
 			if idx := strings.Index(requestPath, "?"); idx != -1 {
 				parsedURL.Path = requestPath[:idx]
@@ -142,7 +146,11 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	method, requestPath, requestHeaders, body := parseRawRequest(ev.Request)
 
 	// Use the path from the raw request if available and valid
-	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+	if requestPath != "" {
+		// Clean Request Path
+		requestPath = strings.TrimPrefix(requestPath, "/")
+		requestPath = "/" + requestPath
+
 		// Strip query string if present
 		if idx := strings.Index(requestPath, "?"); idx != -1 {
 			request.Path = requestPath[:idx]

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -29,8 +29,16 @@ func getTargetURL(ev *nout.ResultEvent) string {
 	// This is necessary because ev.URL might not contain the tested path when using path fuzzing
 	if ev.Request != "" {
 		_, requestPath, _, _ := parseRawRequest(ev.Request)
-		if requestPath != "" {
-			parsedURL.Path = requestPath
+		// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
+		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+			// The requestPath may include query string (e.g., /api/users?query=test)
+			// We need to split it to avoid URL encoding the ? character
+			if idx := strings.Index(requestPath, "?"); idx != -1 {
+				parsedURL.Path = requestPath[:idx]
+				parsedURL.RawQuery = requestPath[idx+1:]
+			} else {
+				parsedURL.Path = requestPath
+			}
 		}
 	}
 
@@ -135,9 +143,18 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	// The path from the raw request is the actual tested path, not from ev.URL
 	method, requestPath, requestHeaders, body := parseRawRequest(ev.Request)
 
-	// Use the path from the raw request if available
-	if requestPath != "" {
-		request.Path = requestPath
+	// Use the path from the raw request if available and valid
+	// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
+	var rawRequestQueryString string
+	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+		// The requestPath may include query string (e.g., /api/users?query=test)
+		// We need to split it properly
+		if idx := strings.Index(requestPath, "?"); idx != -1 {
+			request.Path = requestPath[:idx]
+			rawRequestQueryString = requestPath[idx+1:]
+		} else {
+			request.Path = requestPath
+		}
 	}
 	contentType := http.DetectContentType([]byte(body))
 	if m, err := common.NewHttpMethodFromString(strings.ToUpper(method)); err == nil {
@@ -155,11 +172,19 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	if body != "" {
 		params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
 	}
-	// Parse query parameters from the final URL
-	if finalURL != nil && finalURL.RawQuery != "" {
-		for k, vs := range finalURL.Query() {
-			if len(vs) > 0 {
-				params.Query[k] = vs[0]
+	
+	// Parse query parameters - prefer raw request query string if available, otherwise use finalURL
+	queryStringToParse := rawRequestQueryString
+	if queryStringToParse == "" && finalURL != nil && finalURL.RawQuery != "" {
+		queryStringToParse = finalURL.RawQuery
+	}
+	
+	if queryStringToParse != "" {
+		if parsedQuery, err := url.ParseQuery(queryStringToParse); err == nil {
+			for k, vs := range parsedQuery {
+				if len(vs) > 0 {
+					params.Query[k] = vs[0]
+				}
 			}
 		}
 	}

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -33,7 +33,12 @@ func getTargetURL(ev *nout.ResultEvent) string {
 		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
 			// Strip query string and fragment if present to avoid URL encoding issues
 			if idx := strings.IndexAny(requestPath, "?#"); idx != -1 {
-				parsedURL.Path = requestPath[:idx]
+				requestPath = requestPath[:idx]
+			}
+			// Decode the path since it comes URL-encoded from the HTTP request
+			// This prevents double-encoding when parsedURL.String() re-encodes it
+			if decodedPath, err := url.PathUnescape(requestPath); err == nil {
+				parsedURL.Path = decodedPath
 			} else {
 				parsedURL.Path = requestPath
 			}
@@ -145,7 +150,12 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
 		// Strip query string and fragment if present
 		if idx := strings.IndexAny(requestPath, "?#"); idx != -1 {
-			request.Path = requestPath[:idx]
+			requestPath = requestPath[:idx]
+		}
+		// Decode the path since it comes URL-encoded from the HTTP request
+		// This prevents double-encoding issues
+		if decodedPath, err := url.PathUnescape(requestPath); err == nil {
+			request.Path = decodedPath
 		} else {
 			request.Path = requestPath
 		}

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -1,11 +1,12 @@
 package nuclei
 
 import (
-	// Generated
+	// Standard
 	"fmt"
 	"regexp"
 	"strings"
 
+	// Generated
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 
 	// External


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are localized to report URL/path parsing and logging behavior; main risk is minor behavior drift in how targets are bucketed/serialized due to path decoding and path source changes.
> 
> **Overview**
> Fixes Nuclei target and request URL construction so reports reflect the *actual tested path* during path fuzzing: both `getTargetURL` and `getHTTPRequestResponse` now prefer the path parsed from `ev.Request`, strip query/fragment, and `PathUnescape` to avoid double-encoding.
> 
> Also replaces ad-hoc stdout logging in GraphQL enumeration with context-based Witchcraft `svc1log`, threading `context.Context` into `fetchGraphQLSchema` and emitting structured info/error logs for schema fetch and body close failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3ec42640c045a343c51fe720185819c662e3dd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->