### PR TITLE
Headless Updates

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -383,7 +383,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Request Method Flags for all capture subcommands
 	discoverPageCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
 	discoverPageCmd.Flags().String("headless-path", "", "Path to headless browser executable")
-	discoverPageCmd.Flags().Int("min-dom-stabalize-time", 5, "Minimum time to wait for DOM stabilization in seconds")
+	discoverPageCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	discoverPageCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
 	discoverPageCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	discoverPageCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")
@@ -461,7 +461,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Request Method Flags
 	discoverProbeCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
 	discoverProbeCmd.Flags().String("headless-path", "", "Path to headless browser executable")
-	discoverProbeCmd.Flags().Int("min-dom-stabalize-time", 5, "Minimum time to wait for DOM stabilization in seconds")
+	discoverProbeCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	discoverProbeCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
 	discoverProbeCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	discoverProbeCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")
@@ -553,7 +553,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Request Method Flags
 	discoverRouteCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
 	discoverRouteCmd.Flags().String("headless-path", "", "Path to headless browser executable")
-	discoverRouteCmd.Flags().Int("min-dom-stabalize-time", 5, "Minimum time to wait for DOM stabilization in seconds")
+	discoverRouteCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	discoverRouteCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
 	discoverRouteCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	discoverRouteCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")
@@ -695,7 +695,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Request Method Flags for all capture subcommands
 	discoverSaasCmd.Flags().String("request-method", "HEADLESS", "Request method (headless, browserbase)")
 	discoverSaasCmd.Flags().String("headless-path", "", "Path to a headless browser executable")
-	discoverSaasCmd.Flags().Int("min-dom-stabalize-time", 5, "Minimum time in seconds to wait for DOM to stabilize")
+	discoverSaasCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time in seconds to wait for DOM to stabilize")
 	discoverSaasCmd.Flags().String("browserbase-token", "", "Browserbase API token")
 	discoverSaasCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	discoverSaasCmd.Flags().Bool("browserbase-proxy", false, "Instruct Browserbase to use a proxy")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -611,7 +611,7 @@ func (a *WebScan) InitPentestCommand() {
 	// Request Method Flags for all capture subcommands
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("headless-path", "", "Path to headless browser executable")
-	pentestRouteStaticAssetTakeoverCmd.Flags().Int("min-dom-stabalize-time", 5, "Minimum time to wait for DOM stabilization in seconds")
+	pentestRouteStaticAssetTakeoverCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -120,7 +120,7 @@ Flags:
       --headless-path string            Path to headless browser executable
   -h, --help                            help for page
       --max-redirects int               Maximum number of redirects to follow (default 10)
-      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 5)
+      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
       --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
       --response-codes string           Response codes to consider as valid responses (default "200-299")
       --screenshot                      Capture a screenshot of the page
@@ -160,7 +160,7 @@ Flags:
       --headless-path string            Path to headless browser executable
   -h, --help                            help for probe
       --max-redirects int               Maximum number of redirects to follow (default 10)
-      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 5)
+      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
       --protocol string                 Protocol to use for the probe (HTTP, HTTPS)
       --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
       --targets strings                 URL targets to probe for web applications
@@ -201,7 +201,7 @@ Flags:
   -h, --help                            help for route
       --ignore-base-url-match           Add route even if it does not share the target's base URL
       --max-redirects int               Maximum number of redirects to follow (default 100)
-      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 5)
+      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
       --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
       --spider-depth int                Maximum depth for route spidering (default 3)
       --target string                   URL target to discover routes from
@@ -241,7 +241,7 @@ Flags:
       --headless-path string            Path to a headless browser executable
   -h, --help                            help for saas
       --max-redirects int               Maximum number of redirects to follow (default 10)
-      --min-dom-stabalize-time int      Minimum time in seconds to wait for DOM to stabilize (default 5)
+      --min-dom-stabalize-time int      Minimum time in seconds to wait for DOM to stabilize (default 20)
       --orgs strings                    The organization names to use for discovery
       --request-method string           Request method (headless, browserbase) (default "HEADLESS")
       --saas-companies strings          The specific SaaS companies to use for discovery (Must be present in the SaaS fingerprints file)

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -203,7 +203,7 @@ Flags:
       --headless-path string              Path to headless browser executable
   -h, --help                              help for static-asset-takeover
       --max-redirects int                 Maximum number of redirects to follow (default 10)
-      --min-dom-stabalize-time int        Minimum time to wait for DOM stabilization in seconds (default 5)
+      --min-dom-stabalize-time int        Minimum time to wait for DOM stabilization in seconds (default 20)
       --request-method string             Request method to use (standard, headless, browserbase) (default "STANDARD")
       --successful-only                   Only show successful takeover attempts
       --target string                     URL target to analyze for static asset takeover

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -66,7 +66,7 @@ func (b *Requester) InitializeBrowser(ctx context.Context) error {
 	launchCtx, launchCancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer launchCancel()
 
-	launch := launcher.New().Headless(true).Bin(binPath).Context(launchCtx)
+	launch := launcher.New().Headless(true).Bin(binPath).NoSandbox(true).Context(launchCtx)
 	browserURL, err := launch.Launch()
 	if err != nil {
 		return fmt.Errorf("browser launch failed: %v", err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only the default value of the `--min-dom-stabalize-time` CLI flag, which may slow headless/browser-based scans but does not alter request logic or data handling.
> 
> **Overview**
> Increases the default `--min-dom-stabalize-time` from 5s to 20s across `discover` subcommands (`page`, `probe`, `route`, `saas`) and `pentest route static-asset-takeover` to allow more time for headless DOM stabilization.
> 
> Updates the corresponding CLI documentation (`discover.md`, `pentest.md`) to reflect the new default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ea5bb37431d4fdde91e9e656a0ba61e2ec5fef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->