### PR TITLE
Add Log Line to Page + Directory Cmds

### DIFF
--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -281,7 +281,7 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 	}
 	if !validCodes[*request.Response.StatusCode] {
 		errMsg := fmt.Sprintf("%s%s returned status code %d which is not in the allowed response codes", request.Request.BaseUrl, request.Request.Path, *request.Response.StatusCode)
-		log.Error(errMsg,
+		log.Info(errMsg,
 			svc1log.SafeParam("url", request.Request.BaseUrl),
 			svc1log.SafeParam("path", request.Request.Path),
 			svc1log.SafeParam("status_code", *request.Response.StatusCode))

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -224,11 +224,15 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 						}
 
 						// Analyze response
-						isValid := AnalyzeResponse(ctx, *httpRequest, validCodes, config.IgnoreBaseContentMatch, baselineSizeInt, baselineWordsInt, baselineSizeRandomPath, baselineWordsRandomPath, config.Threshold)
+						isValid, errMsg := AnalyzeResponse(ctx, *httpRequest, validCodes, config.IgnoreBaseContentMatch, baselineSizeInt, baselineWordsInt, baselineSizeRandomPath, baselineWordsRandomPath, config.Threshold)
 
 						if isValid {
 							attemptsMutex.Lock()
 							attempts = append(attempts, httpRequest)
+							attemptsMutex.Unlock()
+						} else if errMsg != "" {
+							attemptsMutex.Lock()
+							errors = append(errors, errMsg)
 							attemptsMutex.Unlock()
 						}
 
@@ -270,19 +274,27 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 }
 
 // AnalyzeResponse checks if the response signifies that directory/file was found based on the response code and the baseline size and word count
-func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, validCodes map[int]bool, checkBaseContentMatch bool, baselineSize, baselineWords int, baselineSizeRandomPath *int, baselineWordsRandomPath *int, threshold float64) bool {
+func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, validCodes map[int]bool, checkBaseContentMatch bool, baselineSize, baselineWords int, baselineSizeRandomPath *int, baselineWordsRandomPath *int, threshold float64) (bool, string) {
 	log := svc1log.FromContext(ctx)
-	if request.Response == nil || request.Response.StatusCode == nil || !validCodes[*request.Response.StatusCode] {
-		return false
+	if request.Response == nil || request.Response.StatusCode == nil {
+		return false, ""
+	}
+	if !validCodes[*request.Response.StatusCode] {
+		errMsg := fmt.Sprintf("%s%s returned status code %d which is not in the allowed response codes", request.Request.BaseUrl, request.Request.Path, *request.Response.StatusCode)
+		log.Error(errMsg,
+			svc1log.SafeParam("url", request.Request.BaseUrl),
+			svc1log.SafeParam("path", request.Request.Path),
+			svc1log.SafeParam("status_code", *request.Response.StatusCode))
+		return false, errMsg
 	}
 
 	bodyStr := requesthelpers.GetResponseBodyStringFromBodyStruct(request.Response.ResponseBody)
 	if bodyStr == nil {
-		return false
+		return false, ""
 	}
 	bodySize := len(*bodyStr)
 	if bodySize == 0 {
-		return false
+		return false, ""
 	}
 
 	wordCount := len(strings.Fields(*bodyStr))
@@ -291,11 +303,11 @@ func AnalyzeResponse(ctx context.Context, request common.HttpRequestResponse, va
 	if checkBaseContentMatch {
 		if (areSimilar(bodySize, baselineSize, threshold) && areSimilar(wordCount, baselineWords, threshold)) ||
 			(baselineSizeRandomPath != nil && baselineWordsRandomPath != nil && areSimilar(bodySize, *baselineSizeRandomPath, threshold) && areSimilar(wordCount, *baselineWordsRandomPath, threshold)) {
-			return false
+			return false, ""
 		}
 	}
 	log.Info("Valid directory/file found", svc1log.SafeParam("url", request.Request.BaseUrl), svc1log.SafeParam("path", request.Request.Path), svc1log.SafeParam("size", bodySize), svc1log.SafeParam("words", wordCount))
-	return true
+	return true, ""
 }
 
 // baseLine gets the baseline size and word count of the target to be used for validation of the response

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -3,6 +3,7 @@ package discoverpage
 import (
 	// Standard
 	"context"
+	"fmt"
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	"github.com/Method-Security/webscan/generated/go/discover"
@@ -98,7 +99,12 @@ func PerformPageCapture(
 
 	// Check if response is valid and add request if status code is allowed
 	if httpRequestResponse != nil && httpRequestResponse.Response != nil && httpRequestResponse.Response.StatusCode != nil {
-		if _, exists := validCodes[*httpRequestResponse.Response.StatusCode]; exists {
+		if _, exists := validCodes[*httpRequestResponse.Response.StatusCode]; !exists {
+			log.Info("Page returned a response code not in the allowed list, skipping",
+				svc1log.SafeParam("target", config.Target),
+				svc1log.SafeParam("status_code", *httpRequestResponse.Response.StatusCode))
+			errors = append(errors, fmt.Sprintf("page %s returned status code %d which is not in the allowed response codes", config.Target, *httpRequestResponse.Response.StatusCode))
+		} else {
 			result.Request = httpRequestResponse
 
 			// If sensitive content detection is enabled, extract sensitive content from response body


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to response-code validation behavior and additional logging/error collection, with no auth or data model impact.
> 
> **Overview**
> Improves discover-page and directory enumeration diagnostics by **explicitly logging and recording when responses return status codes outside the configured allowed list**.
> 
> `directory.AnalyzeResponse` now returns `(isValid, errMsg)` and emits an info log + error string for disallowed status codes; callers append these messages to the report errors while still collecting valid findings. `discover/page` similarly logs and adds an error when a page’s status code isn’t allowed, instead of silently skipping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc503a9556d3da40b3fec1aabac149a45324c792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->