### PR TITLE
Update Web Spider Param

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -509,7 +509,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get Config flags
-			ignoreBaseURLMatch, err := cmd.Flags().GetBool("ignore-base-url-match")
+			ignoreCrossDomain, err := cmd.Flags().GetBool("ignore-cross-domain")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -559,7 +559,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, ignoreBaseURLMatch, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, ignoreCrossDomainRedirects, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, ignoreCrossDomain, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, ignoreCrossDomainRedirects, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -569,7 +569,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverRouteCmd.Flags().String("target", "", "URL target to discover routes from")
 	// Config Flags
-	discoverRouteCmd.Flags().Bool("ignore-base-url-match", false, "Add route even if it does not share the target's base URL")
+	discoverRouteCmd.Flags().Bool("ignore-cross-domain", true, "Ignore routes that do not share the target's base URL")
 	discoverRouteCmd.Flags().Bool("collect-static-assets", false, "Collect static assets from route discovery")
 	discoverRouteCmd.Flags().Int("spider-depth", 3, "Maximum depth for route spidering")
 	discoverRouteCmd.Flags().Int("max-redirects", 100, "Maximum number of redirects to follow")
@@ -808,11 +808,11 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, ignoreBaseURLMatch bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, ignoreCrossDomainRedirects bool, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, ignoreCrossDomainRedirects bool, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:                     target,
 		CollectStaticAssets:        collectStaticAssets,
-		IgnoreBaseUrlMatch:         ignoreBaseURLMatch,
+		IgnoreCrossDomain:          ignoreCrossDomain,
 		SpiderDepth:                spiderDepth,
 		MaxRedirects:               maxRedirects,
 		VerifyTls:                  verifyTLS,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -823,7 +823,7 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:                     target,
 		CollectStaticAssets:        true,
-		IgnoreBaseUrlMatch:         true,
+		IgnoreCrossDomain:          false,
 		SpiderDepth:                1,
 		VerifyTls:                  verifyTLS,
 		Timeout:                    max(timeout, 0),

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -199,7 +199,7 @@ Flags:
       --collect-static-assets           Collect static assets from route discovery
       --headless-path string            Path to headless browser executable
   -h, --help                            help for route
-      --ignore-base-url-match           Add route even if it does not share the target's base URL
+      --ignore-cross-domain              Ignore routes that do not share the target's base URL (default true)
       --max-redirects int               Maximum number of redirects to follow (default 100)
       --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
       --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -7,7 +7,7 @@ types:
     properties:
       target: string
       collectStaticAssets: boolean
-      ignoreBaseUrlMatch: boolean
+      ignoreCrossDomain: boolean
       spiderDepth: integer
       maxRedirects: integer
       verifyTls: boolean

--- a/internal/discover/page/helpers/sensitivecontent.go
+++ b/internal/discover/page/helpers/sensitivecontent.go
@@ -8,7 +8,6 @@ import (
 
 	// Internal
 	"github.com/Method-Security/webscan/configs"
-
 	// Generated
 	"github.com/Method-Security/webscan/generated/go/discover"
 	// External

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"context"
 	"fmt"
+
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	"github.com/Method-Security/webscan/generated/go/discover"

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -41,7 +41,7 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 		fullURL := discoverroutehelpers.ResolveURL(baseURL, action)
 
 		// Check if the URL is allowed
-		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 			return
 		}
 
@@ -134,7 +134,7 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 			}
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 			urls[urlNoQuery] = struct{}{}
@@ -193,7 +193,7 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			}
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -94,7 +94,7 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, urlStr)
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 				continue
 			}
 
@@ -223,7 +223,7 @@ func extractScriptContentRoutes(ctx context.Context, scriptContent string, baseU
 	}
 
 	// If parsing succeeds, use AST traversal
-	ast.Walk(&visitor{routes: &routes, urls: urls, baseURL: baseURL, baseURLsOnly: routeCaptureConfig.IgnoreBaseUrlMatch, captureStaticAssets: routeCaptureConfig.CollectStaticAssets, errors: &errors}, program)
+	ast.Walk(&visitor{routes: &routes, urls: urls, baseURL: baseURL, baseURLsOnly: routeCaptureConfig.IgnoreCrossDomain, captureStaticAssets: routeCaptureConfig.CollectStaticAssets, errors: &errors}, program)
 
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
 }
@@ -348,14 +348,14 @@ func ExtractScriptRoutes(ctx context.Context, doc *goquery.Document, baseURL str
 			}
 
 			// If onlybaseURLs is set, only request script src that are relative
