### PR TITLE
Update Timeout Limit

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -63,7 +63,7 @@ func (b *Requester) InitializeBrowser(ctx context.Context) error {
 		binPath = resolved
 	}
 
-	launchCtx, launchCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	launchCtx, launchCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer launchCancel()
 
 	launch := launcher.New().Headless(true).Bin(binPath).Context(launchCtx)
@@ -99,7 +99,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 	// Initialize browser if not already done
 	if b.Browser == nil {
 		if err := b.InitializeBrowser(ctx); err != nil {
-			return report, fmt.Errorf("browser initialization failed: %v", err)
+			return report, fmt.Errorf("browser initialization failed: %v", err) // Do not change, DD Metric is based on this error message
 		}
 
 		// Configure TLS verification


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small operational change that only affects browser startup timing and a comment; main risk is longer waits/resource usage if Chromium launch hangs.
> 
> **Overview**
> In `utils/request/headless/headless.go`, increases the headless browser launch timeout from **5 minutes to 10 minutes** to reduce failures during slow startups/downloads.
> 
> Adds an explicit comment on the `browser initialization failed: %v` error string to prevent changes that would break a Datadog metric keyed off that message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f5470b1fce764cf67de9b9db8247b1f3b9261e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->