### PR TITLE
Update Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: webscan
 site_url: https://method-security.github.io/webscan/
-site_description: AWS enumeration capabilities for security teams of all sizes
+site_description: Web scanning capabilities for security teams of all sizes
 docs_dir: docs/
 repo_name: GitHub
 repo_url: https://github.com/Method-Security/webscan


### PR DESCRIPTION
## Summary

- `site_description` was incorrectly set to `"AWS enumeration capabilities for security teams of all sizes"` — this belongs to `methodaws`, not `webscan`
- Fixed to `"Web scanning capabilities for security teams of all sizes"`

## Test plan

- [x] `mkdocs build --strict` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation config tweak that only changes the generated site metadata/SEO description.
> 
> **Overview**
> Updates `mkdocs.yml` to correct the generated documentation site metadata by changing `site_description` from an AWS-enumeration blurb to a web-scanning description appropriate for `webscan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adeb2196a5bedb882e644065a112cef70b4e7436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->