### PR TITLE
Add 'No Cross Domain Redirect' Flag

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -38,6 +38,9 @@ func (a *WebScan) InitDiscoverCommand() {
 		Long:  `Perform various discovery scans to identify web applications, directories, routes, and static assets.`,
 	}
 
+	// General Discover Flags
+	discoverCmd.PersistentFlags().Bool("ignore-cross-domain-redirects", false, "If true, do not follow redirects to a different domain and treat them as errors")
+
 	// Application Command
 	discoverApplicationCmd := &cobra.Command{
 		Use:   "application",
@@ -112,7 +115,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	discoverApplicationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	discoverApplicationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
+	discoverApplicationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 means no limit)")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")
@@ -236,8 +239,13 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			// Set config
-			config := getDiscoverDirectoryConfig(targets, paths, wordlistType, wordlistSize, httpMethods, responseCodes, ignoreBaseContentMatch, verifyTLS, threshold, timeout, maxRedirectsBaselineRequest, threads, maxRuntime, retries, sleep)
+			config := getDiscoverDirectoryConfig(targets, paths, wordlistType, wordlistSize, httpMethods, responseCodes, ignoreBaseContentMatch, verifyTLS, threshold, timeout, ignoreCrossDomainRedirects, maxRedirectsBaselineRequest, threads, maxRuntime, retries, sleep)
 
 			// Generate a report
 			rep, err := discoverdirectory.RunDirectoryDiscovery(cmd.Context(), config)
