### PR TITLE
Add Base URL Detection

### DIFF
--- a/utils/nuclei/templates/discover/application/apiapplication/swagger.yaml
+++ b/utils/nuclei/templates/discover/application/apiapplication/swagger.yaml
@@ -12,6 +12,7 @@ info:
 http:
   - method: GET
     path:
+      - "{{BaseURL}}"
       - "{{BaseURL}}/swagger-ui.html"
       - "{{BaseURL}}/swagger-ui/index.html"
       - "{{BaseURL}}/swagger/index.html"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change to a Nuclei discovery template that only broadens matching by probing the root `{{BaseURL}}`; main impact is potential extra requests/false positives.
> 
> **Overview**
> Updates the `discover-swagger` Nuclei template to include `GET {{BaseURL}}` in the probe list, allowing detection of Swagger/OpenAPI UIs or specs served directly from the root path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d42c81aef33e8f71b4d679909046540eee4b79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->