### PR TITLE
Update Docs

### DIFF
--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -21,9 +21,7 @@ webscan discover [command]
 
 The following flag is available on all `discover` subcommands:
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--ignore-cross-domain-redirects` | bool | false | Do not follow redirects to a different domain and treat them as errors |
+- `--ignore-cross-domain-redirects` (bool, default: `false`) — Do not follow redirects to a different domain and treat them as errors
 
 ## Commands
 

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -38,6 +38,7 @@ Usage:
 
 Flags:
       --global-rate-limit int   Global rate limit (requests per second, 0 = no limit)
+      --global-timeout int      Maximum total scan time in seconds (0 means no timeout)
   -h, --help                    help for application
       --proxy string            Optional HTTP proxy URL
       --resource-type string    Type of resource to fingerprint (e.g., web, api, cms) (default "ALL")
@@ -113,20 +114,22 @@ Usage:
   webscan discover page [flags]
 
 Flags:
-      --browserbase-countries strings   List of countries to use for Browserbase proxy
-      --browserbase-project string      Browserbase project ID
-      --browserbase-proxy               Use Browserbase proxy for requests
-      --browserbase-token string        Browserbase API token for cloud browser access
-      --headless-path string            Path to headless browser executable
-  -h, --help                            help for page
-      --max-redirects int               Maximum number of redirects to follow (default 10)
-      --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
-      --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
-      --response-codes string           Response codes to consider as valid responses (default "200-299")
-      --screenshot                      Capture a screenshot of the page
-      --target string                   URL target to capture and analyze
-      --timeout int                     Timeout per request in seconds (default 30)
-      --verify-tls                      Verify TLS certificates when making HTTPS requests
+      --browserbase-countries strings              List of countries to use for Browserbase proxy
+      --browserbase-project string                 Browserbase project ID
+      --browserbase-proxy                          Use Browserbase proxy for requests
+      --browserbase-token string                   Browserbase API token for cloud browser access
+      --headless-path string                       Path to headless browser executable
+  -h, --help                                       help for page
+      --max-redirects int                          Maximum number of redirects to follow (default 10)
+      --min-dom-stabalize-time int                 Minimum time to wait for DOM stabilization in seconds (default 20)
+      --request-method string                      Request method to use (standard, headless, browserbase) (default "STANDARD")
+      --response-codes string                      Response codes to consider as valid responses (default "200-299")
+      --screenshot                                 Capture a screenshot of the page
+      --sensitive-content-detection                Enable sensitive content detection
+      --sensitive-content-fingerprints-path string Path to a custom sensitive content fingerprints file (uses built-in fingerprints by default)
+      --target string                              URL target to capture and analyze
+      --timeout int                                Timeout per request in seconds (default 30)
+      --verify-tls                                 Verify TLS certificates when making HTTPS requests
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -199,7 +202,7 @@ Flags:
       --collect-static-assets           Collect static assets from route discovery
       --headless-path string            Path to headless browser executable
   -h, --help                            help for route
-      --ignore-cross-domain              Ignore routes that do not share the target's base URL (default true)
+      --ignore-cross-domain              Ignore routes that do not share the target's base URL (default false)
       --max-redirects int               Maximum number of redirects to follow (default 100)
       --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
       --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
@@ -245,9 +248,9 @@ Flags:
       --orgs strings                    The organization names to use for discovery
       --request-method string           Request method (headless, browserbase) (default "HEADLESS")
       --saas-companies strings          The specific SaaS companies to use for discovery (Must be present in the SaaS fingerprints file)
-      --saas-file-paths strings         Files containing SaaS application fingerprints (default ["/opt/method/webscan/var/conf/discover/saas/saas_fingerprints.json"])
+      --saas-file-paths strings         Files containing SaaS application fingerprints
       --sso-companies strings           The specific SSO companies to use for discovery (Must be present in the SSO fingerprints file)
-      --sso-file-paths strings          Files containing SSO application fingerprints (default ["/opt/method/webscan/var/conf/discover/saas/sso_fingerprints.json"])
+      --sso-file-paths strings          Files containing SSO application fingerprints
       --threads int                     Number of concurrent threads for discovery (default: number of CPUs)
       --timeout int                     Timeout in seconds for the capture (default 30)
       --verify-tls                      Verify TLS certificates when making HTTPS requests

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -17,6 +17,14 @@ webscan discover [command]
 - **route**: Route discovery and analysis
 - **saas**: SaaS application discovery by organization name
 
+## Common Flags
+
+The following flag is available on all `discover` subcommands:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ignore-cross-domain-redirects` | bool | false | Do not follow redirects to a different domain and treat them as errors |
+
 ## Commands
 
 ### Application

--- a/docs/docs/enumerate.md
+++ b/docs/docs/enumerate.md
@@ -11,6 +11,7 @@ webscan enumerate [command]
 
 - **api-application**: Enumerate API applications including GraphQL and Swagger endpoints
 - **cms**: Enumerate content management systems like WordPress plugins and Drupal modules