@@ -326,6 +334,12 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Get Request Method flag
 			requestMethodConfig, err := requesthelpers.GetRequestMethodFlags(cmd)
 			if err != nil {
@@ -346,7 +360,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverPageConfig(target, sensitiveContentDetection, sensitiveContentFingerprintsPath, responseCodes, maxRedirects, verifyTLS, timeout, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverPageConfig(target, sensitiveContentDetection, sensitiveContentFingerprintsPath, responseCodes, maxRedirects, verifyTLS, timeout, ignoreCrossDomainRedirects, takeScreenshot, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Load sensitive content fingerprints if sensitive content detection is enabled and no fingerprints are found, return an error
 			var sensitiveContentFingerprints *discover.SensitiveContentFingerprints
@@ -432,6 +446,12 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Get Request Method flags
 			requestMethodConfig, err := requesthelpers.GetRequestMethodFlags(cmd)
 			if err != nil {
@@ -440,7 +460,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverProbeConfig(targets, protocol, maxRedirects, verifyTLS, timeout, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverProbeConfig(targets, protocol, maxRedirects, verifyTLS, timeout, ignoreCrossDomainRedirects, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate report
 			report, err := discoverprobe.PerformWebProbe(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -525,6 +545,12 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Get Request Method flags
 			requestMethodConfig, err := requesthelpers.GetRequestMethodFlags(cmd)
 			if err != nil {
@@ -533,7 +559,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, ignoreBaseURLMatch, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, ignoreBaseURLMatch, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, ignoreCrossDomainRedirects, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -730,18 +756,19 @@ func getDiscoverApplicationConfig(targets []string, resource string, timeout int
 }
 
 // getDiscoverPageConfig builds the config for page capture and analysis.
-func getDiscoverPageConfig(target string, sensitiveContentDetection bool, sensitiveContentFingerprintsPath string, responseCodes string, maxRedirects int, verifyTLS bool, timeout int, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
+func getDiscoverPageConfig(target string, sensitiveContentDetection bool, sensitiveContentFingerprintsPath string, responseCodes string, maxRedirects int, verifyTLS bool, timeout int, ignoreCrossDomainRedirects bool, takeScreenshot bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverPageConfig {
 	config := discover.DiscoverPageConfig{
-		Target:                    target,
-		ResponseCodes:             responseCodes,
-		SensitiveContentDetection: sensitiveContentDetection,
-		MaxRedirects:              maxRedirects,
-		VerifyTls:                 verifyTLS,
-		Timeout:                   max(timeout, 0),
-		Screenshot:                takeScreenshot,
-		RequestMethod:             requestMethod,
-		HeadlessConfig:            headlessConfig,
-		BrowserbaseConfig:         browserbaseConfig,
+		Target:                     target,
+		ResponseCodes:              responseCodes,
+		SensitiveContentDetection:  sensitiveContentDetection,
+		MaxRedirects:               maxRedirects,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Screenshot:                 takeScreenshot,
+		RequestMethod:              requestMethod,
+		HeadlessConfig:             headlessConfig,
+		BrowserbaseConfig:          browserbaseConfig,
 	}
 	if sensitiveContentFingerprintsPath != "" {
 		config.SensitiveContentFingerprintsPath = &sensitiveContentFingerprintsPath
@@ -750,15 +777,16 @@ func getDiscoverPageConfig(target string, sensitiveContentDetection bool, sensit
 }
 
 // getDiscoverProbeConfig builds the config for probe discovery.
-func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int, verifyTLS bool, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
+func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int, verifyTLS bool, timeout int, ignoreCrossDomainRedirects bool, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
-		Targets:           targets,
-		MaxRedirects:      maxRedirects,
-		VerifyTls:         verifyTLS,
-		Timeout:           max(timeout, 0),
-		RequestMethod:     requestMethod,
-		HeadlessConfig:    headlessConfig,
-		BrowserbaseConfig: browserbaseConfig,
+		Targets:                    targets,
+		MaxRedirects:               maxRedirects,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		RequestMethod:              requestMethod,
+		HeadlessConfig:             headlessConfig,
+		BrowserbaseConfig:          browserbaseConfig,
 	}
 
 	// Set protocol if provided, otherwise leave unset for backward compatibility
@@ -780,19 +808,20 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, ignoreBaseURLMatch bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, ignoreBaseURLMatch bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, ignoreCrossDomainRedirects bool, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
-		Target:              target,
-		CollectStaticAssets: collectStaticAssets,
-		IgnoreBaseUrlMatch:  ignoreBaseURLMatch,
-		SpiderDepth:         spiderDepth,
-		MaxRedirects:        maxRedirects,
-		VerifyTls:           verifyTLS,
-		Timeout:             max(timeout, 0),
-		Threads:             max(threads, 0),
-		RequestMethod:       requestMethod,
-		HeadlessConfig:      headlessConfig,
-		BrowserbaseConfig:   browserbaseConfig,
+		Target:                     target,
+		CollectStaticAssets:        collectStaticAssets,
+		IgnoreBaseUrlMatch:         ignoreBaseURLMatch,
+		SpiderDepth:                spiderDepth,
+		MaxRedirects:               maxRedirects,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Threads:                    max(threads, 0),
+		RequestMethod:              requestMethod,
+		HeadlessConfig:             headlessConfig,
+		BrowserbaseConfig:          browserbaseConfig,
 	}
 	return config
 }
@@ -815,7 +844,7 @@ func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies [
 }
 
 // getDiscoverDirectoryConfig builds the config for directory discovery.
-func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType string, wordlistSize string, httpMethods []common.HttpMethod, responseCodes string, ignoreBaseContentMatch bool, verifyTLS bool, threshold float64, timeout int, maxRedirectsBaselineRequest int, threads int, maxRuntime int, retries int, sleep int) discover.DiscoverDirectoryConfig {
+func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType string, wordlistSize string, httpMethods []common.HttpMethod, responseCodes string, ignoreBaseContentMatch bool, verifyTLS bool, threshold float64, timeout int, ignoreCrossDomainRedirects bool, maxRedirectsBaselineRequest int, threads int, maxRuntime int, retries int, sleep int) discover.DiscoverDirectoryConfig {
 	config := discover.DiscoverDirectoryConfig{
 		Targets:                     targets,
 		Paths:                       paths,
@@ -825,6 +854,7 @@ func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType s
 		VerifyTls:                   verifyTLS,
 		Threshold:                   threshold,
 		Timeout:                     timeout,
+		IgnoreCrossDomainRedirects:  ignoreCrossDomainRedirects,
 		MaxRedirectsBaselineRequest: maxRedirectsBaselineRequest,
 		Threads:                     threads,
 		MaxRuntime:                  maxRuntime,

--- a/fern/definition/common/config.yml
+++ b/fern/definition/common/config.yml
@@ -9,6 +9,7 @@ types:
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer
+      ignoreCrossDomainRedirects: boolean
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>

--- a/fern/definition/discover/directory.yml
+++ b/fern/definition/discover/directory.yml
@@ -25,6 +25,7 @@ types:
       verifyTls: boolean
       threshold: float
       timeout: integer
+      ignoreCrossDomainRedirects: boolean
       maxRedirectsBaselineRequest: integer
       maxRuntime: integer
       retries: integer

--- a/fern/definition/discover/page.yml
+++ b/fern/definition/discover/page.yml
@@ -37,6 +37,7 @@ types:
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer
+      ignoreCrossDomainRedirects: boolean
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -10,6 +10,7 @@ types:
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer
+      ignoreCrossDomainRedirects: boolean
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -12,6 +12,7 @@ types:
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer
+      ignoreCrossDomainRedirects: boolean
       threads: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -35,14 +35,15 @@ func createDirectorySendHTTPRequestConfig(baseURL, path string, method common.Ht
 		Params:  &requestParams,
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       MaxRedirects,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -28,14 +28,15 @@ func getHTTPRequestConfig(baseURL string, path string, queryParams map[string]st
 		},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       config.MaxRedirects,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		RequestMethod:      config.RequestMethod,
-		HeadlessConfig:     config.HeadlessConfig,
-		BrowserbaseConfig:  config.BrowserbaseConfig,
-		BrowserbaseSecrets: browserbaseSecrets,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		RequestMethod:              config.RequestMethod,
+		HeadlessConfig:             config.HeadlessConfig,
+		BrowserbaseConfig:          config.BrowserbaseConfig,
+		BrowserbaseSecrets:         browserbaseSecrets,
 	}
 }
 

--- a/internal/discover/probe.go
+++ b/internal/discover/probe.go
@@ -24,14 +24,15 @@ func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]st
 		},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       config.MaxRedirects,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		RequestMethod:      config.RequestMethod,
-		HeadlessConfig:     config.HeadlessConfig,
-		BrowserbaseConfig:  config.BrowserbaseConfig,
-		BrowserbaseSecrets: browserbaseSecrets,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		RequestMethod:              config.RequestMethod,
+		HeadlessConfig:             config.HeadlessConfig,
+		BrowserbaseConfig:          config.BrowserbaseConfig,
+		BrowserbaseSecrets:         browserbaseSecrets,
 	}
 }
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -128,14 +128,15 @@ func createSendHTTPRequestConfigWithQuery(baseURL, path string, queryParams map[
 		},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       config.MaxRedirects,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		RequestMethod:      config.RequestMethod,
-		HeadlessConfig:     config.HeadlessConfig,
-		BrowserbaseConfig:  config.BrowserbaseConfig,
-		BrowserbaseSecrets: browserbaseSecrets,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		RequestMethod:              config.RequestMethod,
+		HeadlessConfig:             config.HeadlessConfig,
+		BrowserbaseConfig:          config.BrowserbaseConfig,
+		BrowserbaseSecrets:         browserbaseSecrets,
 	}
 }
 

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -154,7 +154,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 
 		// Setup request monitoring and navigate
 		headerCapture := setupHeaderInterception(page)
-		handleNavigation(ctx, page, &redirectChain, requestComplete, &once, config.MaxRedirects, browsersErr)
+		handleNavigation(ctx, page, &redirectChain, requestComplete, &once, config.MaxRedirects, config.IgnoreCrossDomainRedirects, browsersErr)
 
 		navErr := performNavigation(ctx, page, constructedURL, config)
 		if navErr != nil {

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -154,7 +154,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 
 		// Setup request monitoring and navigate
 		headerCapture := setupHeaderInterception(page)
-		handleNavigation(ctx, page, &redirectChain, requestComplete, &once, config.MaxRedirects, config.IgnoreCrossDomainRedirects, browsersErr)
+		handleNavigation(ctx, page, &redirectChain, requestComplete, &once, config.MaxRedirects, browsersErr)
 
 		navErr := performNavigation(ctx, page, constructedURL, config)
 		if navErr != nil {
@@ -321,6 +321,17 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 	if browserErr != nil {
 		log.Error("Navigation failed", svc1log.SafeParam("url", *constructedURL), svc1log.SafeParam("error", browserErr.Error()))
 		finalErr = fmt.Errorf("headless capture failed: %s", cleanErrMsg(browserErr))
+	}
+
+	// Check for cross-domain redirect after navigation completes
+	if finalErr == nil && config.IgnoreCrossDomainRedirects && len(redirectChain) > 1 {
+		originalURL := redirectChain[0]
+		for _, chainURL := range redirectChain[1:] {
+			if isCrossDomainRedirect(originalURL, chainURL) {
+				log.Info("Cross-domain redirect detected in redirect chain", svc1log.SafeParam("from", originalURL), svc1log.SafeParam("to", chainURL))
+				return common.HttpRequestResponse{Request: config.Request}, fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, chainURL)
+			}
+		}
 	}
 
 	return report, finalErr

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -84,7 +85,7 @@ func setupHeaderInterception(page *rod.Page) *NetworkHeaderCapture {
 }
 
 // handleNavigation sets up tracking for top-level frame navigations
-func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]string, requestComplete chan struct{}, once *sync.Once, maxRedirects int, redirectError chan error) {
+func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]string, requestComplete chan struct{}, once *sync.Once, maxRedirects int, ignoreCrossDomainRedirects bool, redirectError chan error) {
 	log := svc1log.FromContext(ctx)
 
 	// Use a simple completion flag to prevent further event processing
@@ -94,6 +95,48 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 	enableNetworkErr := proto.NetworkEnable{}.Call(page)
 	if enableNetworkErr != nil {
 		log.Warn("Failed to enable network tracking for redirects", svc1log.SafeParam("error", enableNetworkErr))
+	}
+
+	// Enable Fetch domain interception to block cross-domain redirects before the browser follows them
+	if ignoreCrossDomainRedirects {
+		err := proto.FetchEnable{
+			Patterns: []*proto.FetchRequestPattern{
+				{
+					ResourceType: proto.NetworkResourceTypeDocument,
+				},
+			},
+		}.Call(page)
+		if err != nil {
+			log.Warn("Failed to enable Fetch interception for cross-domain redirect blocking", svc1log.SafeParam("error", err))
+		} else {
+			go page.EachEvent(func(e *proto.FetchRequestPaused) {
+				if atomic.LoadInt32(&completed) == 1 {
+					// Already completed, just continue the request to avoid hanging
+					_ = proto.FetchContinueRequest{RequestID: e.RequestID}.Call(page)
+					return
+				}
+
+				requestURL := e.Request.URL
+				if len(*redirectChain) > 0 {
+					originalURL := (*redirectChain)[0]
+					if isCrossDomainRedirect(originalURL, requestURL) {
+						log.Info("Fetch: blocking cross-domain request", svc1log.SafeParam("original", originalURL), svc1log.SafeParam("blocked", requestURL))
+						_ = proto.FetchFailRequest{
+							RequestID:   e.RequestID,
+							ErrorReason: proto.NetworkErrorReasonAborted,
+						}.Call(page)
+						once.Do(func() {
+							atomic.StoreInt32(&completed, 1)
+							redirectError <- fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, requestURL) // Dont change this comment used for DD metric
+							close(requestComplete)
+						})
+						return
+					}
+				}
+				// Allow same-domain requests to proceed
+				_ = proto.FetchContinueRequest{RequestID: e.RequestID}.Call(page)
+			})()
+		}
 	}
 
 	// Set up event listeners for navigation events and network redirects
@@ -112,6 +155,20 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 				if location, exists := e.Response.Headers["location"]; exists && location.Str() != "" {
 					locationURL := location.Str()
 					log.Debug("Captured HTTP redirect", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL), svc1log.SafeParam("status", e.Response.Status))
+
+					// Check for cross-domain redirect at the network level
+					if ignoreCrossDomainRedirects && len(*redirectChain) > 0 {
+						originalURL := (*redirectChain)[0]
+						if isCrossDomainRedirect(originalURL, locationURL) {
+							log.Info("Blocking cross-domain redirect at network level", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL))
+							once.Do(func() {
+								atomic.StoreInt32(&completed, 1)
+								redirectError <- fmt.Errorf("cross-domain redirect blocked: %s -> %s", e.Response.URL, locationURL) // Dont change this comment used for DD metric
+								close(requestComplete)
+							})
+							return
+						}
+					}
 
 					// Add the redirect destination to the chain if not already present
 					exists := false
@@ -146,6 +203,20 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 						close(requestComplete)
 					})
 					return
