### PR TITLE
Fix Nuclei Query Param Parsing + Update Templates

### DIFF
--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -146,9 +146,21 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	// The path from the raw request is the actual tested path, not from ev.URL
 	method, requestPath, requestHeaders, body := parseRawRequest(ev.Request)
 
-	// Use the path from the raw request if available and valid
+	// Extract query string from raw request path if present
+	var rawRequestQueryString string
 	if requestPath != "" && strings.HasPrefix(requestPath, "/") {
-		// Strip query string and fragment if present
+		// Check for query string before stripping
+		if qIdx := strings.Index(requestPath, "?"); qIdx != -1 {
+			// Find the end of query string (before fragment if present)
+			endIdx := strings.Index(requestPath[qIdx:], "#")
+			if endIdx != -1 {
+				rawRequestQueryString = requestPath[qIdx+1 : qIdx+endIdx]
+			} else {
+				rawRequestQueryString = requestPath[qIdx+1:]
+			}
+		}
+
+		// Strip query string and fragment to get clean path
 		if idx := strings.IndexAny(requestPath, "?#"); idx != -1 {
 			requestPath = requestPath[:idx]
 		}
@@ -176,11 +188,19 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 	if body != "" {
 		params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
 	}
-	// Parse query parameters from the final URL
-	if finalURL != nil && finalURL.RawQuery != "" {
-		for k, vs := range finalURL.Query() {
-			if len(vs) > 0 {
-				params.Query[k] = vs[0]
+
+	// Parse query parameters - prefer raw request query string, fall back to finalURL
+	queryStringToParse := rawRequestQueryString
+	if queryStringToParse == "" && finalURL != nil && finalURL.RawQuery != "" {
+		queryStringToParse = finalURL.RawQuery
+	}
+
+	if queryStringToParse != "" {
+		if parsedQuery, err := url.ParseQuery(queryStringToParse); err == nil {
+			for k, vs := range parsedQuery {
+				if len(vs) > 0 {
+					params.Query[k] = vs[0]
+				}
 			}
 		}
 	}

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -214,8 +214,9 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 
 	// Create redirect chain with the final URL if it's different from base
 	var redirectChain []string
+	fullURL := request.GetBaseUrl() + request.GetPath()
 	if finalURL != nil {
-		redirectChain = append(redirectChain, ev.URL) // ev.URL is the final destination
+		redirectChain = append(redirectChain, fullURL)
 	}
 
 	response = requesthelpers.CreateHTTPResponse(statusCode, redirectChain, singleToMulti(responseHeaders), responseBody)

--- a/utils/nuclei/templates/discover/application/apiapplication/graphql.yaml
+++ b/utils/nuclei/templates/discover/application/apiapplication/graphql.yaml
@@ -31,10 +31,13 @@ http:
     headers:
       Content-Type: application/json
     body: '{"query": "{ __schema { queryType { name } } }"}'
-    redirects: true
-    max-redirects: 5
+    redirects: false
     stop-at-first-match: true
+    matchers-condition: and
     matchers:
+      - type: status
+        status:
+          - 200
       - type: word
         part: body
         words:

--- a/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
@@ -30,9 +30,6 @@ http:
     max-redirects: 5
     stop-at-first-match: true
     matchers:
-      - type: status
-        status:
-          - 200
       - type: dsl
         dsl:
           - 'contains(tolower(body), "\"app\":\"kubernetes-dashboard\"") || contains(tolower(body), "data-ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "kubernetes-dashboard-head") || contains(tolower(header), "kubernetes-dashboard") || (contains(tolower(header), "x-rancher-version") && contains(tolower(body), "ember-basic-dropdown")) || (contains(tolower(header), "pl=rancher") && contains(tolower(body), "ember-basic-dropdown"))'

--- a/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
@@ -29,7 +29,6 @@ http:
     redirects: true
     max-redirects: 5
     stop-at-first-match: true
-    matchers-condition: and
     matchers:
       - type: status
         status:

--- a/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
@@ -29,49 +29,11 @@ http:
     redirects: true
     max-redirects: 5
     stop-at-first-match: true
+    matchers-condition: and
     matchers:
-      - type: word
-        part: body
-        words:
-          - "Kubernetes Dashboard"
-          - "Kubernetes Web UI" 
-          - "Kubernetes Management Console"
-          - "k8s-app=kubernetes-dashboard"
-          - "Kubernetes Cluster Manager"
-          - "Enterprise Kubernetes Manager"
-        case-insensitive: true
-      - type: regex
-        part: body
-        regex:
-          - '(?i)<title[^>]*>.*Kubernetes.*Dashboard.*</title>'
-          - '(?i)<title[^>]*>.*K8s.*Manager.*</title>'
-          - '(?i)kubernetes.*management.*console'
-          - '(?i)cluster.*administration.*interface'
-      - type: word
-        part: body
-        words:
-          - '"app":"kubernetes-dashboard"'
-          - '"kubernetes.io/managed-by"'
-          - 'data-ng-app="kubernetesDashboard"'
-          - 'ng-app="kubernetesDashboard"'
-          - 'kubernetes-dashboard-head'
-          - 'kubernetes-dashboard'
-        case-insensitive: true
-      - type: regex
-        part: body
-        regex:
-          - '(?i)kubectl.*proxy.*dashboard'
-      - type: word
-        part: header
-        words:
-          - "kubernetes-dashboard"
-        case-insensitive: true
+      - type: status
+        status:
+          - 200
       - type: dsl
         dsl:
-          - '(contains(tolower(body), "cluster overview") || contains(tolower(body), "node overview") || contains(tolower(body), "pod status") || contains(tolower(body), "deployment status") || contains(tolower(body), "service discovery") || contains(tolower(body), "workload management") || contains(tolower(body), "resource monitoring")) && (contains(tolower(body), "kubernetes") || contains(tolower(body), "k8s") || contains(tolower(body), "kubectl") || contains(tolower(body), "namespace") || contains(tolower(body), "pod") || contains(tolower(body), "deployment") || contains(tolower(body), "configmap") || contains(tolower(body), "secret"))'
-      - type: dsl
-        dsl:
-          - 'contains(tolower(header), "x-rancher-version") && (contains(tolower(body), "ember-basic-dropdown") || contains(tolower(body), "/assets/vendor.css") || contains(tolower(body), "/assets/ui-"))'
-      - type: dsl
-        dsl:
-          - 'contains(tolower(header), "pl=rancher") && contains(tolower(body), "ember-basic-dropdown")'
+          - 'body matches "(?i)<title[^>]*>.*[Kk]ubernetes.*[Dd]ashboard.*</title>" || body matches "(?i)<title[^>]*>.*[Kk]8s.*[Mm]anager.*</title>" || contains(tolower(body), "\"app\":\"kubernetes-dashboard\"") || contains(tolower(body), "data-ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "kubernetes-dashboard-head") || contains(tolower(header), "kubernetes-dashboard") || (contains(tolower(header), "x-rancher-version") && contains(tolower(body), "ember-basic-dropdown")) || (contains(tolower(header), "pl=rancher") && contains(tolower(body), "ember-basic-dropdown"))'

--- a/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes-enterprise-manager.yaml
@@ -36,4 +36,9 @@ http:
           - 200
       - type: dsl
         dsl:
-          - 'body matches "(?i)<title[^>]*>.*[Kk]ubernetes.*[Dd]ashboard.*</title>" || body matches "(?i)<title[^>]*>.*[Kk]8s.*[Mm]anager.*</title>" || contains(tolower(body), "\"app\":\"kubernetes-dashboard\"") || contains(tolower(body), "data-ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "kubernetes-dashboard-head") || contains(tolower(header), "kubernetes-dashboard") || (contains(tolower(header), "x-rancher-version") && contains(tolower(body), "ember-basic-dropdown")) || (contains(tolower(header), "pl=rancher") && contains(tolower(body), "ember-basic-dropdown"))'
+          - 'contains(tolower(body), "\"app\":\"kubernetes-dashboard\"") || contains(tolower(body), "data-ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "ng-app=\"kubernetesdashboard\"") || contains(tolower(body), "kubernetes-dashboard-head") || contains(tolower(header), "kubernetes-dashboard") || (contains(tolower(header), "x-rancher-version") && contains(tolower(body), "ember-basic-dropdown")) || (contains(tolower(header), "pl=rancher") && contains(tolower(body), "ember-basic-dropdown"))'
+      - type: regex
+        part: body
+        regex:
+          - '(?i)<title[^>]*>.*Kubernetes.*Dashboard.*</title>'
+          - '(?i)<title[^>]*>.*K8s.*Manager.*</title>'

--- a/utils/nuclei/templates/discover/application/kube/kubernetes.yaml
+++ b/utils/nuclei/templates/discover/application/kube/kubernetes.yaml
@@ -41,6 +41,5 @@ http:
       - type: word
         part: body
         words:
-          - "Kubernetes Dashboard"
           - "k8s-app=kubernetes-dashboard"
         case-insensitive: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect how scan results reconstruct request URLs/query params and redirect chains, which can impact downstream parsing and reporting accuracy. Template matcher/redirect tweaks may change detection coverage (false positives/negatives) across scans.
> 
> **Overview**
> Fixes Nuclei report request parsing so query parameters are extracted from the *raw request path* (before it’s stripped/decoded) and only fall back to `ev.URL`’s `RawQuery` when needed; the generated redirect chain now records the reconstructed `baseUrl+path` instead of `ev.URL`.
> 
> Updates discovery templates: GraphQL detection no longer follows redirects and now requires a `200` status plus schema keywords; Kubernetes enterprise manager detection consolidates many matchers into stricter DSL/title checks; Kubernetes discovery removes the generic “Kubernetes Dashboard” body word matcher.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 510491edee245adcf70186e08f5e61834c5bcdbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->