### PR TITLE
Bump Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.20.0"
+  "version": "3.78.1"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -13,7 +13,7 @@ groups:
   pypi-local:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         output:
           location: local-file-system
           path: ../generated/python
@@ -21,7 +21,7 @@ groups:
   pypi-test:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodwebscan
         output:
@@ -33,7 +33,7 @@ groups:
   pypi:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodwebscan
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only version bumps for code generation tooling; risk is limited to potential regenerated client/model diffs or generator behavior changes.
> 
> **Overview**
> Updates Fern tooling versions by bumping `fern/fern.config.json` from `3.20.0` to `3.78.1`.
> 
> Upgrades the Python SDK/model generator `fernapi/fern-pydantic-model` from `1.11.1` to `1.11.2` across `pypi-local`, `pypi-test`, and `pypi` generator groups (no other generator config changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 177bdb872a6bccdd9fef86ba2935af33edbb79ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->