+				}
+
+				// Check for cross-domain redirect
+				if ignoreCrossDomainRedirects && len(*redirectChain) > 0 {
+					originalURL := (*redirectChain)[0]
+					if isCrossDomainRedirect(originalURL, e.Frame.URL) {
+						log.Info("Blocking cross-domain redirect", svc1log.SafeParam("from", originalURL), svc1log.SafeParam("to", e.Frame.URL))
+						once.Do(func() {
+							atomic.StoreInt32(&completed, 1)
+							redirectError <- fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, e.Frame.URL) // Dont change this comment used for DD metric
+							close(requestComplete)
+						})
+						return
+					}
 				}
 
 				// Check if URL is already in chain
@@ -416,6 +487,19 @@ func getStatusCodeFromPage(page *rod.Page) int {
 
 	// Default to 0 if we can't determine status
 	return 0
+}
+
+// isCrossDomainRedirect checks if a redirect URL points to a different domain than the original URL
+func isCrossDomainRedirect(originalURL, redirectURL string) bool {
+	parsedOriginal, err := url.Parse(originalURL)
+	if err != nil {
+		return false
+	}
+	parsedRedirect, err := url.Parse(redirectURL)
+	if err != nil {
+		return false
+	}
+	return parsedOriginal.Host != parsedRedirect.Host
 }
 
 // cleanErrMsg extracts meaningful error message from navigation errors

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -85,7 +85,7 @@ func setupHeaderInterception(page *rod.Page) *NetworkHeaderCapture {
 }
 
 // handleNavigation sets up tracking for top-level frame navigations