+- **container-registry**: Enumerate container registries including Docker registries
 - **general**: Perform general enumeration tasks like rate limit testing
 - **kube**: Enumerate Kubernetes resources and configurations
 
@@ -155,6 +156,36 @@ Global Flags:
   -v, --verbose              Verbose output
 ```
 
+
+### Container Registry
+
+Enumerate container registries and their contents.
+
+#### Docker
+```bash
+webscan enumerate container-registry docker --targets https://registry.example.com
+```
+##### Help Text
+```bash
+webscan enumerate container-registry docker -h
+Discover and analyze Docker container registries, including repositories, images, and their manifest data.
+
+Usage:
+  webscan enumerate container-registry docker [flags]
+
+Flags:
+  -h, --help              help for docker
+      --targets strings   URLs of Docker Container Registries to enumerate
+      --threads int       Number of concurrent manifest requests per repository (default 25)
+      --timeout int       Timeout per request in seconds (default 30)
+      --verify-tls        Verify TLS certificates when making HTTPS requests
+
+Global Flags:
+  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string   Path to output file. If blank, will output to STDOUT
+  -q, --quiet                Suppress output
+  -v, --verbose              Verbose output
+```
 
 ### General
 

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -35,6 +35,7 @@ Flags:
       --dast-categories strings      Dast Categories (ie. XSS, SQLI, RFI, etc.)
       --dast-request-params string   Base64 JSON blob of request parameters that will be fuzzed
       --global-rate-limit int        Global rate limit (requests per second, 0 = no limit)
+      --global-timeout int           Maximum total scan time in seconds (0 means no timeout)
   -h, --help                         help for dast
       --http-methods strings         HTTP methods to use (e.g. GET,POST,PUT)
       --proxy string                 Optional HTTP proxy URL
@@ -67,13 +68,15 @@ Usage:
   webscan pentest application scan cve [flags]
 
 Flags:
-  -h, --help             help for cve
-      --proxy string     Optional HTTP proxy URL
-      --targets strings  Targets to be scanned
-      --threads int      Number of threads (default 25)
-      --timeout int      Timeout per request in seconds (default 30)
-      --verbose-logs     Verbose logs
-      --years strings    Restrict CVE scans to particular years (default is all available years)
+      --global-rate-limit int  Global rate limit (requests per second, 0 = no limit)
+      --global-timeout int     Maximum total scan time in seconds (0 means no timeout)
+  -h, --help                   help for cve
+      --proxy string           Optional HTTP proxy URL
+      --targets strings        Targets to be scanned
+      --threads int            Number of threads (default 25)
+      --timeout int            Timeout per request in seconds (default 30)
+      --verbose-logs           Verbose logs
+      --years strings          Restrict CVE scans to particular years (default is all available years)
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -96,13 +99,15 @@ Usage:
   webscan pentest application scan misconfiguration [flags]
 
 Flags:
-  -h, --help                              help for misconfiguration
+      --global-rate-limit int               Global rate limit (requests per second, 0 = no limit)
+      --global-timeout int                  Maximum total scan time in seconds (0 means no timeout)
+  -h, --help                                help for misconfiguration
       --misconfiguration-categories strings Categories of misconfigurations to scan for
-      --proxy string                       Optional HTTP proxy URL
-      --targets strings                    Targets to be scanned
-      --threads int                        Number of threads (default 25)
-      --timeout int                        Timeout per request in seconds (default 30)
-      --verbose-logs                       Verbose logs
+      --proxy string                        Optional HTTP proxy URL
+      --targets strings                     Targets to be scanned
+      --threads int                         Number of threads (default 25)
+      --timeout int                         Timeout per request in seconds (default 30)
+      --verbose-logs                        Verbose logs
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -125,6 +130,8 @@ Usage:
   webscan pentest application scan technology [flags]
 
 Flags:
+      --global-rate-limit int     Global rate limit (requests per second, 0 = no limit)
+      --global-timeout int        Maximum total scan time in seconds (0 means no timeout)
   -h, --help                      help for technology
       --proxy string              Optional HTTP proxy URL
       --targets strings           Targets to be scanned
@@ -199,7 +206,8 @@ Flags:
       --browserbase-project string        Browserbase project ID
       --browserbase-proxy                 Use Browserbase proxy for requests
       --browserbase-token string          Browserbase API token for cloud browser access
-      --fingerprint-file-paths strings    Paths to fingerprint definition files (default ["/opt/method/webscan/var/conf/pentest/route/static_asset_takeover.json"])
+      --detect-404-responses              Detect 404 responses as potential takeover responses
+      --fingerprint-file-paths strings    Paths to fingerprint definition files
       --headless-path string              Path to headless browser executable
   -h, --help                              help for static-asset-takeover
       --max-redirects int                 Maximum number of redirects to follow (default 10)
@@ -237,6 +245,7 @@ Usage:
 
 Flags:
       --global-rate-limit int         Global rate limit (requests per second, 0 = no limit)
+      --global-timeout int            Maximum total scan time in seconds (0 means no timeout)
   -h, --help                          help for detect
       --http-methods strings          HTTP methods to use (e.g. GET,POST,PUT)
       --proxy string                  Optional HTTP proxy URL

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -19,8 +19,10 @@ webscan pentest [command]
 ### Application Commands
 
 #### DAST (Dynamic Application Security Testing)
+
+##### Usage
 ```bash
