### PR TITLE
Fix Integrated Wordlist for Sensitive Content

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -374,7 +374,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverPageCmd.Flags().String("target", "", "URL target to capture and analyze")
 	// Config Flags
 	discoverPageCmd.Flags().Bool("sensitive-content-detection", false, "Enable sensitive content detection")
-	discoverPageCmd.Flags().String("sensitive-content-fingerprints-path", "configs/discover/page/sensitive_content_fingerprints.json", "Path to the sensitive content fingerprints file")
+	discoverPageCmd.Flags().String("sensitive-content-fingerprints-path", "", "Path to a custom sensitive content fingerprints file (uses built-in fingerprints by default)")
 	discoverPageCmd.Flags().String("response-codes", "200-299", "Response codes to consider as valid responses")
 	discoverPageCmd.Flags().Bool("screenshot", false, "Capture a screenshot of the page")
 	discoverPageCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")

--- a/internal/discover/page/helpers/sensitivecontent.go
+++ b/internal/discover/page/helpers/sensitivecontent.go
@@ -6,18 +6,29 @@ import (
 	"os"
 	"regexp"
 
+	// Internal
+	"github.com/Method-Security/webscan/configs"
+
 	// Generated
 	"github.com/Method-Security/webscan/generated/go/discover"
-	//External
+	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// LoadSensitiveConentFingerprints loads fingerprints from the JSON configuration file
+const embeddedFingerprintsPath = "discover/page/sensitive_content_fingerprints.json"
+
+// LoadSensitiveConentFingerprints loads fingerprints from a custom file path or
+// falls back to the embedded default fingerprints baked into the binary.
 func LoadSensitiveConentFingerprints(ctx context.Context, configPath *string) (*discover.SensitiveContentFingerprints, error) {
 	log := svc1log.FromContext(ctx)
 
-	// Read the JSON file
-	data, err := os.ReadFile(*configPath)
+	var data []byte
+	var err error
+	if configPath != nil && *configPath != "" {
+		data, err = os.ReadFile(*configPath)
+	} else {
+		data, err = configs.ReadFile(embeddedFingerprintsPath)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes how the sensitive-content fingerprints file is sourced, falling back to an embedded default when no path is provided.
> 
> **Overview**
> `discover page` no longer hardcodes a default `--sensitive-content-fingerprints-path`; the flag is now optional and described as *custom-only*.
> 
> Sensitive content detection now loads fingerprints from the provided file path when set, otherwise reads the built-in embedded `discover/page/sensitive_content_fingerprints.json` via `configs.ReadFile`, ensuring sensitive-content detection works out of the box.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8912624f2178228d084f84a4c0c7164f92827f0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->