-func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]string, requestComplete chan struct{}, once *sync.Once, maxRedirects int, ignoreCrossDomainRedirects bool, redirectError chan error) {
+func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]string, requestComplete chan struct{}, once *sync.Once, maxRedirects int, redirectError chan error) {
 	log := svc1log.FromContext(ctx)
 
 	// Use a simple completion flag to prevent further event processing
@@ -114,21 +114,7 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 					locationURL := location.Str()
 					log.Debug("Captured HTTP redirect", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL), svc1log.SafeParam("status", e.Response.Status))
 
-					// Check for cross-domain redirect at the network level
-					if ignoreCrossDomainRedirects && len(*redirectChain) > 0 {
-						originalURL := (*redirectChain)[0]
-						if isCrossDomainRedirect(originalURL, locationURL) {
-							log.Info("Blocking cross-domain redirect at network level", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL))
-							once.Do(func() {
-								atomic.StoreInt32(&completed, 1)
-								redirectError <- fmt.Errorf("cross-domain redirect blocked: %s -> %s", e.Response.URL, locationURL) // Dont change this comment used for DD metric
-								close(requestComplete)
-							})
-							return
-						}
-					}
-
-					// Add the redirect destination to the chain if not already present
+						// Add the redirect destination to the chain if not already present
 					exists := false
 					for _, url := range *redirectChain {
 						if url == locationURL {

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -97,48 +97,6 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 		log.Warn("Failed to enable network tracking for redirects", svc1log.SafeParam("error", enableNetworkErr))
 	}
 
-	// Enable Fetch domain interception to block cross-domain redirects before the browser follows them
-	if ignoreCrossDomainRedirects {
-		err := proto.FetchEnable{
-			Patterns: []*proto.FetchRequestPattern{
-				{
-					ResourceType: proto.NetworkResourceTypeDocument,
-				},
-			},
-		}.Call(page)
-		if err != nil {
-			log.Warn("Failed to enable Fetch interception for cross-domain redirect blocking", svc1log.SafeParam("error", err))
-		} else {
-			go page.EachEvent(func(e *proto.FetchRequestPaused) {
-				if atomic.LoadInt32(&completed) == 1 {
-					// Already completed, just continue the request to avoid hanging
-					_ = proto.FetchContinueRequest{RequestID: e.RequestID}.Call(page)
-					return
-				}
-
-				requestURL := e.Request.URL
-				if len(*redirectChain) > 0 {
-					originalURL := (*redirectChain)[0]
-					if isCrossDomainRedirect(originalURL, requestURL) {
-						log.Info("Fetch: blocking cross-domain request", svc1log.SafeParam("original", originalURL), svc1log.SafeParam("blocked", requestURL))
-						_ = proto.FetchFailRequest{
-							RequestID:   e.RequestID,
-							ErrorReason: proto.NetworkErrorReasonAborted,
-						}.Call(page)
-						once.Do(func() {
-							atomic.StoreInt32(&completed, 1)
-							redirectError <- fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, requestURL) // Dont change this comment used for DD metric
-							close(requestComplete)
-						})
-						return
-					}
-				}
-				// Allow same-domain requests to proceed
-				_ = proto.FetchContinueRequest{RequestID: e.RequestID}.Call(page)
-			})()
-		}
-	}
-
 	// Set up event listeners for navigation events and network redirects
 	go page.EachEvent(
 		// Capture HTTP redirect responses at the network level
@@ -203,20 +161,6 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 						close(requestComplete)
 					})
 					return