-webscan pentest application dast --targets https://example.com --dast-categories XSS,SQLI --http-methods GET,POST
+webscan pentest application dast --targets https://example.com
 ```
 
 ##### Help Text
@@ -52,14 +54,14 @@ Global Flags:
 ```
 
 
-#### Scan
+#### CVE Scan
 
-##### CVE
+##### Usage
 ```bash
 webscan pentest application scan cve --targets https://example.com
 ```
 
-###### Help Text
+##### Help Text
 ```bash
 webscan pentest application scan cve -h
 Scan targets for CVEs
@@ -85,12 +87,14 @@ Global Flags:
   -v, --verbose              Verbose output
 ```
 
-##### Misconfiguration
+#### Misconfiguration Scan
+
+##### Usage
 ```bash
 webscan pentest application scan misconfiguration --targets https://example.com
 ```
 
-###### Help Text
+##### Help Text
 ```bash
 webscan pentest application scan misconfiguration -h
 Scan targets for security misconfigurations using nuclei templates.
@@ -116,12 +120,14 @@ Global Flags:
   -v, --verbose              Verbose output
 ```
 
-##### Technology
+#### Technology Scan
+
+##### Usage
 ```bash
 webscan pentest application scan technology --targets https://example.com
 ```
 
-###### Help Text
+##### Help Text
 ```bash
 webscan pentest application scan technology -h
 Scan targets for technology-specific vulnerabilities using nuclei templates.
@@ -156,6 +162,8 @@ Analyze CMS Applications to detect potential vulnerabilities.
 Analyze WordPress to detect potential vulnerabilities.
 
 ##### XMLRPC Functions Exposed
+
+##### Usage
 ```bash
 webscan pentest cms wordpress xmlrpc-functions-exposed --targets https://example.com
 ```
@@ -189,8 +197,10 @@ Global Flags:
 Analyze routes to detect potential vulnerabilities.
 
 #### Static Asset Takeover
+
+##### Usage
 ```bash
-webscan pentest route static-asset-takeover --target https://example.com
+webscan pentest route static-asset-takeover --targets https://example.com
 ```
 
 ##### Help Text
@@ -231,8 +241,10 @@ Global Flags:
 Detect and analyze Web Application Firewalls (WAFs) protecting web applications.
 
 #### Detect
+
+##### Usage
 ```bash
-webscan pentest waf detect --targets https://example.com --http-methods GET,POST
+webscan pentest waf detect --targets https://example.com
 ```
 
 ##### Help Text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: webscan
 site_url: https://method-security.github.io/webscan/
-site_description: AWS enumeration capabilities for security teams of all sizes
+site_description: Web scanning capabilities for security teams of all sizes
 docs_dir: docs/
 repo_name: GitHub
 repo_url: https://github.com/Method-Security/webscan


### PR DESCRIPTION
## Summary

- **discover.md**: Fix `--ignore-cross-domain` default (`true` → `false`); add `--global-timeout` to application command; add `--sensitive-content-detection` and `--sensitive-content-fingerprints-path` to page command; remove hardcoded paths from saas/sso file-path defaults
- **enumerate.md**: Add complete `container-registry docker` command section
- **pentest.md**: Add `--global-timeout` and `--global-rate-limit` to DAST, CVE, misconfiguration, technology, and WAF detect commands; fix `--fingerprint-file-paths` default (remove hardcoded path); add `--detect-404-responses` to static asset takeover

## Test plan

- [x] `mkdocs build --strict` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates reflecting new/changed CLI flags and command sections; no runtime code changes so risk is limited to potential doc accuracy/regressions.
> 
> **Overview**
> Updates `discover` docs to add a shared `--ignore-cross-domain-redirects` flag, document `--global-timeout` for `discover application`, add sensitive content detection flags for `discover page`, correct the `route --ignore-cross-domain` default, and remove hardcoded default paths for SaaS/SSO fingerprint files.
> 
> Expands `enumerate` docs with a full `container-registry docker` section, and refreshes `pentest` docs with added `--global-rate-limit/--global-timeout` flags plus updated static-asset takeover options (including `--detect-404-responses` and fingerprint path defaults). Also updates `mkdocs.yml` site description copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa43607ac16312df96b2e80a2a6973049f525ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->