### PR TITLE
Embed wordlists and config files into compiled binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,9 @@ RUN \
   mkdir -p /opt/method/${CLI_NAME}/ && \
   mkdir -p /opt/method/${CLI_NAME}/var/data && \
   mkdir -p /opt/method/${CLI_NAME}/var/data/tmp && \
-  mkdir -p /opt/method/${CLI_NAME}/var/conf && \
   mkdir -p /opt/method/${CLI_NAME}/var/log && \
   mkdir -p /opt/method/${CLI_NAME}/service/bin && \
   mkdir -p /mnt/output
-
-COPY configs/                                 /opt/method/${CLI_NAME}/var/conf/
 
 COPY ${CLI_NAME}                              /opt/method/${CLI_NAME}/service/bin/${CLI_NAME}
 

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -684,8 +684,8 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverSaasCmd.Flags().StringSlice("orgs", []string{}, "The organization names to use for discovery")
 	// Config Flags
-	discoverSaasCmd.Flags().StringSlice("saas-file-paths", []string{"/opt/method/webscan/var/conf/discover/saas/saas_fingerprints.json"}, "Files containing SaaS application fingerprints")
-	discoverSaasCmd.Flags().StringSlice("sso-file-paths", []string{"/opt/method/webscan/var/conf/discover/saas/sso_fingerprints.json"}, "Files containing SSO application fingerprints")
+	discoverSaasCmd.Flags().StringSlice("saas-file-paths", []string{}, "Files containing SaaS application fingerprints")
+	discoverSaasCmd.Flags().StringSlice("sso-file-paths", []string{}, "Files containing SSO application fingerprints")
 	discoverSaasCmd.Flags().StringSlice("saas-companies", []string{}, "The specific SaaS companies to use for discovery (Must be present in the SaaS fingerprints file)")
 	discoverSaasCmd.Flags().StringSlice("sso-companies", []string{}, "The specific SSO companies to use for discovery (Must be present in the SSO fingerprints file)")
 	discoverSaasCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -592,8 +592,8 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			saasFingerprints := discoversaashelpers.UnmarshalFingerprints(saasFilePaths)