-				}
-
-				// Check for cross-domain redirect
-				if ignoreCrossDomainRedirects && len(*redirectChain) > 0 {
-					originalURL := (*redirectChain)[0]
-					if isCrossDomainRedirect(originalURL, e.Frame.URL) {
-						log.Info("Blocking cross-domain redirect", svc1log.SafeParam("from", originalURL), svc1log.SafeParam("to", e.Frame.URL))
-						once.Do(func() {
-							atomic.StoreInt32(&completed, 1)
-							redirectError <- fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, e.Frame.URL) // Dont change this comment used for DD metric
-							close(requestComplete)
-						})
-						return
-					}
 				}
 
 				// Check if URL is already in chain
@@ -489,17 +433,19 @@ func getStatusCodeFromPage(page *rod.Page) int {
 	return 0
 }
 
-// isCrossDomainRedirect checks if a redirect URL points to a different domain than the original URL
+// isCrossDomainRedirect checks if a redirect URL points to a different domain than the original URL.
+// Relative redirect URLs (e.g. "/login") are resolved against the original URL first so that
+// same-domain relative redirects are not incorrectly flagged as cross-domain.
 func isCrossDomainRedirect(originalURL, redirectURL string) bool {
 	parsedOriginal, err := url.Parse(originalURL)
 	if err != nil {
 		return false
 	}
-	parsedRedirect, err := url.Parse(redirectURL)
+	resolved, err := parsedOriginal.Parse(redirectURL)
 	if err != nil {
 		return false
 	}
-	return parsedOriginal.Host != parsedRedirect.Host
+	return parsedOriginal.Host != resolved.Host
 }
 
 // cleanErrMsg extracts meaningful error message from navigation errors

