### PR TITLE
Bug Fix

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -361,7 +361,6 @@ func (a *WebScan) InitDiscoverCommand() {
 					a.OutputSignal.AddError(errors.New("no sensitive content fingerprints found"))
 					return
 				}
-				return
 			}
 
 			// Generate a report


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI control-flow fix that only affects whether `discover page` runs to completion when sensitive content detection is enabled.
> 
> **Overview**
> Fixes a control-flow bug in `discover page` where enabling sensitive content detection could cause an early return after successfully loading fingerprints, preventing report generation.
> 
> Now the command only exits on actual errors or when no fingerprints are found, and otherwise continues to `PerformPageCapture`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bbd95c54cd815fdabbec18947b04e7025257377. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->