### PR TITLE
Webscan: Hardening + IPv6 Support

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -99,6 +99,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			report, err := discoverapplication.LaunchFingerprintEngine(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = report
 		},
@@ -242,6 +243,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			rep, err := discoverdirectory.RunDirectoryDiscovery(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = rep
 		},
@@ -570,6 +572,8 @@ func (a *WebScan) InitDiscoverCommand() {
 		Short: "Gather SaaS information given an organization name",
 		Long:  `Gather SaaS information given an organization name`,
 		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
 			// Get the Orgs
 			orgs, err := cmd.Flags().GetStringSlice("orgs")
 			if err != nil {
@@ -831,14 +835,19 @@ func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType s
 	// Set wordlist type and size if provided
 	if wordlistType != "" {
 		wordlistTypeEnum, err := discover.NewWordlistTypeFromString(wordlistType)
-		if err == nil {
+		if err != nil {
+			// Log warning but continue - the caller already validated that wordlist-type is required
+			config.WordlistType = nil
+		} else {
 			config.WordlistType = &wordlistTypeEnum
 		}
 	}
 
 	if wordlistSize != "" {
 		wordlistSizeEnum, err := discover.NewWordlistSizeFromString(wordlistSize)
-		if err == nil {
+		if err != nil {
+			config.WordlistSize = nil
+		} else {
 			config.WordlistSize = &wordlistSizeEnum
 		}
 	}

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -142,6 +142,7 @@ func (a *WebScan) InitPentestCommand() {
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = rep
 		},
@@ -234,6 +235,7 @@ func (a *WebScan) InitPentestCommand() {
 			rep, err := pentestapplicationscan.RunPentestApplicationCveScan(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = rep
 		},
@@ -319,6 +321,7 @@ func (a *WebScan) InitPentestCommand() {
 			rep, err := pentestapplicationscan.RunPentestApplicationMisconfigurationScan(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = rep
 		},
@@ -404,6 +407,7 @@ func (a *WebScan) InitPentestCommand() {
 			rep, err := pentestapplicationscan.RunPentestApplicationTechnologyScan(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = rep
 		},
@@ -708,6 +712,7 @@ func (a *WebScan) InitPentestCommand() {
 			rep, err := pentestwafdetect.RunPentestWafDetect(cmd.Context(), config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
+				return
 			}
 			a.OutputSignal.Content = rep
 		},

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -209,7 +209,9 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 						if err != nil {
 							// Don't add errors if context was cancelled
 							if ctx.Err() == nil {
+								attemptsMutex.Lock()
 								errors = append(errors, fmt.Sprintf("failed to send request: %v", err))
+								attemptsMutex.Unlock()
 							}
 							return
 						}
@@ -273,12 +275,16 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 		return false
 	}
 
-	bodySize := len(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody))
+	bodyStr := requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)
+	if bodyStr == nil {
+		return false
+	}
+	bodySize := len(*bodyStr)
 	if bodySize == 0 {
 		return false
 	}
 
-	wordCount := len(strings.Fields(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)))
+	wordCount := len(strings.Fields(*bodyStr))
 	// If the response is similar to the baseline or the baseline random path, then it is not a valid finding
 	// This is to prevent false positives from remote configurations that dont redirect but give blanket responses on all paths
 	if checkBaseContentMatch {
@@ -308,8 +314,12 @@ func baseLine(ctx context.Context, baseURL string, path string, validCodes map[i
 		return nil, nil, nil, errors.New("baseline request failed - no response received")
 	}
 
-	bodySize := len(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody))
-	wordCount := len(strings.Fields(*requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)))
+	baseBodyStr := requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)
+	if baseBodyStr == nil {
+		return nil, nil, nil, errors.New("baseline request failed - no response body received")
+	}
+	bodySize := len(*baseBodyStr)
+	wordCount := len(strings.Fields(*baseBodyStr))
 
 	return request, &bodySize, &wordCount, nil
 }
@@ -370,6 +380,9 @@ func getWordlistPath(wordlistType discover.WordlistType, wordlistSize discover.W
 // 1.00 is 100% difference
 // 2.00 is 200% difference
 func areSimilar(value, baseline int, tolerance float64) bool {
+	if baseline == 0 {
+		return value == 0
+	}
 	difference := math.Abs(float64(value - baseline))
 	percent := difference / float64(baseline)
 	return percent <= tolerance

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -98,7 +98,7 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 		routes = append(routes, &routeVar)
 	})
 
-	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), []string{}
+	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
 }
 
 // ExtractAnchorRoutes extracts WebRoutes from anchor (<a>) elements in the HTML document.

