### PR TITLE
Update Nuclei Global Timeout Param

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -91,9 +91,14 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, timeout, threads, proxy, verboseLogs, globalRateLimit)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -116,6 +121,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	discoverApplicationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	discoverApplicationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 means no limit)")
+	discoverApplicationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")
@@ -731,7 +737,7 @@ func (a *WebScan) InitDiscoverCommand() {
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -745,6 +751,7 @@ func getDiscoverApplicationConfig(targets []string, resource string, timeout int
 		Proxy:           &proxy,
 		VerboseLogs:     verboseLogs,
 		GlobalRateLimit: max(0, globalRateLimit),
+		GlobalTimeout:   max(0, globalTimeout),
 	}
 	return config, nil
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -121,7 +121,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	discoverApplicationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	discoverApplicationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 means no limit)")
-	discoverApplicationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
+	discoverApplicationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -164,7 +164,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationDastCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
+	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationDastCmd.MarkFlagRequired("targets")
@@ -260,7 +260,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationCveCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationCveCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
+	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationCveCmd.MarkFlagRequired("targets")
@@ -353,7 +353,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationMisconfigurationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
+	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationMisconfigurationCmd.MarkFlagRequired("targets")
@@ -445,7 +445,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationTechnologyCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
+	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationTechnologyCmd.MarkFlagRequired("targets")
@@ -757,7 +757,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestWafDetectCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestWafDetectCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestWafDetectCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestWafDetectCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
+	pentestWafDetectCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
 
 	// Mark Required Flags
 	_ = pentestWafDetectCmd.MarkFlagRequired("targets")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -134,9 +134,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, &proxy, verboseLogs, globalRateLimit)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -159,6 +164,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationDastCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
+	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationDastCmd.MarkFlagRequired("targets")
@@ -227,9 +233,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationCveConfig(targets, years, timeout, threads, proxy, verboseLogs, globalRateLimit)
+			config := getPentestApplicationCveConfig(targets, years, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationCveScan(cmd.Context(), config)
@@ -249,6 +260,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationCveCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationCveCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
+	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationCveCmd.MarkFlagRequired("targets")
@@ -313,9 +325,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit)
+			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationMisconfigurationScan(cmd.Context(), config)
@@ -336,6 +353,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationMisconfigurationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
+	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationMisconfigurationCmd.MarkFlagRequired("targets")
@@ -399,9 +417,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit)
+			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationTechnologyScan(cmd.Context(), config)
@@ -422,6 +445,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationTechnologyCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
+	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
 
 	// Mark Required Flags
 	_ = pentestApplicationTechnologyCmd.MarkFlagRequired("targets")
@@ -704,9 +728,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, timeout, threads, proxy, verboseLogs, globalRateLimit)
+			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestwafdetect.RunPentestWafDetect(cmd.Context(), config)
@@ -728,6 +757,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestWafDetectCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestWafDetectCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestWafDetectCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
+	pentestWafDetectCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 = auto-derived from timeout)")
 
 	// Mark Required Flags
 	_ = pentestWafDetectCmd.MarkFlagRequired("targets")
@@ -747,7 +777,7 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
 		Targets:           targets,
 		DastCategories:    dastCategories,
@@ -758,12 +788,13 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 		Proxy:             proxy,
 		VerboseLogs:       verboseLogs,
 		GlobalRateLimit:   max(0, globalRateLimit),
+		GlobalTimeout:     max(0, globalTimeout),
 	}
 	return config
 }
 
 // getPentestApplicationCveConfig builds the config for scan pentest.
-func getPentestApplicationCveConfig(targets []string, years []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) pentestapplicationscanfern.PentestApplicationCveConfig {
+func getPentestApplicationCveConfig(targets []string, years []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationCveConfig {
 	config := pentestapplicationscanfern.PentestApplicationCveConfig{
 		Targets:         targets,
 		Years:           years,
@@ -772,12 +803,13 @@ func getPentestApplicationCveConfig(targets []string, years []string, timeout in
 		Proxy:           &proxy,
 		VerboseLogs:     verboseLogs,
 		GlobalRateLimit: max(0, globalRateLimit),
+		GlobalTimeout:   max(0, globalTimeout),
 	}
 	return config
 }
 
 // getPentestApplicationMisconfigurationConfig builds the config for scan pentest.
-func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
+func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
 	config := pentestapplicationscanfern.PentestApplicationMisconfigurationConfig{
 		Targets:                    targets,
 		MisconfigurationCategories: misconfigurationCategories,
@@ -786,12 +818,13 @@ func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurat
 		Proxy:                      &proxy,
 		VerboseLogs:                verboseLogs,
 		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
 	}
 	return config
 }
 
 // getPentestApplicationTechnologiesConfig builds the config for scan pentest.
-func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
+func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
 	config := pentestapplicationscanfern.PentestApplicationTechnologyConfig{
 		Targets:         targets,
 		TechnologyTypes: technologyTypes,
@@ -800,6 +833,7 @@ func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []p
 		Proxy:           &proxy,
 		VerboseLogs:     verboseLogs,
 		GlobalRateLimit: max(0, globalRateLimit),
+		GlobalTimeout:   max(0, globalTimeout),
 	}
 	return config
 }
@@ -845,7 +879,7 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 }
 
 // getPentestWafDetectConfig builds the config for waf detect pentest.