-			if !routeCaptureConfig.IgnoreBaseUrlMatch && discoverroutehelpers.IsAbsoluteURL(src) {
+			if routeCaptureConfig.IgnoreCrossDomain && discoverroutehelpers.IsAbsoluteURL(src) {
 				return
 			}
 
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, src)
 
 			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 				return
 			}
 

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -277,7 +277,7 @@ func (v *visitor) processFetchCall(node *ast.CallExpression) {
 
 	// Check if the URL is allowed
 	// Only consider URLs that are part of the base URL if specified
-	if !discoverroutehelpers.IsURLAllowed(v.baseURL, urlStr, v.baseURLsOnly, v.baseURLsOnly) {
+	if !discoverroutehelpers.IsURLAllowed(v.baseURL, urlStr, v.baseURLsOnly, v.captureStaticAssets) {
 		return
 	}
 

--- a/internal/discover/route/helpers/extractors/networkExtractors.go
+++ b/internal/discover/route/helpers/extractors/networkExtractors.go
@@ -20,7 +20,7 @@ import (
 
 // ExtractNetworkRoutes uses a headless browser to capture network requests and extract route details from them.
 // Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
-func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, target string, baseURLsOnly bool, captureStaticAssets bool) ([]*discover.RouteDetails, []string, []string) {
+func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, target string, ignoreCrossDomain bool, captureStaticAssets bool) ([]*discover.RouteDetails, []string, []string) {
 	// Get the logger from the context
 	log := svc1log.FromContext(ctx)
 
@@ -103,8 +103,7 @@ func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, targ
 			continue
 		}
 
-		// Skip requests that don't match the base domain when baseURLsOnly is true
-		if !discoverroutehelpers.IsURLAllowed(target, reqURL.String(), baseURLsOnly, captureStaticAssets) {
+		if !discoverroutehelpers.IsURLAllowed(target, reqURL.String(), ignoreCrossDomain, captureStaticAssets) {
 			log.Debug("Skipping URL", svc1log.SafeParam("url", reqURL.String()), svc1log.SafeParam("target", target))
 			continue
 		}

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -269,19 +269,17 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 }
 
 // IsURLAllowed checks if a target URL is allowed based on base URL, static asset rules, and domain matching.
-func IsURLAllowed(baseURL string, targetURL string, ignoreBaseURLMatch bool, collectStaticAssets bool) bool {
-	// First check to see if the targetURL is a static asset type
+func IsURLAllowed(baseURL string, targetURL string, ignoreCrossDomain bool, collectStaticAssets bool) bool {
 	if collectStaticAssets {
 		if utils.IsStaticAsset(targetURL) {
-			return true // Allow static assets when ignoreStaticAssets is false
+			return true
 		}
 	}
 
-	if ignoreBaseURLMatch {
+	if !ignoreCrossDomain {
 		return true
 	}
 
-	// Check if targetDomain is the same as baseDomain or a subdomain
 	return IsSubdomain(baseURL, targetURL)
 }
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -49,7 +49,7 @@ func ExtractRedirectRoutes(redirectChain []string, baseURL string, routeCaptureC
 		}
 
 		// Check if the URL is allowed
-		if !discoverroutehelpers.IsURLAllowed(baseURL, redirectURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets) {
+		if !discoverroutehelpers.IsURLAllowed(baseURL, redirectURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 			continue
 		}
 
@@ -250,7 +250,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		}
 
 		fullRedirectedURL := redirectedURL
-		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.IgnoreBaseUrlMatch, routeCaptureConfig.CollectStaticAssets)
+		networkRoutes, networkUrls, networkErrors := capturerouteextractors.ExtractNetworkRoutes(networkRouteCtx, browser, fullRedirectedURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets)
 		routes = append(routes, networkRoutes...)
 		urls = discoverroutehelpers.AddListToSetString(urls, networkUrls)
 		errors = append(errors, networkErrors...)
@@ -264,7 +264,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	staticAssets := make(map[string]struct{})
 	for url := range urls {
 		if routeCaptureConfig.CollectStaticAssets && utils.IsStaticAsset(url) {
-			if discoverroutehelpers.IsSubdomain(redirectedURLBase, url) || routeCaptureConfig.IgnoreBaseUrlMatch {
+			if discoverroutehelpers.IsSubdomain(redirectedURLBase, url) || !routeCaptureConfig.IgnoreCrossDomain {
 				staticAssets[url] = struct{}{}
 			}
 		}

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -114,7 +114,7 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 					locationURL := location.Str()
 					log.Debug("Captured HTTP redirect", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL), svc1log.SafeParam("status", e.Response.Status))
 
-						// Add the redirect destination to the chain if not already present
+					// Add the redirect destination to the chain if not already present
 					exists := false
 					for _, url := range *redirectChain {
 						if url == locationURL {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the route discovery config/CLI flag semantics and defaults (now ignoring cross-domain routes by default), which can significantly alter scan results and downstream integrations relying on the previous schema/flag behavior.
> 
> **Overview**
> **Route discovery now treats cross-domain filtering as a first-class setting.** The `discover route` CLI flag is renamed from `--ignore-base-url-match` to `--ignore-cross-domain`, with updated default/description so route extraction and spidering can exclude non-target domains by default.
> 
> The `DiscoverRouteConfig` field is renamed from `ignoreBaseUrlMatch` to `ignoreCrossDomain` across the Fern definition and Go call sites, and all HTML/JS/network extractors plus redirect/static-asset filtering are updated to use the new field. Also fixes a JS extractor bug where `IsURLAllowed` was passed the wrong static-asset flag, and includes minor import/formatting cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88f873f9db206751a8b27682f39ed3fe08b07366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->