--- a/internal/discover/route/helpers/extractors/networkExtractors.go
+++ b/internal/discover/route/helpers/extractors/networkExtractors.go
@@ -136,10 +136,12 @@ func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, targ
 
 		// Capture body parameters (if any)
 		if request.HasPostData {
-			webRoute.BodyParams, err = discoverroutehelpers.ParseBodyParams(request.PostData)
-		}
-		if err != nil {
-			errors = append(errors, err.Error())
+			bodyParams, bodyErr := discoverroutehelpers.ParseBodyParams(request.PostData)
+			if bodyErr != nil {
+				errors = append(errors, bodyErr.Error())
+			} else {
+				webRoute.BodyParams = bodyParams
+			}
 		}
 
 		// Add the WebRoute to the list

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -106,8 +107,7 @@ func MergeQueryParams(params1 []*discover.RouteQueryParam, params2 []*discover.R
 		paramMap[param.Name] = param
 	}
 	for _, param := range params2 {
-		if _, exists := paramMap[param.Name]; exists {
-			existingParam := paramMap[param.Name]
+		if existingParam, exists := paramMap[param.Name]; exists {
 			if existingParam.ExampleValues != nil && param.ExampleValues != nil {
 				// Use a set to deduplicate example values
 				valueSet := make(map[string]struct{})
@@ -127,6 +127,8 @@ func MergeQueryParams(params1 []*discover.RouteQueryParam, params2 []*discover.R
 				existingParam.ExampleValues = param.ExampleValues
 			} // else existingParam.ExampleValues is already set
 			paramMap[param.Name] = existingParam
+		} else {
+			paramMap[param.Name] = param
 		}
 	}
 
@@ -155,8 +157,7 @@ func MergeBodyParams(params1 []*discover.RouteBodyParam, params2 []*discover.Rou
 		paramMap[param.Name] = param
 	}
 	for _, param := range params2 {
-		if _, exists := paramMap[param.Name]; exists {
-			existingParam := paramMap[param.Name]
+		if existingParam, exists := paramMap[param.Name]; exists {
 			if existingParam.ExampleValues != nil && param.ExampleValues != nil {
 				// Use a set to deduplicate example values
 				valueSet := make(map[string]struct{})
@@ -176,6 +177,8 @@ func MergeBodyParams(params1 []*discover.RouteBodyParam, params2 []*discover.Rou
 				existingParam.ExampleValues = param.ExampleValues
 			}
 			paramMap[param.Name] = existingParam
+		} else {
+			paramMap[param.Name] = param
 		}
 	}
 
@@ -290,6 +293,11 @@ func ExtractDomain(rawURL string, maxDomainLevel int) string {
 	}
 	domain := u.Hostname()
 
+	// IPv6 addresses use colons, not dots — return as-is without domain level splitting
+	if net.ParseIP(domain) != nil {
+		return domain
+	}
+
 	if maxDomainLevel > 0 {
 		parts := strings.Split(domain, ".")
 		if len(parts) > maxDomainLevel {
@@ -308,6 +316,12 @@ func IsSubdomain(baseURL string, targetURL string) bool {
 	if baseDomain == "" || targetDomain == "" {
 		return false
 	}
+
+	// For IP addresses (IPv4 or IPv6), require an exact match — IPs don't have subdomains
+	if net.ParseIP(baseDomain) != nil || net.ParseIP(targetDomain) != nil {
+		return baseDomain == targetDomain
+	}
+
 	return targetDomain == baseDomain || strings.HasSuffix(targetDomain, "."+baseDomain)
 }
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -146,7 +146,16 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	errors := []string{}
 
 	log.Info("Parsing HTML content using goquery")
-	htmlContent := *requesthelpers.GetResponseBodyStringFromBodyStruct(httpRequestResponse.Response.ResponseBody)
+	htmlContentPtr := requesthelpers.GetResponseBodyStringFromBodyStruct(httpRequestResponse.Response.ResponseBody)
+	if htmlContentPtr == nil {
+		errors = append(errors, "No response body content available")
+		return routes, discoverroutehelpers.SetToListString(urls), errors
+	}
+	if httpRequestResponse.Response.RedirectChain == nil || len(httpRequestResponse.Response.RedirectChain) == 0 {
+		errors = append(errors, "No redirect chain available")
+		return routes, discoverroutehelpers.SetToListString(urls), errors
+	}
+	htmlContent := *htmlContentPtr
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to parse HTML content from %s: %s", httpRequestResponse.Response.RedirectChain[len(httpRequestResponse.Response.RedirectChain)-1], err)
@@ -429,6 +438,6 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 	// Remove duplicate Routes and Static Assets
 	report.Result.Routes = discoverroutehelpers.MergeWebRoutes(allRoutes)
 	report.Result.StaticAssets = discoverroutehelpers.MergeStaticAssets(allStaticAssets)
-	report.Errors = errors
+	report.Errors = append(report.Errors, errors...)
 	return report
 }

--- a/internal/discover/saas/active/helpers/analysis.go
+++ b/internal/discover/saas/active/helpers/analysis.go
@@ -19,8 +19,8 @@ func AnalyzeSaasRequest(ctx context.Context, request *discover.SaasActiveRequest
 	log := svc1log.FromContext(ctx)
 	// Initial validation
 	// Note: If no response body or headers, or status code is not 200, return false
-	if (request.Request == nil && request.Request.Response == nil && request.Request.Response.ResponseHeaders == nil) ||
-		(request.Request == nil || request.Request.Response == nil || request.Request.Response.StatusCode == nil || *request.Request.Response.StatusCode != 200) {
+	if (request.Request == nil || request.Request.Response == nil || request.Request.Response.ResponseHeaders == nil) ||
+		(request.Request.Response.StatusCode == nil || *request.Request.Response.StatusCode != 200) {
 		return nil
 	}
 

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -381,14 +382,24 @@ func PerformAppEnumerateSwagger(ctx context.Context, config enumerateapiapplicat
 
 	// Use the already-parsed docType from the detection phase
 
-	if version, ok := docType["swagger"]; ok && strings.HasPrefix(version.(string), "2") {
-		versionStr := version.(string)
-		result.Version = &versionStr
-		err = handleSwaggerV2(document, &report, target)
-	} else if version, ok := docType["openapi"]; ok && strings.HasPrefix(version.(string), "3") {
-		versionStr := version.(string)
-		result.Version = &versionStr
-		err = handleOpenAPIV3(document, &report, target)
+	if version, ok := docType["swagger"]; ok {
+		versionStr := fmt.Sprintf("%v", version)
+		if strings.HasPrefix(versionStr, "2") {
+			result.Version = &versionStr
+			err = handleSwaggerV2(document, &report, target)
+		} else {
+			report.Errors = append(report.Errors, fmt.Sprintf("unsupported Swagger version: %s", versionStr))
+			return report
+		}
+	} else if version, ok := docType["openapi"]; ok {
+		versionStr := fmt.Sprintf("%v", version)
+		if strings.HasPrefix(versionStr, "3") {
+			result.Version = &versionStr
+			err = handleOpenAPIV3(document, &report, target)
+		} else {
+			report.Errors = append(report.Errors, fmt.Sprintf("unsupported OpenAPI version: %s", versionStr))
+			return report
+		}
 	} else {
 		report.Errors = append(report.Errors, "unsupported OpenAPI version")
 		return report
@@ -436,7 +447,18 @@ func handleSwaggerV2(document libopenapi.Document, report *enumerateapiapplicati
 		if basePath == "" {
 			basePath = ""
 		}
-		baseEndpointURL = fmt.Sprintf("%s://%s%s", scheme, model.Host, basePath)
+		// Wrap IPv6 addresses in brackets for valid URL construction
+		host := model.Host
+		if hostOnly, _, splitErr := net.SplitHostPort(host); splitErr == nil {
+			// host:port form — check if host part is IPv6
+			if net.ParseIP(hostOnly) != nil && strings.Contains(hostOnly, ":") {
+				host = fmt.Sprintf("[%s]:%s", hostOnly, host[strings.LastIndex(host, ":")+1:])
+			}
+		} else if net.ParseIP(host) != nil && strings.Contains(host, ":") {
+			// bare IPv6 address without port
+			host = fmt.Sprintf("[%s]", host)
+		}
+		baseEndpointURL = fmt.Sprintf("%s://%s%s", scheme, host, basePath)
 	} else {
 		// No host specified, use the target's base URL
 		parsedURL, err := url.Parse(target)
@@ -472,6 +494,9 @@ func handleSwaggerV2(document libopenapi.Document, report *enumerateapiapplicati
 	}
 
 	// Iterate over paths and methods to populate the report
+	if model.Paths == nil || model.Paths.PathItems == nil {
+		return nil
+	}
 	for pair := model.Paths.PathItems.Oldest(); pair != nil; pair = pair.Next() {
 		path := pair.Key
 		pathItem := pair.Value
@@ -569,8 +594,10 @@ func handleOpenAPIV3(document libopenapi.Document, report *enumerateapiapplicati
 
 	// Extract security definitions
 	securityDefinitions := make(map[string]*v3.SecurityScheme)
-	for pair := model.Components.SecuritySchemes.Oldest(); pair != nil; pair = pair.Next() {
-		securityDefinitions[pair.Key] = pair.Value
+	if model.Components != nil && model.Components.SecuritySchemes != nil {
+		for pair := model.Components.SecuritySchemes.Oldest(); pair != nil; pair = pair.Next() {
+			securityDefinitions[pair.Key] = pair.Value
+		}
 	}
 
 	// Add security schemes to the report
@@ -583,6 +610,9 @@ func handleOpenAPIV3(document libopenapi.Document, report *enumerateapiapplicati
 	}
 
 	// Iterate over paths and methods to populate the report
+	if model.Paths == nil || model.Paths.PathItems == nil {
+		return nil
+	}
 	for pair := model.Paths.PathItems.Oldest(); pair != nil; pair = pair.Next() {
 		path := pair.Key
 		pathItem := pair.Value

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -281,18 +281,22 @@ func checkWordPressAPI(ctx context.Context, url string, config *enumeratecmsword
 		}
 
 		// Check routes for plugin endpoints
+		fetchedFromRoute := false
 		for route := range apiResponse.Routes {
 			if strings.Contains(route, "/wp/v2/plugins") {
 				// Try to fetch plugin list directly if available
 				pluginsFromRoutes := fetchPluginsFromAPI(ctx, url, "/wp-json/wp/v2/plugins", config)
 				pluginsList = append(pluginsList, pluginsFromRoutes...)
+				fetchedFromRoute = true
 				break
 			}
 		}
-	}
 
-	// Also check the older /wp-json/wp/v2/ endpoint
-	pluginsList = append(pluginsList, fetchPluginsFromAPI(ctx, url, "/wp-json/wp/v2/plugins", config)...)
+		// Fallback: also try the plugins endpoint even if not listed in routes
+		if !fetchedFromRoute {
+			pluginsList = append(pluginsList, fetchPluginsFromAPI(ctx, url, "/wp-json/wp/v2/plugins", config)...)
+		}
+	}
 
 	return pluginsList, errors
 }
@@ -312,6 +316,9 @@ func fetchPluginsFromAPI(ctx context.Context, baseURL string, path string, confi
 	// Try to parse as JSON array of plugins
 	var pluginList []map[string]interface{}
 	responseBody := requesthelpers.GetResponseBodyStringFromBodyStruct(apiRequest.Response.ResponseBody)
+	if responseBody == nil {
+		return plugins
+	}
 	if err := json.Unmarshal([]byte(*responseBody), &pluginList); err == nil {
 		for _, pluginData := range pluginList {
 			name, _ := pluginData["name"].(string)

--- a/internal/enumerate/general/ratelimit.go
+++ b/internal/enumerate/general/ratelimit.go
@@ -369,8 +369,11 @@ func RateLimitDetected(request *common.HttpRequestResponse, hasSeen200 bool) boo
 
 	// Check response body for common rate limit messages
 	if response.ResponseBody != nil {
-		body := *requesthelpers.GetResponseBodyStringFromBodyStruct(response.ResponseBody)
-		body = strings.ToLower(body)
+		bodyPtr := requesthelpers.GetResponseBodyStringFromBodyStruct(response.ResponseBody)
+		if bodyPtr == nil {
+			return false
+		}
+		body := strings.ToLower(*bodyPtr)
 		rateLimitPhrases := []string{
 			"rate limit exceeded",
 			"too many requests",

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -138,7 +138,11 @@ func detectSuccessfulXmlrpcGrab(requestInfo *common.HttpRequestResponse) bool {
 	if requestInfo.Response == nil || requestInfo.Response.ResponseBody == nil {
 		return false
 	}
-	body := *requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody)
+	bodyPtr := requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody)
+	if bodyPtr == nil {
+		return false
+	}
+	body := *bodyPtr
 	return strings.Contains(body, "<methodResponse>") && strings.Contains(body, "<params>")
 }
 
@@ -150,6 +154,9 @@ func parseXMLRPCFunctions(responseBody *common.Body) []string {
 
 	// Get the body string
 	bodyString := requesthelpers.GetResponseBodyStringFromBodyStruct(responseBody)
+	if bodyString == nil {
+		return []string{}
+	}
 
 	// Extract function names from XML response
 	var functions []string
@@ -190,7 +197,11 @@ func detectSuccessfulFunctionAuth(requestInfo *common.HttpRequestResponse, funct
 		return &success
 	}
 
-	body := strings.ToLower(*requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody))
+	bodyPtr := requesthelpers.GetResponseBodyStringFromBodyStruct(requestInfo.Response.ResponseBody)
+	if bodyPtr == nil {
+		return &success
+	}
+	body := strings.ToLower(*bodyPtr)
 
 	// Check if this is a pingback function
 	isPingback := strings.Contains(strings.ToLower(functionName), "pingback")

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -67,6 +67,7 @@ func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePat
 
 		// Read the entire file
 		data, err := io.ReadAll(file)
+		_ = file.Close()
 		if err != nil {
 			continue
 		}
@@ -74,10 +75,6 @@ func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePat
 			Fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint
 		}
 		if err := json.Unmarshal(data, &config); err != nil {
-			continue
-		}
-		err = file.Close()
-		if err != nil {
 			continue
 		}
 		fingerprints = append(fingerprints, config.Fingerprints...)
@@ -106,6 +103,10 @@ func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.Http
 
 	// Check each fingerprint
 	instance := pentestroutefern.StaticAssetTakeoverVulnerableDetails{}
+	if httpRequestResponse.Response.StatusCode == nil {
+		return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
+	}
+	statusCode := *httpRequestResponse.Response.StatusCode
 	for _, fingerprint := range fingerprints {
 
 		// Does response body contain any of the exclude response bodies
@@ -116,7 +117,7 @@ func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.Http
 		}
 		// Does the status code and response body of the request match the fingerprint
 		for _, fingerprintBody := range fingerprint.ResponseBody {
-			if *httpRequestResponse.Response.StatusCode == fingerprint.StatusCode && strings.Contains(lowerResponseBody, fingerprintBody) {
+			if statusCode == fingerprint.StatusCode && strings.Contains(lowerResponseBody, fingerprintBody) {
 				instance.Vulnerable = true
 				instance.Fingerprint = fingerprint
 				return instance
@@ -125,7 +126,7 @@ func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.Http
 	}
 
 	// Check if we should detect 404 responses
-	if detect404Responses && *httpRequestResponse.Response.StatusCode == 404 {
+	if detect404Responses && statusCode == 404 {
 		instance.Vulnerable = true
 		instance.Fingerprint = &pentestroutefern.StaticAssetTakeoverFingerprint{
 			Name:        "404 Response",
@@ -213,11 +214,15 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 
 		// Set the request method to 'STANDARD' even when original request was HEADLESS since its not required to
 		// pull in the static asset and has higher overhead
-		config.RouteCaptureConfig.RequestMethod = common.RequestMethodStandard
-		config.RouteCaptureConfig.MaxRedirects = 0 // Don't follow any redirects on static asset requests
-		config.RouteCaptureConfig.HeadlessConfig = nil
-		config.RouteCaptureConfig.BrowserbaseConfig = nil
-		requestConfig := createSendHTTPRequestConfig(staticAssetBaseURL, staticAssetPath, queryParams, config, nil)
+		// Use a copy of config to avoid mutating the original
+		staticAssetConfig := config
+		staticAssetRouteCaptureConfig := *config.RouteCaptureConfig
+		staticAssetRouteCaptureConfig.RequestMethod = common.RequestMethodStandard
+		staticAssetRouteCaptureConfig.MaxRedirects = 0 // Don't follow any redirects on static asset requests
+		staticAssetRouteCaptureConfig.HeadlessConfig = nil
+		staticAssetRouteCaptureConfig.BrowserbaseConfig = nil
+		staticAssetConfig.RouteCaptureConfig = &staticAssetRouteCaptureConfig
+		requestConfig := createSendHTTPRequestConfig(staticAssetBaseURL, staticAssetPath, queryParams, staticAssetConfig, nil)
 		result, err := request.SendRequest(ctx, requestConfig)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("error performing request: %s", err))

--- a/utils/general.go
+++ b/utils/general.go
@@ -28,6 +28,10 @@ func GetEntriesFromTXTFiles(paths []string) ([]string, error) {
 		for scanner.Scan() {
 			lines = append(lines, scanner.Text())
 		}
+		if err := scanner.Err(); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
 		err = file.Close()
 		if err != nil {
 			return nil, err

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -316,8 +316,8 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 		reference = ev.Info.Reference.ToSlice()
 	}
 	var softwareWeakness string
-	if ev.Info.Metadata["method-software-weakness-name"] != nil {
-		softwareWeakness = ev.Info.Metadata["method-software-weakness-name"].(string)
+	if v, ok := ev.Info.Metadata["method-software-weakness-name"].(string); ok {
+		softwareWeakness = v
 	}
 
 	// Extract template metadata if available

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -35,7 +35,7 @@ type Config struct {
 	GlobalRateLimit int
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg *Config) error {
 	if cfg.RunMode == nuclei.NucleiRunModeDast {
 		if len(cfg.RawRequests) == 0 {
 			return fmt.Errorf("runner: no RawRequests provided for dast mode")
@@ -67,7 +67,7 @@ func copyFilesToTmpDirs(cfg Config) (templateDir, workflowDir string, err error)
 
 	// Copy templates
 	for _, src := range cfg.TemplateFS {
-		_ = fs.WalkDir(src, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr := fs.WalkDir(src, ".", func(p string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
 			}
@@ -84,7 +84,9 @@ func copyFilesToTmpDirs(cfg Config) (templateDir, workflowDir string, err error)
 			}
 			dst := filepath.Join(templateDir, filepath.Base(p))
 			return os.WriteFile(dst, data, 0o600)
-		})
+		}); walkErr != nil {
+			return "", "", fmt.Errorf("failed to copy templates: %w", walkErr)
+		}
 	}
 
 	// Copy workflows with subtemplates structure
@@ -94,7 +96,7 @@ func copyFilesToTmpDirs(cfg Config) (templateDir, workflowDir string, err error)
 	}
 
 	for _, src := range cfg.WorkflowFS {
-		_ = fs.WalkDir(src, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr := fs.WalkDir(src, ".", func(p string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
 			}
@@ -121,7 +123,9 @@ func copyFilesToTmpDirs(cfg Config) (templateDir, workflowDir string, err error)
 				dst = filepath.Join(subtemplatesDir, filename)
 			}
 			return os.WriteFile(dst, data, 0o600)
-		})
+		}); walkErr != nil {
+			return "", "", fmt.Errorf("failed to copy workflows: %w", walkErr)
+		}
 	}
 
 	return templateDir, workflowDir, nil
@@ -236,18 +240,22 @@ func loadTargets(eng *nucleilib.NucleiEngine, cfg Config) error {
 		if err != nil {
 			return err
 		}
+		tmpName := f.Name()
 		defer func() {
-			_ = os.Remove(f.Name())
+			_ = os.Remove(tmpName)
 		}()
 		for _, line := range cfg.RawRequests {
 			if _, err := f.WriteString(line + "\n"); err != nil {
+				_ = f.Close()
 				return err
 			}
 		}
-		_ = f.Sync()
+		if err := f.Close(); err != nil {
+			return err
+		}
 
 		// tell Nuclei to parse JSONL
-		if err := eng.LoadTargetsWithHttpData(f.Name(), "jsonl"); err != nil {
+		if err := eng.LoadTargetsWithHttpData(tmpName, "jsonl"); err != nil {
 			return err
 		}
 	} else {
@@ -284,7 +292,7 @@ func GetRunnerConfig(templateFileSystems, workflowFileSystems []fs.FS, config nu
 func Run(ctx context.Context, cfg Config, reportBuilder *report.Builder) ([]*nuclei.NucleiTargetInfo, error) {
 	log := svc1log.FromContext(ctx)
 	log.Info("Validating config")
-	if err := validateConfig(cfg); err != nil {
+	if err := validateConfig(&cfg); err != nil {
 		return nil, err
 	}
 

--- a/utils/request/headless/browserbase/browserbase.go
+++ b/utils/request/headless/browserbase/browserbase.go
@@ -35,7 +35,11 @@ func NewBrowserbaseRequester(
 		return nil
 	}
 
-	websocket := NewWebSocket(ctx, browserbaseClient.ConnectionString(*session))
+	websocket, err := NewWebSocket(ctx, browserbaseClient.ConnectionString(*session))
+	if err != nil {
+		svc1log.FromContext(ctx).Error("Failed to create websocket connection", svc1log.SafeParam("error", err.Error()))
+		return nil
+	}
 	client := cdp.New().Start(websocket)
 	return &Requester{
 		Requester: headless.NewRequesterWithClient(client, timeout, minDOMStabalizeTime),

--- a/utils/request/headless/browserbase/client.go
+++ b/utils/request/headless/browserbase/client.go
@@ -89,7 +89,10 @@ func (b *Client) CloseSession(ctx context.Context, sessionID string) error {
 		return err
 	}
 
-	request, _ := http.NewRequest("POST", b.URL+"/v1/sessions/"+sessionID, bytes.NewBuffer(payloadBytes))
+	request, err := http.NewRequest("POST", b.URL+"/v1/sessions/"+sessionID, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return err
+	}
 	request.Header.Add("X-BB-API-Key", b.APIKey)
 	request.Header.Add("Content-Type", "application/json")
 
@@ -167,7 +170,10 @@ func (b *Client) createSession(ctx context.Context, createSessionRequest *Create
 
 	log.Debug(fmt.Sprintf("Creating session with payload: %s", string(payloadBytes)))
 
-	request, _ := http.NewRequest("POST", fmt.Sprintf("%s/v1/sessions", b.URL), bytes.NewBuffer(payloadBytes))
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/sessions", b.URL), bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("X-BB-API-Key", b.APIKey)
 

--- a/utils/request/headless/browserbase/websocket.go
+++ b/utils/request/headless/browserbase/websocket.go
@@ -3,7 +3,7 @@ package browserbase
 import (
 	// Standard
 	"context"
-	"log"
+	"fmt"
 	"net"
 
 	// External
@@ -15,12 +15,12 @@ type WebSocket struct {
 	conn net.Conn
 }
 
-func NewWebSocket(ctx context.Context, url string) *WebSocket {
-	conn, _, _, err := ws.Dial(context.Background(), url)
+func NewWebSocket(ctx context.Context, url string) (*WebSocket, error) {
+	conn, _, _, err := ws.Dial(ctx, url)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("failed to dial websocket: %w", err)
 	}
-	return &WebSocket{conn}
+	return &WebSocket{conn}, nil
 }
 
 func (w *WebSocket) Send(b []byte) error {

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -144,7 +144,7 @@ func CreateBodyFromBytes(contentType string, bodyData []byte) *common.Body {
 		fields := make(map[string]string)
 		bodyStr := string(bodyData)
 		for _, pair := range strings.Split(bodyStr, "&") {
-			kv := strings.Split(pair, "=")
+			kv := strings.SplitN(pair, "=", 2)
 			if len(kv) == 2 {
 				fields[kv[0]] = kv[1]
 			}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core scanning pipelines (discover/route/directory, swagger enumeration, nuclei runner) and changes URL/domain handling for IPv4/IPv6, so regressions could alter scan coverage or filtering despite being largely defensive hardening.
> 
> **Overview**
> Improves CLI scan commands to **stop on engine errors** (avoiding emitting partial/invalid output) and adds missing panic protection to `discover saas`.
> 
> Hardens discovery/pentest/enumeration logic by adding **nil checks and safer parsing** around response bodies, redirect chains, and metadata type assertions to prevent panics and reduce false positives (directory discovery baseline/comparisons, route extraction, rate-limit detection, WordPress XMLRPC + plugin enumeration).
> 
> Adds **IPv6 support** in route-domain matching (`ExtractDomain`/`IsSubdomain`) and Swagger base URL construction (bracket-wrapping IPv6 hosts), plus fixes a few edge cases (unsupported OpenAPI/Swagger versions, missing `Paths`/security schemes, form parsing with `SplitN`, avoid mutating shared config in static-asset takeover, better temp-file/WalkDir error handling in the Nuclei runner, and non-fatal Browserbase websocket failures).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5a6d4870d90c3a24a142cd57003e8711d25311b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->