### PR TITLE
Update Swagger Enumerate Fern to have Optional Lists

### DIFF
--- a/fern/definition/enumerate/apiapplication/common.yml
+++ b/fern/definition/enumerate/apiapplication/common.yml
@@ -45,7 +45,7 @@ types:
       schemes: map<string, optional<list<string>>>
   RequestSchema:
     properties:
-      type: list<string>
+      type: optional<list<string>>
       properties: optional<list<SchemaProperty>>
       required: optional<list<string>>
       items: optional<RequestSchema>
@@ -75,7 +75,7 @@ types:
   SchemaProperty:
     properties:
       name: string
-      type: list<string>
+      type: optional<list<string>>
       format: optional<string>
       description: optional<string>
       required: optional<boolean>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Fern type definitions used for Swagger enumeration, which can affect generated models/clients and downstream parsing of schemas that assumed `type` was always present.
> 
> **Overview**
> Updates the Swagger enumerate Fern definition so `RequestSchema.type` and `SchemaProperty.type` are now `optional<list<string>>` instead of required `list<string>`, allowing schemas/properties without an explicit `type` to be represented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c626813330bcb8c717da359aafc112ded5ed1456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->