--- a/utils/request/standard/helpers/send.go
+++ b/utils/request/standard/helpers/send.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"time"
 
 	// Generated
@@ -90,6 +91,19 @@ func SendHTTPRequest(ctx context.Context, url string, headers map[string]string,
 		if err != nil {
 			log.Error("Failed to parse redirect location", svc1log.SafeParam("error", err))
 			return nil, redirectChain, fmt.Errorf("failed to parse redirect location: %v", err)
+		}
+
+		// Check if redirect is cross-domain and should be blocked
+		if config.IgnoreCrossDomainRedirects {
+			originalURL, parseErr := neturl.Parse(url)
+			if parseErr == nil && originalURL.Host != nextURL.Host {
+				log.Info("Blocking cross-domain redirect", svc1log.SafeParam("from", currentURL), svc1log.SafeParam("to", nextURL.String()))
+				err = resp.Body.Close()
+				if err != nil {
+					log.Error("Failed to close response body", svc1log.SafeParam("error", err))
+				}
+				return nil, redirectChain, fmt.Errorf("cross-domain redirect blocked: %s -> %s", currentURL, nextURL.String()) // Dont change this comment used for DD metric
+			}
 		}
 
 		// Check if this is just a trailing slash redirect (should not count as a redirect)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes redirect-following behavior across multiple discovery commands and both standard/headless requesters, which could alter scan results and introduce new error paths on redirect-heavy targets.
> 
> **Overview**
> Adds a new `--ignore-cross-domain-redirects` persistent flag to `discover` that, when enabled, **blocks redirects to a different domain** and treats them as request errors.
> 
> Plumbs `ignoreCrossDomainRedirects` through the Fern-defined configs (`SendHTTPRequestConfig`, and discover `directory`/`page`/`probe`/`route` configs) and into request execution, adding cross-domain redirect detection to both `utils/request/standard` and `utils/request/headless` (including relative-URL resolution for headless redirect chains).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8928b0dd1a90d0021fb2dc5e1bf1d0b6acac93a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->