### PR TITLE
Only enable headless Chrome for DAST mode

### DIFF
--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -154,29 +154,6 @@ func buildNucleiOptions(cfg Config, templateDir, workflowDir string) []nucleilib
 		nucleilib.WithTemplatesOrWorkflows(templateSources),
 		nucleilib.EnableSelfContainedTemplates(),
 		nucleilib.DisableUpdateCheck(),
-		nucleilib.EnableHeadlessWithOpts(
-			&nucleilib.HeadlessOpts{
-				PageTimeout: cfg.Timeout, // Use config timeout instead of fixed 30s
-				ShowBrowser: false,
-				UseChrome:   true,
-				HeadlessOptions: func() []string {
-					baseOptions := []string{
-						"--no-sandbox",            // needed when running as root or in many Docker images
-						"--disable-dev-shm-usage", // avoids /dev/shm size limits in containers
-						"--disable-gpu",           // GPU isn't available in headless Linux anyway
-						"--mute-audio",
-						"--disable-background-timer-throttling",
-						"--disable-web-security",                         // helps bypass some WAF restrictions
-						"--disable-features=VizDisplayCompositor",        // prevent hanging
-						"--timeout=" + fmt.Sprintf("%d000", cfg.Timeout), // JavaScript timeout in milliseconds
-					}
-					if cfg.Proxy != "" {
-						baseOptions = append(baseOptions, "--proxy-server="+cfg.Proxy)
-					}
-					return baseOptions
-				}(),
-			},
-		),
 		nucleilib.WithNetworkConfig(nucleilib.NetworkConfig{
 			Timeout: cfg.Timeout,
 		}),
@@ -205,6 +182,33 @@ func buildNucleiOptions(cfg Config, templateDir, workflowDir string) []nucleilib
 			e.Options().Timeout = cfg.Timeout
 			return nil
 		},
+	}
+
+	// Enable headless browser only for DAST mode (e.g. XSS workflows)
+	if cfg.RunMode == nuclei.NucleiRunModeDast {
+		opts = append(opts, nucleilib.EnableHeadlessWithOpts(
+			&nucleilib.HeadlessOpts{
+				PageTimeout: cfg.Timeout,
+				ShowBrowser: false,
+				UseChrome:   true,
+				HeadlessOptions: func() []string {
+					baseOptions := []string{
+						"--no-sandbox",
+						"--disable-dev-shm-usage",
+						"--disable-gpu",
+						"--mute-audio",
+						"--disable-background-timer-throttling",
+						"--disable-web-security",
+						"--disable-features=VizDisplayCompositor",
+						"--timeout=" + fmt.Sprintf("%d000", cfg.Timeout),
+					}
+					if cfg.Proxy != "" {
+						baseOptions = append(baseOptions, "--proxy-server="+cfg.Proxy)
+					}
+					return baseOptions
+				}(),
+			},
+		))
 	}
 
 	// Add custom catalog if we have workflows


### PR DESCRIPTION
## Summary
- Nuclei's `EnableHeadlessWithOpts` was called unconditionally, requiring Chrome on every machine — even for scan-mode commands (discover, enumerate, pentest scan) that only use HTTP templates
- Moves headless browser initialization behind a `RunMode == DAST` check so scan-mode commands work without Chrome installed
- DAST mode (XSS workflows etc.) still gets full headless Chrome support

## Test plan
- [ ] Run `discover application` on a machine without Chrome — should complete successfully
- [ ] Run a DAST pentest on a machine with Chrome — should still use headless browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scopes headless browser initialization to `RunMode == DAST`, reducing runtime dependencies for scan-mode runs while leaving DAST behavior unchanged.
> 
> **Overview**
> Prevents non-DAST Nuclei runs from requiring Chrome by **only enabling `EnableHeadlessWithOpts` when `cfg.RunMode == NucleiRunModeDast`**.
> 
> DAST mode still configures the same headless Chrome options (timeouts/proxy flags), but scan-mode commands now run without headless initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66fa6e68546f283bd88d4ec3a6557099e66ab052. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->