### PR TITLE
No Sandbox Chrome Flag Fix

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -63,10 +63,10 @@ func (b *Requester) InitializeBrowser(ctx context.Context) error {
 		binPath = resolved
 	}
 
-	launchCtx, launchCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	launchCtx, launchCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer launchCancel()
 
-	launch := launcher.New().Headless(true).Bin(binPath).Context(launchCtx)
+	launch := launcher.New().Headless(true).Bin(binPath).NoSandbox(true).Context(launchCtx)
 	browserURL, err := launch.Launch()
 	if err != nil {
 		return fmt.Errorf("browser launch failed: %v", err)
@@ -99,7 +99,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 	// Initialize browser if not already done
 	if b.Browser == nil {
 		if err := b.InitializeBrowser(ctx); err != nil {
-			return report, fmt.Errorf("browser initialization failed: %v", err)
+			return report, fmt.Errorf("browser initialization failed: %v", err) // Do not change, DD Metric is based on this error message
 		}
 
 		// Configure TLS verification


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Disabling Chrome’s sandbox changes the security posture of the headless browser process and may have environment-specific side effects, though the code change is small and localized.
> 
> **Overview**
> For headless requests, Chromium is now launched with `NoSandbox(true)` (i.e., `--no-sandbox`) in `utils/request/headless/headless.go` to avoid sandbox-related launch failures in constrained/containerized environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18903158aadb5e948defea2d95da5f12f0396de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->