### PR TITLE
Discover Directory: Bug Fix

### DIFF
--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -59,7 +59,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 	log.Info("Starting Directory Discovery with multi-threading")
 
 	// Initialize report
-	report := discover.DiscoverDirectoryReport{}
+	report := discover.DiscoverDirectoryReport{Config: &config}
 	errors := []string{}
 	result := discover.DiscoverDirectoryResult{}
 
@@ -263,7 +263,6 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 	result.Targets = targets
 
 	report.Result = &result
-	report.Config = &config
 	report.Errors = errors
 	return &report, nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to report construction/metadata; no request logic or discovery behavior is altered.
> 
> **Overview**
> Fixes directory discovery reporting so the `DiscoverDirectoryReport` always includes the run `Config`, even when returning early due to errors or timeouts.
> 
> This moves `report.Config = &config` to report initialization and removes the late assignment at the end of `RunDirectoryDiscovery`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dd80205eb4c4b89076b0000d0766c65483aed4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->