### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.78.1"
+  "version": "4.68.4"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,9 +3,9 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.38.0
+        version: 1.34.5
         config:
-          importpath: github.com/Method-Security/webscan/generated/go
+          importPath: github.com/Method-Security/webscan/generated/go
         output:
           location: local-file-system
           path: ../generated/go

--- a/godel/config/godel.yml
+++ b/godel/config/godel.yml
@@ -19,4 +19,5 @@ exclude:
     - "testdata"
   paths:
     - "godel"
+    - "generated"
     - "pkg/products"

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -773,11 +773,11 @@ func convertSecurityDefinitionsV3(securityDefinitions map[string]*v3.SecuritySch
 	return schemes
 }
 
-func convertOAuthFlowV3(flows *v3.OAuthFlows) *enumerateapiapplicationfern.OAuthFlow {
+func convertOAuthFlowV3(flows *v3.OAuthFlows) *enumerateapiapplicationfern.OauthFlow {
 	if flows == nil {
 		return nil
 	}
-	return &enumerateapiapplicationfern.OAuthFlow{
+	return &enumerateapiapplicationfern.OauthFlow{
 		Implicit:          convertOAuthFlowDetailsV3(flows.Implicit),
 		Password:          convertOAuthFlowDetailsV3(flows.Password),
 		ClientCredentials: convertOAuthFlowDetailsV3(flows.ClientCredentials),
@@ -785,11 +785,11 @@ func convertOAuthFlowV3(flows *v3.OAuthFlows) *enumerateapiapplicationfern.OAuth
 	}
 }
 
-func convertOAuthFlowDetailsV3(flow *v3.OAuthFlow) *enumerateapiapplicationfern.OAuthFlowDetails {
+func convertOAuthFlowDetailsV3(flow *v3.OAuthFlow) *enumerateapiapplicationfern.OauthFlowDetails {
 	if flow == nil {
 		return nil
 	}
-	return &enumerateapiapplicationfern.OAuthFlowDetails{
+	return &enumerateapiapplicationfern.OauthFlowDetails{
 		AuthorizationUrl: &flow.AuthorizationUrl,
 		TokenUrl:         &flow.TokenUrl,
 		RefreshUrl:       &flow.RefreshUrl,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily a codegen/tooling upgrade; risk is in regenerated SDK API/name changes (e.g., `OauthFlow` rename) causing compile or integration breakage if other references or generated outputs drift.
> 
> **Overview**
> Upgrades Fern (`fern.config.json` 3.78.1 → 4.68.4) and the Go SDK generator (`fern-go-sdk` 0.38.0 → 1.34.8), including the generator config key rename `importpath` → `importPath`.
> 
> Updates Go code to match new generated type names for OAuth models (`OAuthFlow*` → `OauthFlow*`) in `internal/enumerate/apiapplication/swagger.go`, and adjusts `godel` config to exclude the `generated/` directory from checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d8bd3939e186887c19108c8f21ce57853a2f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->