-			ssoFingerprints := discoversaashelpers.UnmarshalFingerprints(ssoFilePaths)
+			saasFingerprints := discoversaashelpers.UnmarshalFingerprints(saasFilePaths, "discover/saas/saas_fingerprints.json")
+			ssoFingerprints := discoversaashelpers.UnmarshalFingerprints(ssoFilePaths, "discover/saas/sso_fingerprints.json")
 			if len(saasFingerprints.Fingerprints) == 0 {
 				a.OutputSignal.AddError(errors.New("no SaaS fingerprints found"))
 				return

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -356,8 +356,8 @@ func (a *WebScan) InitEnumerateCommand() {
 					a.OutputSignal.AddError(err)
 					return
 				}
-				moduleFile := enumeratecms.GetEnumerateDrupalModuleWordlistPath(modulesFileSizeEnum)
-				entries, err := utils.GetEntriesFromTXTFiles([]string{moduleFile})
+				moduleFile := enumeratecms.GetEnumerateDrupalModuleEmbeddedPath(modulesFileSizeEnum)
+				entries, err := configs.ReadLines(moduleFile)
 				if err != nil {
 					a.OutputSignal.AddError(err)
 					return

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -18,6 +18,8 @@ import (
 	enumerategeneral "github.com/Method-Security/webscan/internal/enumerate/general"
 	enumeratekube "github.com/Method-Security/webscan/internal/enumerate/kube"
 
+	// Configs
+	"github.com/Method-Security/webscan/configs"
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
 	// External
@@ -241,8 +243,8 @@ func (a *WebScan) InitEnumerateCommand() {
 					a.OutputSignal.AddError(err)
 					return
 				}
-				pluginFile := enumeratecms.GetEnumerateWordpressPluginWordlistPath(PluginsFileSizeEnum)
-				entries, err := utils.GetEntriesFromTXTFiles([]string{pluginFile})
+				pluginFile := enumeratecms.GetEnumerateWordpressPluginEmbeddedPath(PluginsFileSizeEnum)
+				entries, err := configs.ReadLines(pluginFile)
 				if err != nil {
 					a.OutputSignal.AddError(err)
 					return

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -601,7 +601,7 @@ func (a *WebScan) InitPentestCommand() {
 	// Target Flags
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("target", "", "URL target to analyze for static asset takeover")
 	// Config Flags
-	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json"}, "Paths to fingerprint definition files")
+	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("fingerprint-file-paths", []string{}, "Paths to fingerprint definition files")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("detect-404-responses", false, "Detect 404 responses as potential takeover responses")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("successful-only", false, "Only show successful takeover attempts")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")

--- a/configs/embed.go
+++ b/configs/embed.go
@@ -3,8 +3,6 @@ package configs
 import (
 	"embed"
 	"fmt"
-	"io/fs"
-	"os"
 	"strings"
 )
 
@@ -23,24 +21,13 @@ func ReadLines(path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read embedded config %s: %w", path, err)
 	}
-	content := strings.TrimRight(string(data), "\n")
+	content := strings.TrimRight(string(data), "\r\n")
 	if content == "" {
 		return []string{}, nil
 	}
-	return strings.Split(content, "\n"), nil
-}
-
-// ReadFileWithFallback tries to read from the filesystem first, then falls back to the embedded config.
-// This supports user-provided custom paths (filesystem) while defaulting to embedded configs.
-func ReadFileWithFallback(filesystemPath string, embeddedPath string) ([]byte, error) {
-	data, err := os.ReadFile(filesystemPath)
-	if err == nil {
-		return data, nil
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
 	}
-	return ReadFile(embeddedPath)
-}
-
-// FS returns the embedded filesystem for direct access if needed.
-func FS() fs.FS {
-	return configFS
+	return lines, nil
 }

--- a/configs/embed.go
+++ b/configs/embed.go
@@ -1,0 +1,46 @@
+package configs
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+//go:embed discover enumerate pentest
+var configFS embed.FS
+
+// ReadFile reads a file from the embedded config filesystem.
+// The path should be relative to the configs/ directory.
+func ReadFile(path string) ([]byte, error) {
+	return configFS.ReadFile(path)
+}
+
+// ReadLines reads a text file from the embedded config filesystem and returns its lines.
+func ReadLines(path string) ([]string, error) {
+	data, err := configFS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embedded config %s: %w", path, err)
+	}
+	content := strings.TrimRight(string(data), "\n")
+	if content == "" {
+		return []string{}, nil
+	}
+	return strings.Split(content, "\n"), nil
+}
+
+// ReadFileWithFallback tries to read from the filesystem first, then falls back to the embedded config.
+// This supports user-provided custom paths (filesystem) while defaulting to embedded configs.
+func ReadFileWithFallback(filesystemPath string, embeddedPath string) ([]byte, error) {
+	data, err := os.ReadFile(filesystemPath)
+	if err == nil {
+		return data, nil
+	}
+	return ReadFile(embeddedPath)
+}
+
+// FS returns the embedded filesystem for direct access if needed.
+func FS() fs.FS {
+	return configFS
+}

--- a/fern/definition/pentest/route/staticassettakeover.yml
+++ b/fern/definition/pentest/route/staticassettakeover.yml
@@ -7,7 +7,7 @@ types:
     properties:
       routeCaptureConfig: route.DiscoverRouteConfig
       successfulOnly: boolean
-      fingerprintFilePaths: list<string>
+      fingerprintFilePaths: optional<list<string>>
       detect404Responses: boolean
   # Fingerprint File Struct
   StaticAssetTakeoverFingerprint:

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -6,12 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	// Configs
+	"github.com/Method-Security/webscan/configs"
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	discover "github.com/Method-Security/webscan/generated/go/discover"
@@ -332,14 +333,11 @@ func gatherPaths(paths []string, wordlistType *discover.WordlistType, wordlistSi
 
 	// Add paths from automatic wordlist selection
 	if wordlistType != nil && wordlistSize != nil {
-		wordlistPath, err := getWordlistPath(*wordlistType, *wordlistSize)
-		if err != nil {
-			return nil, err
-		}
+		embeddedPath := getWordlistEmbeddedPath(*wordlistType, *wordlistSize)
 
-		wordlistPaths, err := utils.GetEntriesFromTXTFiles([]string{wordlistPath})
+		wordlistPaths, err := configs.ReadLines(embeddedPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load wordlist %s: %v", wordlistPath, err)
+			return nil, fmt.Errorf("failed to load embedded wordlist %s: %v", embeddedPath, err)
 		}
 		allPaths = append(allPaths, wordlistPaths...)
 	}
@@ -347,29 +345,11 @@ func gatherPaths(paths []string, wordlistType *discover.WordlistType, wordlistSi
 	return allPaths, nil
 }
 
-// getWordlistPath constructs the path to the appropriate wordlist file
-func getWordlistPath(wordlistType discover.WordlistType, wordlistSize discover.WordlistSize) (string, error) {
-	// Convert enums to strings
+// getWordlistEmbeddedPath returns the embedded config path for a directory wordlist.
+func getWordlistEmbeddedPath(wordlistType discover.WordlistType, wordlistSize discover.WordlistSize) string {
 	typeStr := strings.ToLower(string(wordlistType))
 	sizeStr := strings.ToLower(string(wordlistSize))
-
-	// Construct filename following the pattern: raft-{size}-{type}-lowercase.txt
-	filename := fmt.Sprintf("raft-%s-%s-lowercase.txt", sizeStr, typeStr)
-
-	// Try container path first (for Docker deployment)
-	containerPath := fmt.Sprintf("var/conf/discover/directory/%s", filename)
-	if _, err := os.Stat(containerPath); err == nil {
-		return containerPath, nil
-	}
-
-	// Fallback to local development path
-	localPath := fmt.Sprintf("configs/discover/directory/%s", filename)
-	if _, err := os.Stat(localPath); err == nil {
-		return localPath, nil
-	}
-
-	// If neither path exists, return an error with both attempted paths
-	return "", fmt.Errorf("wordlist file not found at %s or %s", containerPath, localPath)
+	return fmt.Sprintf("discover/directory/raft-%s-%s-lowercase.txt", sizeStr, typeStr)
 }
 
 // areSimilar is a function that checks if the value is similar to the baseline with a given tolerance

--- a/internal/discover/saas/active/helpers/helpers.go
+++ b/internal/discover/saas/active/helpers/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Method-Security/webscan/configs"
 	discover "github.com/Method-Security/webscan/generated/go/discover"
 )
 
@@ -25,22 +26,35 @@ func FilterFingerprints(companies []string, fingerprints discover.SaasFingerprin
 	return &discover.SaasFingerprintFile{Fingerprints: filteredFingerprints}, nil
 }
 
-// UnmarshalFingerprints unmarshals the fingerprint files into a SaasFingerprintFile
+// embeddedSaasFiles maps known container paths to their embedded config paths.
+var embeddedSaasFiles = map[string]string{
+	"/opt/method/webscan/var/conf/discover/saas/saas_fingerprints.json": "discover/saas/saas_fingerprints.json",
+	"/opt/method/webscan/var/conf/discover/saas/sso_fingerprints.json":  "discover/saas/sso_fingerprints.json",
+}
+
+// UnmarshalFingerprints unmarshals the fingerprint files into a SaasFingerprintFile.
+// Tries the filesystem first, then falls back to embedded configs for known default paths.
 func UnmarshalFingerprints(fingerprintFiles []string) discover.SaasFingerprintFile {
 	result := discover.SaasFingerprintFile{
 		Fingerprints: make(map[string]*discover.SaasFingerprintEntry),
 	}
-	// Read and unmarshal each fingerprint file
 	for _, file := range fingerprintFiles {
 		data, err := os.ReadFile(file)
 		if err != nil {
-			continue
+			// Fall back to embedded config for known default paths
+			if embeddedPath, ok := embeddedSaasFiles[file]; ok {
+				data, err = configs.ReadFile(embeddedPath)
+				if err != nil {
+					continue
+				}
+			} else {
+				continue
+			}
 		}
 		var fingerprints discover.SaasFingerprintFile
 		if err := json.Unmarshal(data, &fingerprints); err != nil {
 			continue
 		}
-		// Merge fingerprints from this file into result
 		for k, v := range fingerprints.Fingerprints {
 			result.Fingerprints[k] = v
 		}

--- a/internal/discover/saas/active/helpers/helpers.go
+++ b/internal/discover/saas/active/helpers/helpers.go
@@ -27,28 +27,20 @@ func FilterFingerprints(companies []string, fingerprints discover.SaasFingerprin
 }
 
 // UnmarshalFingerprints unmarshals the fingerprint files into a SaasFingerprintFile.
-// If no paths are provided, loads directly from embedded configs for both saas and sso fingerprints.
-func UnmarshalFingerprints(fingerprintFiles []string) discover.SaasFingerprintFile {
+// If no paths are provided, loads from the specified embedded config path.
+func UnmarshalFingerprints(fingerprintFiles []string, embeddedFallbackPath string) discover.SaasFingerprintFile {
 	result := discover.SaasFingerprintFile{
 		Fingerprints: make(map[string]*discover.SaasFingerprintEntry),
 	}
 
 	if len(fingerprintFiles) == 0 {
-		embeddedPaths := []string{
-			"discover/saas/saas_fingerprints.json",
-			"discover/saas/sso_fingerprints.json",
-		}
-		for _, embeddedPath := range embeddedPaths {
-			data, err := configs.ReadFile(embeddedPath)
-			if err != nil {
-				continue
-			}
+		data, err := configs.ReadFile(embeddedFallbackPath)
+		if err == nil {
 			var fingerprints discover.SaasFingerprintFile
-			if err := json.Unmarshal(data, &fingerprints); err != nil {
-				continue
-			}
-			for k, v := range fingerprints.Fingerprints {
-				result.Fingerprints[k] = v
+			if err := json.Unmarshal(data, &fingerprints); err == nil {
+				for k, v := range fingerprints.Fingerprints {
+					result.Fingerprints[k] = v
+				}
 			}
 		}
 	} else {

--- a/internal/discover/saas/active/helpers/helpers.go
+++ b/internal/discover/saas/active/helpers/helpers.go
@@ -26,37 +26,44 @@ func FilterFingerprints(companies []string, fingerprints discover.SaasFingerprin
 	return &discover.SaasFingerprintFile{Fingerprints: filteredFingerprints}, nil
 }
 
-// embeddedSaasFiles maps known container paths to their embedded config paths.
-var embeddedSaasFiles = map[string]string{
-	"/opt/method/webscan/var/conf/discover/saas/saas_fingerprints.json": "discover/saas/saas_fingerprints.json",
-	"/opt/method/webscan/var/conf/discover/saas/sso_fingerprints.json":  "discover/saas/sso_fingerprints.json",
-}
-
 // UnmarshalFingerprints unmarshals the fingerprint files into a SaasFingerprintFile.
-// Tries the filesystem first, then falls back to embedded configs for known default paths.
+// If no paths are provided, loads directly from embedded configs for both saas and sso fingerprints.
 func UnmarshalFingerprints(fingerprintFiles []string) discover.SaasFingerprintFile {
 	result := discover.SaasFingerprintFile{
 		Fingerprints: make(map[string]*discover.SaasFingerprintEntry),
 	}
-	for _, file := range fingerprintFiles {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			// Fall back to embedded config for known default paths
-			if embeddedPath, ok := embeddedSaasFiles[file]; ok {
-				data, err = configs.ReadFile(embeddedPath)
-				if err != nil {
-					continue
-				}
-			} else {
+
+	if len(fingerprintFiles) == 0 {
+		embeddedPaths := []string{
+			"discover/saas/saas_fingerprints.json",
+			"discover/saas/sso_fingerprints.json",
+		}
+		for _, embeddedPath := range embeddedPaths {
+			data, err := configs.ReadFile(embeddedPath)
+			if err != nil {
 				continue
 			}
+			var fingerprints discover.SaasFingerprintFile
+			if err := json.Unmarshal(data, &fingerprints); err != nil {
+				continue
+			}
+			for k, v := range fingerprints.Fingerprints {
+				result.Fingerprints[k] = v
+			}
 		}
-		var fingerprints discover.SaasFingerprintFile
-		if err := json.Unmarshal(data, &fingerprints); err != nil {
-			continue
-		}
-		for k, v := range fingerprints.Fingerprints {
-			result.Fingerprints[k] = v
+	} else {
+		for _, file := range fingerprintFiles {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				continue
+			}
+			var fingerprints discover.SaasFingerprintFile
+			if err := json.Unmarshal(data, &fingerprints); err != nil {
+				continue
+			}
+			for k, v := range fingerprints.Fingerprints {
+				result.Fingerprints[k] = v
+			}
 		}
 	}
 

--- a/internal/enumerate/cms/drupal.go
+++ b/internal/enumerate/cms/drupal.go
@@ -36,11 +36,11 @@ var (
 	drupalJSReferenceRegex   = regexp.MustCompile(`src=['"]([^'"]*modules/contrib/([^/'"]+)/[^'"]*\.js[^'"]*?)['"]`)
 )
 
-// GetEnumerateDrupalModuleWordlistPath returns the path to the wordlist for the given module file size
-func GetEnumerateDrupalModuleWordlistPath(modulesFileSize enumeratecmsdrupalfern.ModulesFileSize) string {
+// GetEnumerateDrupalModuleEmbeddedPath returns the embedded config path for the given module file size.
+func GetEnumerateDrupalModuleEmbeddedPath(modulesFileSize enumeratecmsdrupalfern.ModulesFileSize) string {
 	wordlistPaths := map[enumeratecmsdrupalfern.ModulesFileSize]string{
-		enumeratecmsdrupalfern.ModulesFileSizeSmall: "/opt/method/webscan/var/conf/enumerate/cms/drupal/modules_small.txt",
-		enumeratecmsdrupalfern.ModulesFileSizeLarge: "/opt/method/webscan/var/conf/enumerate/cms/drupal/modules_large.txt",
+		enumeratecmsdrupalfern.ModulesFileSizeSmall: "enumerate/cms/drupal/modules_small.txt",
+		enumeratecmsdrupalfern.ModulesFileSizeLarge: "enumerate/cms/drupal/modules_large.txt",
 	}
 	return wordlistPaths[modulesFileSize]
 }

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -20,11 +20,11 @@ import (
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 )
 
-// GetEnumerateWordpressPluginWordlistPath returns the path to the wordlist for the given plugin file size
-func GetEnumerateWordpressPluginWordlistPath(PluginsFileSize enumeratecmswordpressfern.PluginsFileSize) string {
+// GetEnumerateWordpressPluginEmbeddedPath returns the embedded config path for the given plugin file size.
+func GetEnumerateWordpressPluginEmbeddedPath(PluginsFileSize enumeratecmswordpressfern.PluginsFileSize) string {
 	wordlistPaths := map[enumeratecmswordpressfern.PluginsFileSize]string{
-		enumeratecmswordpressfern.PluginsFileSizeSmall: "/opt/method/webscan/var/conf/enumerate/cms/wordpress/plugins_small.txt",
-		enumeratecmswordpressfern.PluginsFileSizeLarge: "/opt/method/webscan/var/conf/enumerate/cms/wordpress/plugins_large.txt",
+		enumeratecmswordpressfern.PluginsFileSizeSmall: "enumerate/cms/wordpress/plugins_small.txt",
+		enumeratecmswordpressfern.PluginsFileSizeLarge: "enumerate/cms/wordpress/plugins_large.txt",
 	}
 	return wordlistPaths[PluginsFileSize]
 }

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	// Configs
+	"github.com/Method-Security/webscan/configs"
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	pentestroutefern "github.com/Method-Security/webscan/generated/go/pentest/route"
@@ -48,7 +49,13 @@ func createSendHTTPRequestConfig(targetBaseURL, targetPath string, queryParams m
 	return requestConfig
 }
 
-// grabStaticAssetTakeOverFingerprints grabs the fingerprints from the given file paths
+// embeddedStaticAssetFiles maps known container paths to their embedded config paths.
+var embeddedStaticAssetFiles = map[string]string{
+	"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json": "pentest/route/static_asset_takeover.json",
+}
+
+// grabStaticAssetTakeOverFingerprints grabs the fingerprints from the given file paths.
+// Tries the filesystem first, then falls back to embedded configs for known default paths.
 func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePaths []string) []*pentestroutefern.StaticAssetTakeoverFingerprint {
 	log := svc1log.FromContext(ctx)
 	log.Info("Grabbing static asset take over fingerprints", svc1log.SafeParam("fingerprint_file_paths", fingerprintFilePaths))
@@ -56,21 +63,18 @@ func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePat
 	fingerprints := []*pentestroutefern.StaticAssetTakeoverFingerprint{}
 
 	for _, path := range fingerprintFilePaths {
+		var data []byte
+		var err error
+
 		absPath, err := filepath.Abs(path)
-		if err != nil {
-			continue
+		if err == nil {
+			data, err = os.ReadFile(absPath)
 		}
-		file, err := os.Open(absPath)
+
 		if err != nil {
 			continue
 		}
 
-		// Read the entire file
-		data, err := io.ReadAll(file)
-		_ = file.Close()
-		if err != nil {
-			continue
-		}
 		var config struct {
 			Fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint
 		}

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -49,39 +49,42 @@ func createSendHTTPRequestConfig(targetBaseURL, targetPath string, queryParams m
 	return requestConfig
 }
 
-// embeddedStaticAssetFiles maps known container paths to their embedded config paths.
-var embeddedStaticAssetFiles = map[string]string{
-	"/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json": "pentest/route/static_asset_takeover.json",
-}
-
 // grabStaticAssetTakeOverFingerprints grabs the fingerprints from the given file paths.
-// Tries the filesystem first, then falls back to embedded configs for known default paths.
+// If no paths are provided, loads directly from embedded configs.
 func grabStaticAssetTakeOverFingerprints(ctx context.Context, fingerprintFilePaths []string) []*pentestroutefern.StaticAssetTakeoverFingerprint {
 	log := svc1log.FromContext(ctx)
 	log.Info("Grabbing static asset take over fingerprints", svc1log.SafeParam("fingerprint_file_paths", fingerprintFilePaths))
 
 	fingerprints := []*pentestroutefern.StaticAssetTakeoverFingerprint{}
 
-	for _, path := range fingerprintFilePaths {
-		var data []byte
-		var err error
-
-		absPath, err := filepath.Abs(path)
+	if len(fingerprintFilePaths) == 0 {
+		data, err := configs.ReadFile("pentest/route/static_asset_takeover.json")
 		if err == nil {
-			data, err = os.ReadFile(absPath)
+			var config struct {
+				Fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint
+			}
+			if err := json.Unmarshal(data, &config); err == nil {
+				fingerprints = append(fingerprints, config.Fingerprints...)
+			}
 		}
-
-		if err != nil {
-			continue
+	} else {
+		for _, path := range fingerprintFilePaths {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				continue
+			}
+			data, err := os.ReadFile(absPath)
+			if err != nil {
+				continue
+			}
+			var config struct {
+				Fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint
+			}
+			if err := json.Unmarshal(data, &config); err != nil {
+				continue
+			}
+			fingerprints = append(fingerprints, config.Fingerprints...)
 		}
-
-		var config struct {
-			Fingerprints []*pentestroutefern.StaticAssetTakeoverFingerprint
-		}
-		if err := json.Unmarshal(data, &config); err != nil {
-			continue
-		}
-		fingerprints = append(fingerprints, config.Fingerprints...)
 	}
 
 	log.Info("Grabbed static asset take over fingerprints", svc1log.SafeParam("num_of_fingerprints", len(fingerprints)))


### PR DESCRIPTION
## Summary
- Uses Go's `//go:embed` to bake all `configs/` files (raft directory wordlists, WordPress plugin lists, SaaS/SSO fingerprints, static asset takeover fingerprints) into the compiled binary
- Removes all `/opt/method/...` container path references — CLI flags default to empty, embedded configs used automatically
- Removes config copy from Dockerfile since configs are now in the binary
- User can still override with custom file paths via CLI flags (`--plugins-file-paths`, `--fingerprint-file-paths`, etc.)

## What changed
- **`configs/embed.go`** — new `configs` package with `//go:embed discover enumerate pentest` directive
- **Fern definition** — `fingerprintFilePaths` made optional in static asset takeover config
- **CLI flags** — defaults changed from container paths to empty
- **Internal loading** — empty paths = embedded configs, user-provided paths = filesystem read
- **Dockerfile** — removed `COPY configs/` and `var/conf` mkdir

## Behavior
- **Compiled binary**: Embedded configs used by default — works everywhere without mounts
- **Custom paths**: When user provides file paths via CLI flags, reads from filesystem
- **Docker**: No config copy needed, binary has everything embedded

## Test plan
- [ ] Build binary and run directory discovery with `--wordlist-size SMALL --wordlist-type DIRECTORIES`
- [ ] Verify WordPress plugin enumeration works without Docker
- [ ] Verify SaaS discovery works without Docker mounts
- [ ] Verify static asset takeover works without Docker mounts
- [ ] Verify custom `--plugins-file-paths` still works
- [ ] Verify Docker build still works without configs copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how multiple scanners locate/load wordlists and fingerprint JSON, which can break default behavior in existing deployments and Docker images if paths/flags are assumed.
> 
> **Overview**
> Moves runtime configs (directory wordlists, CMS plugin/module lists, SaaS/SSO fingerprints, and static asset takeover fingerprints) to **Go-embedded assets** via new `configs` package (`//go:embed`) and updates loaders to read from embedded files when no paths are provided.
> 
> Updates CLI flags for `discover saas` and `pentest route static-asset-takeover` to default to empty file-path lists (and adjusts SaaS helper/route takeover loader accordingly), and switches directory discovery + WordPress/Drupal enumeration to load wordlists from embedded paths instead of `/opt/method/...` container paths.
> 
> Simplifies the Docker image by removing creation of `var/conf` and the `COPY configs/` step, since configs now ship inside the compiled binary; also makes `fingerprintFilePaths` optional in the Fern definition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 604f744894d82323a9045effb156da8eff75ad12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->