### PR TITLE
Add flag to Static Asset Signal

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -821,17 +821,18 @@ func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, succes
 func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, detect404Responses bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
-		Target:              target,
-		CollectStaticAssets: true,
-		IgnoreBaseUrlMatch:  true,
-		SpiderDepth:         1,
-		VerifyTls:           verifyTLS,
-		Timeout:             max(timeout, 0),
-		Threads:             max(threads, 0),
-		RequestMethod:       requestMethod,
-		MaxRedirects:        maxRedirects,
-		HeadlessConfig:      headlessConfig,
-		BrowserbaseConfig:   browserBaseConfig,
+		Target:                     target,
+		CollectStaticAssets:        true,
+		IgnoreBaseUrlMatch:         true,
+		SpiderDepth:                1,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		Threads:                    max(threads, 0),
+		RequestMethod:              requestMethod,
+		MaxRedirects:               maxRedirects,
+		HeadlessConfig:             headlessConfig,
+		BrowserbaseConfig:          browserBaseConfig,
+		IgnoreCrossDomainRedirects: false,
 	}
 	// Create Static Asset Takeover Config with nested route capture config
 	config := pentestroutefern.PentestRouteStaticAssetTakeoverConfig{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change that only affects how the static-asset-takeover scan follows redirects during route capture.
> 
> **Overview**
> The `pentest route static-asset-takeover` config now explicitly sets `IgnoreCrossDomainRedirects: false` in the underlying `discover.DiscoverRouteConfig`, making cross-domain redirect behavior an explicit part of the scan configuration rather than relying on defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ba52fdd1e7551e49ac07424b448c44aaaff843a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->