### PR TITLE
Update Ping Back Logic

### DIFF
--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -103,7 +103,7 @@ func PerformWordpressXMLRPCFunctionsExposed(ctx context.Context, config pentestc
 				}
 
 				// Detect if the request was successful
-				finding := detectSuccessfulFunctionAuth(xmlrpcAuthRequest)
+				finding := detectSuccessfulFunctionAuth(xmlrpcAuthRequest, function)
 				attempt.Finding = *finding
 				attempt.Request = xmlrpcAuthRequest
 
@@ -179,7 +179,8 @@ func generateFunctionAuthBodyInjectionParam(function string) string {
 }
 
 // detectSuccessfulFunctionAuth detects if the function auth request was successful
-func detectSuccessfulFunctionAuth(requestInfo *common.HttpRequestResponse) *bool {
+// For pingback functions, success means the function is reachable and executes, even if it returns a fault
+func detectSuccessfulFunctionAuth(requestInfo *common.HttpRequestResponse, functionName string) *bool {
 	success := false
 	if requestInfo == nil || requestInfo.Response == nil || requestInfo.Response.ResponseBody == nil {
 		return &success
@@ -190,6 +191,21 @@ func detectSuccessfulFunctionAuth(requestInfo *common.HttpRequestResponse) *bool
 	}
 
 	body := strings.ToLower(*requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody))
+
+	// Check if this is a pingback function
+	isPingback := strings.Contains(strings.ToLower(functionName), "pingback")
+
+	// For pingback functions: success = method is recognized and executes (even with faults)
+	// A fault response from pingback means it's processing the request, which indicates vulnerability
+	if isPingback {
+		success = strings.Contains(body, "<methodresponse>") &&
+			!strings.Contains(body, "method not found") &&
+			!strings.Contains(body, "unknown method") &&
+			!strings.Contains(body, "method does not exist")
+		return &success
+	}
+
+	// For other functions: success = no faults or invalid parameters
 	success = strings.Contains(body, "<methodresponse>") &&
 		!strings.Contains(body, "invalid method parameters") &&
 		!strings.Contains(body, "<fault>") &&


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to response-classification logic for XML-RPC scans; main risk is altered false positive/negative behavior for pingback vs non-pingback methods.
> 
> **Overview**
> Adjusts WordPress XML-RPC function exposure detection to treat `pingback*` methods as *successful/exposed* when the method is recognized and returns a `<methodResponse>` even if it includes a fault.
> 
> This updates `detectSuccessfulFunctionAuth` to accept the function name, adds pingback-specific success criteria (rejecting only "method not found"-style responses), and keeps stricter fault/invalid-parameter checks for all other XML-RPC methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d8066c249fd9cdc0e1dc292eae88771f82e3f02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>5d8066c</u></sup><!-- /BUGBOT_STATUS -->