### PR TITLE
Update Spider Param

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -545,12 +545,6 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
-			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
 			// Get Request Method flags
 			requestMethodConfig, err := requesthelpers.GetRequestMethodFlags(cmd)
 			if err != nil {
@@ -559,7 +553,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, ignoreCrossDomain, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, ignoreCrossDomainRedirects, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverRouteConfig(target, ignoreCrossDomain, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -569,7 +563,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverRouteCmd.Flags().String("target", "", "URL target to discover routes from")
 	// Config Flags
-	discoverRouteCmd.Flags().Bool("ignore-cross-domain", true, "Ignore routes that do not share the target's base URL")
+	discoverRouteCmd.Flags().Bool("ignore-cross-domain", false, "Ignore routes that do not share the target's base URL")
 	discoverRouteCmd.Flags().Bool("collect-static-assets", false, "Collect static assets from route discovery")
 	discoverRouteCmd.Flags().Int("spider-depth", 3, "Maximum depth for route spidering")
 	discoverRouteCmd.Flags().Int("max-redirects", 100, "Maximum number of redirects to follow")
@@ -808,20 +802,19 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, ignoreCrossDomainRedirects bool, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
-		Target:                     target,
-		CollectStaticAssets:        collectStaticAssets,
-		IgnoreCrossDomain:          ignoreCrossDomain,
-		SpiderDepth:                spiderDepth,
-		MaxRedirects:               maxRedirects,
-		VerifyTls:                  verifyTLS,
-		Timeout:                    max(timeout, 0),
-		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
-		Threads:                    max(threads, 0),
-		RequestMethod:              requestMethod,
-		HeadlessConfig:             headlessConfig,
-		BrowserbaseConfig:          browserbaseConfig,
+		Target:              target,
+		CollectStaticAssets: collectStaticAssets,
+		IgnoreCrossDomain:   ignoreCrossDomain,
+		SpiderDepth:         spiderDepth,
+		MaxRedirects:        maxRedirects,
+		VerifyTls:           verifyTLS,
+		Timeout:             max(timeout, 0),
+		Threads:             max(threads, 0),
+		RequestMethod:       requestMethod,
+		HeadlessConfig:      headlessConfig,
+		BrowserbaseConfig:   browserbaseConfig,
 	}
 	return config
 }

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -821,18 +821,17 @@ func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, succes
 func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, detect404Responses bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
-		Target:                     target,
-		CollectStaticAssets:        true,
-		IgnoreCrossDomain:          false,
-		SpiderDepth:                1,
-		VerifyTls:                  verifyTLS,
-		Timeout:                    max(timeout, 0),
-		Threads:                    max(threads, 0),
-		RequestMethod:              requestMethod,
-		MaxRedirects:               maxRedirects,
-		HeadlessConfig:             headlessConfig,
-		BrowserbaseConfig:          browserBaseConfig,
-		IgnoreCrossDomainRedirects: false,
+		Target:              target,
+		CollectStaticAssets: true,
+		IgnoreCrossDomain:   false,
+		SpiderDepth:         1,
+		VerifyTls:           verifyTLS,
+		Timeout:             max(timeout, 0),
+		Threads:             max(threads, 0),
+		RequestMethod:       requestMethod,
+		MaxRedirects:        maxRedirects,
+		HeadlessConfig:      headlessConfig,
+		BrowserbaseConfig:   browserBaseConfig,
 	}
 	// Create Static Asset Takeover Config with nested route capture config
 	config := pentestroutefern.PentestRouteStaticAssetTakeoverConfig{

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -12,7 +12,6 @@ types:
       maxRedirects: integer
       verifyTls: boolean
       timeout: integer
-      ignoreCrossDomainRedirects: boolean
       threads: integer
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -132,7 +132,7 @@ func createSendHTTPRequestConfigWithQuery(baseURL, path string, queryParams map[
 		MaxRedirects:               config.MaxRedirects,
 		VerifyTls:                  config.VerifyTls,
 		Timeout:                    config.Timeout,
-		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomain,
 		RequestMethod:              config.RequestMethod,
 		HeadlessConfig:             config.HeadlessConfig,
 		BrowserbaseConfig:          config.BrowserbaseConfig,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes route discovery redirect behavior by removing the separate `ignoreCrossDomainRedirects` setting and tying redirect filtering to `ignoreCrossDomain`, plus flips the CLI default for cross-domain route filtering; this can materially change scan coverage and which redirects are followed.
> 
> **Overview**
> Route discovery config is simplified by **removing** `ignoreCrossDomainRedirects` from `DiscoverRouteConfig` (Fern schema and call sites) and using `IgnoreCrossDomain` to control cross-domain redirect handling in HTTP requests.
> 
> The `discover route` CLI flag `--ignore-cross-domain` now defaults to `false` (previously `true`), expanding default route discovery to include cross-domain routes/redirects unless explicitly restricted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83d2b72cd34af403016f06bc615295fef492d22e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->