-func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int) waf.PentestWafDetectConfig {
+func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) waf.PentestWafDetectConfig {
 	config := waf.PentestWafDetectConfig{
 		Targets:                targets,
 		RouteRequestParameters: routeRequestParams,
@@ -855,6 +889,7 @@ func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.Re
 		Proxy:                  &proxy,
 		VerboseLogs:            verboseLogs,
 		GlobalRateLimit:        max(0, globalRateLimit),
+		GlobalTimeout:          max(0, globalTimeout),
 	}
 	return config
 }

--- a/fern/definition/common/nuclei/config.yml
+++ b/fern/definition/common/nuclei/config.yml
@@ -23,4 +23,5 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
 

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -45,6 +45,7 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
   # Application Fingerprint Attempt Struct
   ApplicationFingerprintAttempt:
     properties:

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -26,6 +26,7 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
   PentestApplicationDastResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/cve.yml
+++ b/fern/definition/pentest/application/scan/cve.yml
@@ -11,6 +11,7 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
   PentestApplicationCveResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/misconfiguration.yml
+++ b/fern/definition/pentest/application/scan/misconfiguration.yml
@@ -15,6 +15,7 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
   PentestApplicationMisconfigurationResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/technology.yml
+++ b/fern/definition/pentest/application/scan/technology.yml
@@ -17,6 +17,7 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
   PentestApplicationTechnologyResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/waf/detect.yml
+++ b/fern/definition/pentest/waf/detect.yml
@@ -38,6 +38,7 @@ types:
       proxy: optional<string>
       verboseLogs: boolean
       globalRateLimit: integer
+      globalTimeout: integer
   # Detection Results
   WafRuleCategoryEnum:
     enum:

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -100,6 +100,7 @@ func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover
 		Proxy:           config.Proxy,
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}, nil
 }
 

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -67,6 +67,7 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 		Proxy:           config.Proxy,
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}
 }
 

--- a/internal/pentest/application/scan/cve.go
+++ b/internal/pentest/application/scan/cve.go
@@ -36,6 +36,7 @@ func createCveScanNucleiConfig(config pentestapplicationscanfern.PentestApplicat
 		Proxy:           config.Proxy,
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}
 }
 

--- a/internal/pentest/application/scan/misconfiguration.go
+++ b/internal/pentest/application/scan/misconfiguration.go
@@ -40,6 +40,7 @@ func createMisconfigurationScanNucleiConfig(config pentestapplicationscanfern.Pe
 		Proxy:           config.Proxy,
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}
 }
 

--- a/internal/pentest/application/scan/technology.go
+++ b/internal/pentest/application/scan/technology.go
@@ -41,6 +41,7 @@ func createTechnologyScanNucleiConfig(config pentestapplicationscanfern.PentestA
 		Proxy:           config.Proxy,
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}
 }
 

--- a/internal/pentest/waf/detect/detect.go
+++ b/internal/pentest/waf/detect/detect.go
@@ -29,6 +29,7 @@ func createDastNucleiConfigForWafDetect(config waf.PentestWafDetectConfig) nucle
 		Proxy:           config.Proxy,
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}
 }
 

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -33,6 +33,7 @@ type Config struct {
 	VerboseLogs     bool
 	Timeout         int
 	GlobalRateLimit int
+	GlobalTimeout   int
 }
 
 func validateConfig(cfg *Config) error {
@@ -289,6 +290,7 @@ func GetRunnerConfig(templateFileSystems, workflowFileSystems []fs.FS, config nu
 		VerboseLogs:     config.VerboseLogs,
 		Timeout:         config.Timeout,
 		GlobalRateLimit: config.GlobalRateLimit,
+		GlobalTimeout:   config.GlobalTimeout,
 	}
 	return rconfig
 }
@@ -301,11 +303,16 @@ func Run(ctx context.Context, cfg Config, reportBuilder *report.Builder) ([]*nuc
 	}
 
 	// Add a maximum execution timeout for the entire scan to prevent hanging
-	maxScanTime := time.Duration(cfg.Timeout*20) * time.Second // 20x timeout for total scan time
-	scanCtx, cancel := context.WithTimeout(ctx, maxScanTime)
+	var scanCtx context.Context
+	var cancel context.CancelFunc
+	if cfg.GlobalTimeout > 0 {
+		scanCtx, cancel = context.WithTimeout(ctx, time.Duration(cfg.GlobalTimeout)*time.Second)
+	} else {
+		scanCtx, cancel = context.WithCancel(ctx)
+	}
 	defer cancel()
 
-	log.Info("Scan will timeout after", svc1log.SafeParam("maxScanTime", maxScanTime))
+	log.Info("Scan global timeout", svc1log.SafeParam("globalTimeout", cfg.GlobalTimeout))
 
 	log.Info("Copying templates and workflows to tmp dirs")
 	templateDir, workflowDir, err := copyFilesToTmpDirs(cfg)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes scan lifecycle timing across all Nuclei executions and updates generated config schemas; misconfiguration could cause scans to end earlier or run longer than before.
> 
> **Overview**
> Adds a new `global-timeout` CLI flag to Nuclei-backed `discover application` and multiple `pentest` commands, plumbs it into their config builders, and propagates it through the generated Fern config types.
> 
> Updates the Nuclei runner to honor `GlobalTimeout` by applying a scan-wide context timeout when set (otherwise relying on cancellation), replacing the prior fixed `timeout*20` total runtime heuristic and updating logging accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d96f836b322f9c2b5c56a6f4cba00e3e39fb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->