### PR TITLE
Fix Browser Download Log Location

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -63,7 +63,10 @@ func (b *Requester) InitializeBrowser(ctx context.Context) error {
 		binPath = resolved
 	}
 
-	launch := launcher.New().Headless(true).Bin(binPath)
+	launchCtx, launchCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer launchCancel()
+
+	launch := launcher.New().Headless(true).Bin(binPath).Context(launchCtx)
 	browserURL, err := launch.Launch()
 	if err != nil {
 		return fmt.Errorf("browser launch failed: %v", err)

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"context"
 	"fmt"
+	stdlog "log"
 	"os"
 	"strings"
 	"sync"
@@ -27,16 +28,14 @@ import (
 // InitializeBrowser starts a headless browser instance and establishes connection.
 // If a browser path is specified and exists, it uses that binary. Otherwise it
 // falls back to rod's auto-download, which fetches a compatible Chromium to ~/.cache/rod/browser/.
-// The launcher uses a separate 5-minute timeout so that a first-time Chromium download
-// isn't killed by the per-request timeout.
 func (b *Requester) InitializeBrowser(ctx context.Context) error {
 	log := svc1log.FromContext(ctx)
-	launch := launcher.New().Headless(true)
 
+	var binPath string
 	if b.PathToBrowser != nil && *b.PathToBrowser != "" {
 		if _, err := os.Stat(*b.PathToBrowser); err == nil {
 			log.Info("Using specified browser binary", svc1log.SafeParam("path", *b.PathToBrowser))
-			launch = launch.Bin(*b.PathToBrowser)
+			binPath = *b.PathToBrowser
 		} else {
 			log.Warn("Specified browser path not found, falling back to rod auto-download",
 				svc1log.SafeParam("path", *b.PathToBrowser))
@@ -45,12 +44,27 @@ func (b *Requester) InitializeBrowser(ctx context.Context) error {
 		log.Info("No browser path specified, rod will auto-detect or download Chromium")
 	}
 
-	// The launcher uses a separate 5-minute timeout so that a first-time Chromium download
-	// No configurable needed, 5 minutes is a reasonable default.
-	launchCtx, launchCancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer launchCancel()
+	// When no valid binary is available, resolve (and possibly download) one
+	// ourselves so that download progress goes to stderr instead of stdout.
+	// Uses a 5-minute timeout so a first-time Chromium download isn't killed
+	// by the per-request timeout carried in ctx.
+	if binPath == "" {
+		dlCtx, dlCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer dlCancel()
 
-	browserURL, err := launch.Context(launchCtx).Launch()
+		browser := launcher.NewBrowser()
+		browser.Logger = stdlog.New(os.Stderr, "[launcher.Browser]", stdlog.LstdFlags)
+		browser.Context = dlCtx
+
+		resolved, err := browser.Get()
+		if err != nil {
+			return fmt.Errorf("browser resolution failed: %v", err)
+		}
+		binPath = resolved
+	}
+
+	launch := launcher.New().Headless(true).Bin(binPath)
+	browserURL, err := launch.Launch()
 	if err != nil {
 		return fmt.Errorf("browser launch failed: %v", err)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the headless browser startup flow by manually resolving/downloading the Chromium binary and wiring a custom logger, which could affect startup reliability or timeout behavior in environments that rely on rod’s default launcher resolution.
> 
> **Overview**
> **Headless browser initialization now explicitly resolves the Chromium binary before launch.** When no valid `PathToBrowser` is provided, `InitializeBrowser` uses `launcher.NewBrowser().Get()` with a custom `log.Logger` writing to `stderr`, so download/progress output no longer goes to `stdout`.
> 
> Browser launch is updated to always use the resolved `binPath` (with the same 5-minute background timeout), returning clearer errors for resolution vs launch failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa4de796a6411529faad500a2b0c6ea0cb75de4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->