### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -240,45 +240,29 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 32768
-          remove-android: "true"
-          remove-docker-images: "true"
-          remove-dotnet: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
-          remove-swapfile: "true"
-
       - name: Free up disk space and install dependencies
         run: |
           echo "=== Initial disk usage ==="
           df -h
 
-          # Aggressive cleanup first
+          # Aggressive cleanup
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo apt-get autoremove -y
           sudo apt-get autoclean
+          sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           sudo rm -rf /tmp/* /var/tmp/*
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          sudo docker system prune -af || true
+          sudo docker system prune -af
 
-          # Move Docker data directory to the larger buildlv volume
-          echo "=== Moving Docker to buildlv volume ==="
-          sudo systemctl stop docker
-          sudo mkdir -p /home/runner/work/webscan/docker-data
-          sudo mv /var/lib/docker/* /home/runner/work/webscan/docker-data/ || true
-          sudo rm -rf /var/lib/docker
-          sudo ln -s /home/runner/work/webscan/docker-data /var/lib/docker
-          sudo systemctl start docker
-
-          echo "=== After cleanup and Docker move ==="
+          echo "=== After cleanup ==="
           df -h
 
           # Minimal install
-          sudo apt-get clean
           sudo apt-get update --fix-missing
           sudo apt-get install -y --no-install-recommends gcc libc6-dev libpcap-dev
       - name: Set up QEMU

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -65,7 +65,7 @@ jobs:
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm armbuilder \
-            goreleaser build --single-target --clean --snapshot --timeout 60m \
+            goreleaser build --single-target --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - name: Cleanup Docker images
@@ -146,7 +146,7 @@ jobs:
             -e GOARCH=amd64 -e GOOS=linux \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
-            --rm amdbuilder goreleaser build --single-target \
+            --rm amdbuilder goreleaser build --single-target --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - name: Cleanup Docker images

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -256,10 +256,8 @@ jobs:
           echo "=== Initial disk usage ==="
           df -h
 
-
           # Aggressive cleanup first
           sudo apt-get autoremove -y
-          sudo apt-get autoclean
           sudo apt-get autoclean
           sudo rm -rf /var/lib/apt/lists/*
           sudo rm -rf /tmp/* /var/tmp/*
@@ -267,13 +265,17 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
           sudo docker system prune -af || true
 
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          sudo docker system prune -af || true
+          # Move Docker data directory to the larger buildlv volume
+          echo "=== Moving Docker to buildlv volume ==="
+          sudo systemctl stop docker
+          sudo mkdir -p /home/runner/work/webscan/docker-data
+          sudo mv /var/lib/docker/* /home/runner/work/webscan/docker-data/ || true
+          sudo rm -rf /var/lib/docker
+          sudo ln -s /home/runner/work/webscan/docker-data /var/lib/docker
+          sudo systemctl start docker
 
-          echo "=== After cleanup ==="
+          echo "=== After cleanup and Docker move ==="
           df -h
-
 
           # Minimal install
           sudo apt-get clean

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -27,17 +27,18 @@ jobs:
         run: |
           echo "=== Initial disk usage ==="
           df -h
-          
+
           # Aggressive cleanup of pre-installed packages
           sudo apt-get autoremove -y || true
           sudo apt-get autoclean || true
           sudo rm -rf /var/lib/apt/lists/*
           sudo rm -rf /tmp/* /var/tmp/* || true
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
-          
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+
           echo "=== After cleanup ==="
           df -h
-          
+
           # Minimal update and install
           sudo apt-get clean
           sudo apt-get update --fix-missing
@@ -100,17 +101,19 @@ jobs:
         run: |
           echo "=== Initial disk usage ==="
           df -h
-          
+
           # Aggressive cleanup
           sudo apt-get autoremove -y || true
           sudo apt-get autoclean || true
           sudo rm -rf /var/lib/apt/lists/*
           sudo rm -rf /tmp/* /var/tmp/* || true
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
-          
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker system prune -af || true
+
           echo "=== After cleanup ==="
           df -h
-          
+
           # Minimal install
           sudo apt-get clean
           sudo apt-get update --fix-missing
@@ -135,6 +138,12 @@ jobs:
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm amdbuilder goreleaser build --single-target \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+
+      - name: Cleanup Docker images
+        run: |
+          docker rmi amdbuilder || true
+          docker system prune -f
+
       - uses: actions/upload-artifact@v4
         with:
           name: linux-amd64-dist
@@ -229,21 +238,23 @@ jobs:
           
       # Skip maximize-build-space action for custom larger runners
       # Custom runners should have 150GB+ native disk space
-      - name: Free up disk space and install dependencies  
+      - name: Free up disk space and install dependencies
         run: |
           echo "=== Initial disk usage ==="
           df -h
-          
+
           # Aggressive cleanup first
           sudo apt-get autoremove -y
-          sudo apt-get autoclean  
+          sudo apt-get autoclean
           sudo rm -rf /var/lib/apt/lists/*
           sudo rm -rf /tmp/* /var/tmp/*
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
-          
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker system prune -af || true
+
           echo "=== After cleanup ==="
           df -h
-          
+
           # Minimal install
           sudo apt-get clean
           sudo apt-get update --fix-missing
@@ -277,25 +288,6 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-      - name: Free up disk space and install build dependencies
-        run: |
-          echo "=== Initial disk usage ==="
-          df -h
-          
-          # Aggressive cleanup
-          sudo apt-get autoremove -y || true
-          sudo apt-get autoclean || true
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo rm -rf /tmp/* /var/tmp/* || true
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
-          
-          echo "=== After cleanup ==="
-          df -h
-          
-          # Minimal install
-          sudo apt-get clean
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -335,6 +327,11 @@ jobs:
 
       - name: Build Docker Image (AMD64)
         run: docker buildx build . --platform linux/amd64 --tag methodsecurity/webscan:latest-amd64
+
+      - name: Cleanup Docker build cache
+        run: |
+          docker system prune -f
+          df -h
 
       - name: View Output
         run: ls -al output output/*

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -166,14 +166,6 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 32768
-          remove-android: "true"
-          remove-docker-images: "true"
-          remove-dotnet: "true"
-          remove-haskell: "true"
       - name: Install Dependences
         run: sudo apt install libpcap-dev
       - name: Set up QEMU

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -65,7 +65,7 @@ jobs:
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm armbuilder \
-            goreleaser build --single-target --timeout 60m \
+            goreleaser build --single-target --clean --snapshot --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - name: Cleanup Docker images
@@ -146,7 +146,7 @@ jobs:
             -e GOARCH=amd64 -e GOOS=linux \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
-            --rm amdbuilder goreleaser build --single-target --timeout 60m \
+            --rm amdbuilder goreleaser build --single-target --clean --snapshot --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
 
       - name: Cleanup Docker images

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -106,6 +106,7 @@ jobs:
           echo "=== Initial disk usage ==="
           df -h
 
+
           # Aggressive cleanup
           sudo apt-get autoremove -y || true
           sudo apt-get autoclean || true
@@ -115,8 +116,13 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
           sudo docker system prune -af || true
 
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker system prune -af || true
+
           echo "=== After cleanup ==="
           df -h
+
 
           # Minimal install
           sudo apt-get clean
@@ -125,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
@@ -142,6 +148,11 @@ jobs:
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
             --rm amdbuilder goreleaser build --single-target \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
+
+      - name: Cleanup Docker images
+        run: |
+          docker rmi amdbuilder || true
+          docker system prune -f
 
       - name: Cleanup Docker images
         run: |
@@ -193,7 +204,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
@@ -245,8 +256,10 @@ jobs:
           echo "=== Initial disk usage ==="
           df -h
 
+
           # Aggressive cleanup first
           sudo apt-get autoremove -y
+          sudo apt-get autoclean
           sudo apt-get autoclean
           sudo rm -rf /var/lib/apt/lists/*
           sudo rm -rf /tmp/* /var/tmp/*
@@ -254,8 +267,13 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
           sudo docker system prune -af || true
 
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker system prune -af || true
+
           echo "=== After cleanup ==="
           df -h
+
 
           # Minimal install
           sudo apt-get clean
@@ -293,7 +311,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
@@ -329,6 +347,11 @@ jobs:
 
       - name: Build Docker Image (AMD64)
         run: docker buildx build . --platform linux/amd64 --tag methodsecurity/webscan:latest-amd64
+
+      - name: Cleanup Docker build cache
+        run: |
+          docker system prune -f
+          df -h
 
       - name: Cleanup Docker build cache
         run: |

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -334,10 +334,9 @@ jobs:
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
-          mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,60 +19,32 @@ jobs:
   prepare-linux-arm:
     name: Prepare Linux (arm64)
     runs-on: ubuntu-22.04-arm
-    env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo docker system prune -af
-          df -h
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout code
-        uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-
-      - name: Build ARM64 Builder Image
-        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
-
-      - name: Build ARM64 Binary in Alpine Container
-        run: |
-          docker run \
-            -v $PWD:/app/webscan \
-            -e GOARCH=arm64 \
-            -e GOOS=linux \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
-            --rm armbuilder \
-            goreleaser build --single-target --clean --snapshot --timeout 60m \
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: >-
+            build --single-target --clean --snapshot --timeout 60m
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
-
-      - name: Cleanup Docker images
-        run: |
-          docker rmi armbuilder || true
-          docker system prune -f
-
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GOOS: linux
+          GOARCH: arm64
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -101,37 +73,6 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-      - name: Free up disk space and install build dependencies
-        run: |
-          echo "=== Initial disk usage ==="
-          df -h
-
-
-          # Aggressive cleanup
-          sudo apt-get autoremove -y || true
-          sudo apt-get autoclean || true
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo rm -rf /tmp/* /var/tmp/* || true
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          sudo docker system prune -af || true
-
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          sudo docker system prune -af || true
-
-          echo "=== After cleanup ==="
-          df -h
-
-
-          # Minimal install
-          sudo apt-get clean
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
@@ -146,19 +87,8 @@ jobs:
             -e GOARCH=amd64 -e GOOS=linux \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
-            --rm amdbuilder goreleaser build --single-target --clean --snapshot --timeout 60m \
+            --rm amdbuilder goreleaser build --single-target \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
-
-      - name: Cleanup Docker images
-        run: |
-          docker rmi amdbuilder || true
-          docker system prune -f
-
-      - name: Cleanup Docker images
-        run: |
-          docker rmi amdbuilder || true
-          docker system prune -f
-
       - uses: actions/upload-artifact@v4
         with:
           name: linux-amd64-dist
@@ -184,11 +114,11 @@ jobs:
         if: matrix.os == 'macos-latest'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        if: matrix.os == 'public-ubuntu-latest-l'
+        if: matrix.os == 'ubuntu-latest'
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-        if: matrix.os == 'public-ubuntu-latest-l'
+        if: matrix.os == 'ubuntu-latest'
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
@@ -201,10 +131,6 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
@@ -240,31 +166,16 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Free up disk space and install dependencies
-        run: |
-          echo "=== Initial disk usage ==="
-          df -h
-
-          # Aggressive cleanup
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo apt-get autoremove -y
-          sudo apt-get autoclean
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo rm -rf /tmp/* /var/tmp/*
-          sudo docker system prune -af
-
-          echo "=== After cleanup ==="
-          df -h
-
-          # Minimal install
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev libpcap-dev
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 32768
+          remove-android: "true"
+          remove-docker-images: "true"
+          remove-dotnet: "true"
+          remove-haskell: "true"
+      - name: Install Dependences
+        run: sudo apt install libpcap-dev
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -294,10 +205,6 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
@@ -320,9 +227,10 @@ jobs:
           mkdir -p output/build-linux_arm64/
           mkdir -p output/build-linux_amd64/
           mkdir -p output/build-darwin_arm64/
+          mkdir -p output/build-linux_amd64/
           mkdir -p output/build-windows_amd64/
-          mv artifacts/linux-arm64-dist/linux_arm64/build-linux-arm64_linux_arm64/* output/build-linux_arm64/
-          mv artifacts/linux-amd64-dist/linux_amd64/build-linux-amd64_linux_amd64_v1/* output/build-linux_amd64/
+          mv artifacts/linux-arm64-dist/linux_arm64/build-linux_linux_arm64_v8.0/* output/build-linux_arm64/
+          mv artifacts/linux-amd64-dist/linux_amd64/build-linux_linux_amd64_v1/* output/build-linux_amd64/
           mv artifacts/windows-latest-dist/windows_amd64/build-windows_windows_amd64_v1/* output/build-windows_amd64/
           mv artifacts/macos-latest-dist/darwin_arm64/build-macos_darwin_arm64_v8.0/* output/build-darwin_arm64/
         shell: bash
@@ -332,16 +240,6 @@ jobs:
 
       - name: Build Docker Image (AMD64)
         run: docker buildx build . --platform linux/amd64 --tag methodsecurity/webscan:latest-amd64
-
-      - name: Cleanup Docker build cache
-        run: |
-          docker system prune -f
-          df -h
-
-      - name: Cleanup Docker build cache
-        run: |
-          docker system prune -f
-          df -h
 
       - name: View Output
         run: ls -al output output/*

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -18,57 +18,61 @@ env:
 jobs:
   prepare-linux-arm:
     name: Prepare Linux (arm64)
-    runs-on: public-ubuntu-latest-l-arm
+    runs-on: ubuntu-22.04-arm
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - uses: actions/checkout@v4.1.6
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo docker system prune -af
+          df -h
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-      - name: Free up disk space and install build dependencies
-        run: |
-          echo "=== Initial disk usage ==="
-          df -h
 
-          # Aggressive cleanup of pre-installed packages
-          sudo apt-get autoremove -y || true
-          sudo apt-get autoclean || true
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo rm -rf /tmp/* /var/tmp/* || true
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-
-          echo "=== After cleanup ==="
-          df -h
-
-          # Minimal update and install
-          sudo apt-get clean
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          args: >-
-            build --single-target --clean --snapshot --timeout 60m
+
+      - name: Build ARM64 Builder Image
+        run: docker buildx build . --platform linux/arm64 --load --tag armbuilder -f Dockerfile.builder
+
+      - name: Build ARM64 Binary in Alpine Container
+        run: |
+          docker run \
+            -v $PWD:/app/webscan \
+            -e GOARCH=arm64 \
+            -e GOOS=linux \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GORELEASER_KEY=${{ secrets.GORELEASER_KEY }} \
+            --rm armbuilder \
+            goreleaser build --single-target --clean --snapshot --timeout 60m \
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          GOOS: linux
-          GOARCH: arm64
+
+      - name: Cleanup Docker images
+        run: |
+          docker rmi armbuilder || true
+          docker system prune -f
+
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64-dist
@@ -77,7 +81,7 @@ jobs:
 
   prepare-linux-amd64:
     name: Prepare Linux (amd64)
-    runs-on: public-ubuntu-latest-l
+    runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
@@ -221,23 +225,21 @@ jobs:
       - prepare
       - prepare-linux-arm
       - prepare-linux-amd64
-    runs-on: public-ubuntu-latest-l
+    runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Check initial disk space on larger runner
-        run: |
-          echo "=== RUNNER DISK SPACE ANALYSIS ==="
-          df -h
-          echo ""
-          echo "=== DISK USAGE BY DIRECTORY ==="
-          sudo du -sh /* 2>/dev/null | sort -hr | head -10
-          echo ""
-          echo "=== AVAILABLE INODES ==="
-          df -i
-          
-      # Skip maximize-build-space action for custom larger runners
-      # Custom runners should have 150GB+ native disk space
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 32768
+          remove-android: "true"
+          remove-docker-images: "true"
+          remove-dotnet: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+          remove-swapfile: "true"
+
       - name: Free up disk space and install dependencies
         run: |
           echo "=== Initial disk usage ==="

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -9,22 +9,7 @@ partial:
   by: target
 
 builds:
-  - id: build-linux-amd64
-    main: .
-    binary: webscan
-    ldflags:
-      - -s -w
-      - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X github.com/method-security/webscan/main.version={{.Version}}
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    goarch:
-      - amd64
-    goarm:
-      - "7"
-  - id: build-linux-arm64
+  - id: build-linux
     main: .
     binary: webscan
     ldflags:
@@ -37,6 +22,7 @@ builds:
       - linux
     goarch:
       - arm64
+      - amd64
     goarm:
       - "7"
   - id: build-macos

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -9,7 +9,22 @@ partial:
   by: target
 
 builds:
-  - id: build-linux
+  - id: build-linux-amd64
+    main: .
+    binary: webscan
+    ldflags:
+      - -s -w
+      - "-extldflags '-static -lm -ldl -lpthread'"
+      - -X github.com/method-security/webscan/main.version={{.Version}}
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    goarm:
+      - "7"
+  - id: build-linux-arm64
     main: .
     binary: webscan
     ldflags:
@@ -22,7 +37,6 @@ builds:
       - linux
     goarch:
       - arm64
-      - amd64
     goarm:
       - "7"
   - id: build-macos


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI behavior may change due to runner/environment differences and removing disk cleanup/dependency install steps, which could cause new build failures or resource issues.
> 
> **Overview**
> Updates the reusable GitHub Actions build workflow to run on standard GitHub-hosted runners (`ubuntu-latest` and `ubuntu-22.04-arm`) instead of custom `public-ubuntu-*` runners.
> 
> Removes the custom “free disk space”, build dependency, and explicit Node setup steps across jobs, replacing them with a minimal `libpcap-dev` install in the final `build` job and keeping Fern codegen via `npm install -g fern-api`.
> 
> Minor CI cleanups include adjusting OS condition checks for QEMU/Buildx and ensuring the workflow ends with a proper newline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edb458800439db2e96405d59054a0a7f6ee1f2e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->