### PR TITLE
Update Headless Redirect Logic + Discover Route Bug Fix

### DIFF
--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -51,8 +51,13 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			errors = append(errors, err.Error())
 			return
 		}
-		routeVar.BaseUrl = baseURL
-		routeVar.Path = urlNoQuery
+		routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
+		if err != nil {
+			errors = append(errors, err.Error())
+			return
+		}
+		routeVar.BaseUrl = routeBaseURL
+		routeVar.Path = routePath
 		urls[urlNoQuery] = struct{}{}
 
 		// Extract method attribute
@@ -63,12 +68,6 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			method = strings.ToUpper(method)
 		}
 		routeVar.Method = common.HttpMethod(method).Ptr()
-
-		// Get the path from the full URL and set it
-		parsedURL, err := url.Parse(fullURL)
-		if err == nil {
-			routeVar.Path = parsedURL.Path
-		}
 
 		// Collect input names
 		var queryParams []*discover.RouteQueryParam
@@ -139,16 +138,16 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 			}
 			urls[urlNoQuery] = struct{}{}
 
-			// Get the path from the full URL without query params
-			parsedURL, err := url.Parse(urlNoQuery)
+			// Get the origin and path from the full URL without query params
+			routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
 			if err != nil {
 				errors = append(errors, err.Error())
 				return
 			}
 
 			routeVar := &discover.RouteDetails{
-				BaseUrl: baseURL,
-				Path:    parsedURL.Path,
+				BaseUrl: routeBaseURL,
+				Path:    routePath,
 				Method:  common.HttpMethodGet.Ptr(), // Anchor links are accessed via GET
 			}
 
@@ -199,16 +198,16 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 
 			urls[urlNoQuery] = struct{}{}
 
-			// Get the path from the full URL
-			parsedURL, err := url.Parse(urlNoQuery)
+			// Get the origin and path from the full URL
+			routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
 			if err != nil {
 				errors = append(errors, err.Error())
 				return
 			}
 
 			routeVar := &discover.RouteDetails{
-				BaseUrl: baseURL,
-				Path:    parsedURL.Path,
+				BaseUrl: routeBaseURL,
+				Path:    routePath,
 				Method:  common.HttpMethodGet.Ptr(), // Link elements are accessed via GET
 			}
 

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -105,7 +104,7 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 				continue
 			}
 
-			parsedURL, err := url.Parse(urlNoQuery)
+			routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
 			if err != nil {
 				errors = append(errors, err.Error())
 				continue
@@ -117,8 +116,8 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 			}
 
 			route := &discover.RouteDetails{
-				BaseUrl: baseURL,
-				Path:    parsedURL.Path,
+				BaseUrl: routeBaseURL,
+				Path:    routePath,
 				Method:  common.HttpMethod(method).Ptr(),
 			}
 
@@ -274,10 +273,11 @@ func (v *visitor) processFetchCall(node *ast.CallExpression) {
 		return
 	}
 	urlStr := urlArg.Value
+	fullURL := discoverroutehelpers.ResolveURL(v.baseURL, urlStr)
 
 	// Check if the URL is allowed
 	// Only consider URLs that are part of the base URL if specified
-	if !discoverroutehelpers.IsURLAllowed(v.baseURL, urlStr, v.baseURLsOnly, v.captureStaticAssets) {
+	if !discoverroutehelpers.IsURLAllowed(v.baseURL, fullURL, v.baseURLsOnly, v.captureStaticAssets) {
 		return
 	}
 
@@ -302,7 +302,7 @@ func (v *visitor) processFetchCall(node *ast.CallExpression) {
 		}
 	}
 
-	v.addRoute(urlStr, method, bodyParams, queryParams)
+	v.addRoute(fullURL, method, bodyParams, queryParams)
 }
 
 // addRoute adds a route to the list
@@ -314,15 +314,15 @@ func (v *visitor) addRoute(urlStr, method string, bodyParams []*discover.RouteBo
 		return
 	}
 
-	parsedURL, err := url.Parse(urlNoQuery)
+	routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
 	if err != nil {
 		*v.errors = append(*v.errors, err.Error())
 		return
 	}
 
 	route := &discover.RouteDetails{
-		BaseUrl:     v.baseURL,
-		Path:        parsedURL.Path,
+		BaseUrl:     routeBaseURL,
+		Path:        routePath,
 		Method:      common.HttpMethod(method).Ptr(),
 		BodyParams:  bodyParams,
 		QueryParams: queryParams,

--- a/internal/discover/route/helpers/extractors/networkExtractors.go
+++ b/internal/discover/route/helpers/extractors/networkExtractors.go
@@ -115,18 +115,18 @@ func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, targ
 			continue
 		}
 
-		// Get the path from the full URL
-		parsedURL, err := url.Parse(urlNoQuery)
+		// Get the origin and path from the full URL
+		routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
 		if err != nil {
 			errors = append(errors, err.Error())
 			continue
 		}
 
 		// Build WebRoute object
-		log.Info("Building WebRoute object", svc1log.SafeParam("url", urlNoQuery), svc1log.SafeParam("path", parsedURL.Path), svc1log.SafeParam("method", request.Method))
+		log.Info("Building WebRoute object", svc1log.SafeParam("url", urlNoQuery), svc1log.SafeParam("path", routePath), svc1log.SafeParam("method", request.Method))
 		webRoute := &discover.RouteDetails{
-			BaseUrl: urlNoQuery,
-			Path:    parsedURL.Path,
+			BaseUrl: routeBaseURL,
+			Path:    routePath,
 			Method:  common.HttpMethod(request.Method).Ptr(),
 		}
 

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -268,6 +268,23 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 	return parsedURL.String(), nil
 }
 
+// SplitURLBaseAndPath returns the URL origin and path as separate route fields.
+func SplitURLBaseAndPath(rawURL string) (string, string, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	baseURL := ""
+	if parsedURL.Scheme != "" && parsedURL.Host != "" {
+		baseURL = fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+	} else if parsedURL.Host != "" {
+		baseURL = "//" + parsedURL.Host
+	}
+
+	return strings.TrimRight(baseURL, "/"), parsedURL.Path, nil
+}
+
 // IsURLAllowed checks if a target URL is allowed based on base URL, static asset rules, and domain matching.
 func IsURLAllowed(baseURL string, targetURL string, ignoreCrossDomain bool, collectStaticAssets bool) bool {
 	if collectStaticAssets {

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -90,15 +90,18 @@ func ExtractRedirectRoutes(redirectChain []string, baseURL string, routeCaptureC
 // buildAllParameterURLs creates URLs for ALL discovered parameter values (no sampling)
 func buildAllParameterURLs(route *discover.RouteDetails) []string {
 	var allURLs []string
-	baseURL := route.BaseUrl + route.Path
-
-	if len(route.QueryParams) == 0 {
+	if route == nil || route.QueryParams == nil || len(route.QueryParams) == 0 {
 		return allURLs
 	}
 
+	baseURL := route.BaseUrl + route.Path
+
 	// Build URLs with ALL discovered parameter values - no sampling or limits
 	for _, param := range route.QueryParams {
-		if len(param.ExampleValues) > 0 {
+		if param == nil {
+			continue
+		}
+		if param.ExampleValues != nil && len(param.ExampleValues) > 0 {
 			// Test EVERY value for this parameter to ensure complete coverage
 			for _, value := range param.ExampleValues {
 				// For single parameter, create simple query string
@@ -152,7 +155,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		errors = append(errors, "No response body content available")
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
-	if len(httpRequestResponse.Response.RedirectChain) == 0 {
+	if httpRequestResponse.Response.RedirectChain == nil || len(httpRequestResponse.Response.RedirectChain) == 0 {
 		errors = append(errors, "No redirect chain available")
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
@@ -394,6 +397,9 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 
 				// Collect routes to spider
 				for _, route := range routes {
+					if route == nil {
+						continue
+					}
 					// Visit the base route (without parameters)
 					baseRouteURL := route.BaseUrl + route.Path
 					mu.Lock()
@@ -405,7 +411,7 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 					mu.Unlock()
 
 					// Visit routes with ALL their discovered query parameter values (comprehensive testing)
-					if len(route.QueryParams) > 0 {
+					if route.QueryParams != nil && len(route.QueryParams) > 0 {
 						// Build URLs with ALL parameter values - no sampling to ensure complete coverage
 						allParameterURLs := buildAllParameterURLs(route)
 						mu.Lock()

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -66,7 +66,7 @@ func ExtractRedirectRoutes(redirectChain []string, baseURL string, routeCaptureC
 			continue
 		}
 
-		parsedCleanURL, err := url.Parse(urlNoQuery)
+		routeBaseURL, routePath, err := discoverroutehelpers.SplitURLBaseAndPath(urlNoQuery)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("Failed to parse clean redirect URL %s: %s", urlNoQuery, err))
 			continue
@@ -75,8 +75,8 @@ func ExtractRedirectRoutes(redirectChain []string, baseURL string, routeCaptureC
 		urls[urlNoQuery] = struct{}{}
 
 		routeVar := &discover.RouteDetails{
-			BaseUrl:     baseURL,
-			Path:        parsedCleanURL.Path,
+			BaseUrl:     routeBaseURL,
+			Path:        routePath,
 			Method:      common.HttpMethodGet.Ptr(), // Redirects are typically GET
 			QueryParams: queryParams,
 		}
@@ -92,13 +92,13 @@ func buildAllParameterURLs(route *discover.RouteDetails) []string {
 	var allURLs []string
 	baseURL := route.BaseUrl + route.Path
 
-	if route.QueryParams == nil || len(route.QueryParams) == 0 {
+	if len(route.QueryParams) == 0 {
 		return allURLs
 	}
 
 	// Build URLs with ALL discovered parameter values - no sampling or limits
 	for _, param := range route.QueryParams {
-		if param.ExampleValues != nil && len(param.ExampleValues) > 0 {
+		if len(param.ExampleValues) > 0 {
 			// Test EVERY value for this parameter to ensure complete coverage
 			for _, value := range param.ExampleValues {
 				// For single parameter, create simple query string
@@ -152,7 +152,7 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 		errors = append(errors, "No response body content available")
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
-	if httpRequestResponse.Response.RedirectChain == nil || len(httpRequestResponse.Response.RedirectChain) == 0 {
+	if len(httpRequestResponse.Response.RedirectChain) == 0 {
 		errors = append(errors, "No redirect chain available")
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
@@ -168,17 +168,14 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	redirectedURL := httpRequestResponse.Response.RedirectChain[len(httpRequestResponse.Response.RedirectChain)-1]
 	log.Info("Redirected URL", svc1log.SafeParam("url", redirectedURL))
 
-	// Parse the redirected URL to preserve query parameters
-	parsedRedirectedURL, err := url.Parse(redirectedURL)
+	// Use the full page URL for resolving relative paths, but keep BaseUrl output origin-only.
+	redirectedURLBase, _, err := discoverroutehelpers.SplitURLBaseAndPath(redirectedURL)
 	if err != nil {
-		errorMsg := fmt.Sprintf("Failed to parse redirected URL %s: %s", redirectedURL, err)
+		errorMsg := fmt.Sprintf("Failed to split redirected URL %s: %s", redirectedURL, err)
 		log.Error(errorMsg)
 		errors = append(errors, errorMsg)
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
-
-	// Extract base URL (without query parameters for route extraction context)
-	redirectedURLBase := fmt.Sprintf("%s://%s", parsedRedirectedURL.Scheme, parsedRedirectedURL.Host)
 
 	// Helper function to process errors with context
 	processErrors := func(source string, newErrors []string) {
@@ -189,35 +186,35 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 
 	// Extract routes from form elements
 	log.Info("Extracting routes from form elements")
-	formRoutes, formUrls, formErrors := capturerouteextractors.ExtractFormRoutes(doc, redirectedURLBase, routeCaptureConfig)
+	formRoutes, formUrls, formErrors := capturerouteextractors.ExtractFormRoutes(doc, redirectedURL, routeCaptureConfig)
 	routes = append(routes, formRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, formUrls)
 	processErrors("Form Elements", formErrors)
 
 	// Extract routes from anchor elements
 	log.Info("Extracting routes from anchor elements")
-	anchorRoutes, anchorUrls, anchorErrors := capturerouteextractors.ExtractAnchorRoutes(doc, redirectedURLBase, routeCaptureConfig)
+	anchorRoutes, anchorUrls, anchorErrors := capturerouteextractors.ExtractAnchorRoutes(doc, redirectedURL, routeCaptureConfig)
 	routes = append(routes, anchorRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, anchorUrls)
 	processErrors("Anchor Elements", anchorErrors)
 
 	// Extract routes from link elements
 	log.Info("Extracting routes from link elements")
-	linkRoutes, linkUrls, linkErrors := capturerouteextractors.ExtractLinkRoutes(doc, redirectedURLBase, routeCaptureConfig)
+	linkRoutes, linkUrls, linkErrors := capturerouteextractors.ExtractLinkRoutes(doc, redirectedURL, routeCaptureConfig)
 	routes = append(routes, linkRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, linkUrls)
 	processErrors("Link Elements", linkErrors)
 
 	// Extract routes from script elements
 	log.Info("Extracting routes from script elements")
-	scriptRoutes, scriptUrls, scriptErrors := capturerouteextractors.ExtractScriptRoutes(ctx, doc, redirectedURLBase, routeCaptureConfig)
+	scriptRoutes, scriptUrls, scriptErrors := capturerouteextractors.ExtractScriptRoutes(ctx, doc, redirectedURL, routeCaptureConfig)
 	routes = append(routes, scriptRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, scriptUrls)
 	errors = append(errors, scriptErrors...)
 
 	// Extract routes from inline script elements
 	log.Info("Extracting routes from inline script elements")
-	inlineScriptRoutes, inlineScriptUrls, inlineScriptErrors := capturerouteextractors.ExtractInlineScriptRoutes(ctx, doc, redirectedURLBase, routeCaptureConfig)
+	inlineScriptRoutes, inlineScriptUrls, inlineScriptErrors := capturerouteextractors.ExtractInlineScriptRoutes(ctx, doc, redirectedURL, routeCaptureConfig)
 	routes = append(routes, inlineScriptRoutes...)
 	urls = discoverroutehelpers.AddListToSetString(urls, inlineScriptUrls)
 	errors = append(errors, inlineScriptErrors...)
@@ -350,11 +347,14 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 					return
 				}
 
-				// Extract base URL
-				currentBaseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+				// Extract base URL and path
+				currentBaseURL, currentPath, err := discoverroutehelpers.SplitURLBaseAndPath(targetURL)
+				if err != nil {
+					errChan <- fmt.Sprintf("error splitting URL %s: %s", targetURL, err)
+					return
+				}
 
-				// Separate path and query parameters
-				currentPath := parsedURL.Path
+				// Separate query parameters
 				var queryParams map[string]string
 				if parsedURL.RawQuery != "" {
 					queryParams = make(map[string]string)
@@ -405,7 +405,7 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 					mu.Unlock()
 
 					// Visit routes with ALL their discovered query parameter values (comprehensive testing)
-					if route.QueryParams != nil && len(route.QueryParams) > 0 {
+					if len(route.QueryParams) > 0 {
 						// Build URLs with ALL parameter values - no sampling to ensure complete coverage
 						allParameterURLs := buildAllParameterURLs(route)
 						mu.Lock()

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -122,6 +122,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		requestComplete = make(chan struct{})
 		browsersErr     = make(chan error, 1)
 		redirectChain   = []string{*constructedURL}
+		redirectChainMu sync.Mutex
 		browserErr      error
 		statusCode      int
 	)
@@ -154,7 +155,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 
 		// Setup request monitoring and navigate
 		headerCapture := setupHeaderInterception(page)
-		handleNavigation(ctx, page, &redirectChain, requestComplete, &once, config.MaxRedirects, browsersErr)
+		handleNavigation(ctx, page, &redirectChain, &redirectChainMu, requestComplete, &once, config.MaxRedirects, browsersErr)
 
 		navErr := performNavigation(ctx, page, constructedURL, config)
 		if navErr != nil {
@@ -173,13 +174,27 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 			}
 			return
 		case <-requestComplete:
-			log.Info("Request complete, redirect chain", svc1log.SafeParam("chain", strings.Join(redirectChain, " -> ")))
+			redirectChainMu.Lock()
+			chain := strings.Join(redirectChain, " -> ")
+			redirectChainMu.Unlock()
+			log.Info("Request complete, redirect chain", svc1log.SafeParam("chain", chain))
+			select {
+			case err := <-browsersErr:
+				if err != nil {
+					log.Error("Redirect error occurred", svc1log.SafeParam("error", err.Error()))
+					browserErr = err
+				}
+			default:
+			}
 		case <-ctx.Done():
+			redirectChainMu.Lock()
+			chain := strings.Join(redirectChain, " -> ")
+			redirectChainMu.Unlock()
 			if ctx.Err() == context.DeadlineExceeded {
 				log.Warn("Request timed out",
 					svc1log.SafeParam("url", *constructedURL),
 					svc1log.SafeParam("timeout", config.Timeout),
-					svc1log.SafeParam("redirectChain", strings.Join(redirectChain, " -> ")))
+					svc1log.SafeParam("redirectChain", chain))
 				browserErr = fmt.Errorf("request timeout after %d seconds", config.Timeout)
 			} else {
 				log.Warn("Request cancelled",
@@ -193,6 +208,18 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		// =========================================================================================
 		// RESPONSE PROCESSING
 		// =========================================================================================
+
+		// Wait for page to fully load and for client-side routers/auth flows to
+		// settle before reading finalURL or HTML.
+		err = waitForPageLoad(page, b.MinDOMStabalizeTimeSeconds, log)
+		if err != nil {
+			log.Warn("Page stabilization warning", svc1log.SafeParam("error", err.Error()))
+		}
+
+		// Use the latest captured main-document headers after stabilization so
+		// headers, finalURL, and HTML describe the same terminal document.
+		var responseHeaders map[string][]string
+		responseHeaders = getResponseHeaders(ctx, page, headerCapture)
 
 		// Batch JavaScript evaluations for better performance
 		batchJS := `() => {
@@ -210,7 +237,6 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 
 		batchResult, err := page.Eval(batchJS)
 		var finalURL string
-		var responseHeaders map[string][]string
 		var isErrorPage bool
 
 		if err != nil {
@@ -251,31 +277,28 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 			}
 		}
 
-		// Always use the reliable headers extraction method
-		responseHeaders = getResponseHeaders(ctx, page, headerCapture)
-
 		// Redirect Chain
 		if finalURL != "" && !utils.IsStaticAsset(finalURL) {
-			exists := false
-			for _, url := range redirectChain {
-				if url == finalURL {
-					exists = true
-					break
-				}
+			redirectChainMu.Lock()
+			added, redirectErr := appendRedirectURLLocked(&redirectChain, finalURL, config.MaxRedirects)
+			if redirectErr != nil {
+				redirectChainMu.Unlock()
+				browserErr = redirectErr
+				return
 			}
-			if !exists {
-				redirectChain = append(redirectChain, finalURL)
+			if added {
+				chain := strings.Join(redirectChain, " -> ")
+				redirectChainMu.Unlock()
 				log.Info("Adding final URL to chain", svc1log.SafeParam("url", finalURL))
-				log.Info("Updated redirect chain", svc1log.SafeParam("chain", strings.Join(redirectChain, " -> ")))
+				log.Info("Updated redirect chain", svc1log.SafeParam("chain", chain))
+			} else {
+				redirectChainMu.Unlock()
 			}
 		}
+		redirectChainMu.Lock()
 		redirectChain = filterRedirectChain(redirectChain)
-
-		// Wait for page to fully load (optimized)
-		err = waitForPageLoad(page, b.MinDOMStabalizeTimeSeconds, log)
-		if err != nil {
-			log.Warn("Page stabilization warning", svc1log.SafeParam("error", err.Error()))
-		}
+		responseRedirectChain := append([]string(nil), redirectChain...)
+		redirectChainMu.Unlock()
 
 		log.Info("Final URL", svc1log.SafeParam("url", finalURL))
 
@@ -304,7 +327,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		// Build final response
 		response := requesthelpers.CreateHTTPResponse(
 			statusCode,
-			redirectChain,
+			responseRedirectChain,
 			responseHeaders,
 			responseBody,
 		)
@@ -324,9 +347,12 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 	}
 
 	// Check for cross-domain redirect after navigation completes
-	if finalErr == nil && config.IgnoreCrossDomainRedirects && len(redirectChain) > 1 {
-		originalURL := redirectChain[0]
-		for _, chainURL := range redirectChain[1:] {
+	redirectChainMu.Lock()
+	finalRedirectChain := append([]string(nil), redirectChain...)
+	redirectChainMu.Unlock()
+	if finalErr == nil && config.IgnoreCrossDomainRedirects && len(finalRedirectChain) > 1 {
+		originalURL := finalRedirectChain[0]
+		for _, chainURL := range finalRedirectChain[1:] {
 			if isCrossDomainRedirect(originalURL, chainURL) {
 				log.Info("Cross-domain redirect detected in redirect chain", svc1log.SafeParam("from", originalURL), svc1log.SafeParam("to", chainURL))
 				return common.HttpRequestResponse{Request: config.Request}, fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, chainURL)

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -215,6 +215,15 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		if err != nil {
 			log.Warn("Page stabilization warning", svc1log.SafeParam("error", err.Error()))
 		}
+		select {
+		case err := <-browsersErr:
+			if err != nil {
+				log.Error("Redirect error occurred during stabilization", svc1log.SafeParam("error", err.Error()))
+				browserErr = err
+				return
+			}
+		default:
+		}
 
 		// Use the latest captured main-document headers after stabilization so
 		// headers, finalURL, and HTML describe the same terminal document.

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -100,9 +100,6 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 	// Set up event listeners for navigation events and network redirects
 	go page.EachEvent(
 		func(e *proto.NetworkRequestWillBeSent) {
-			if atomic.LoadInt32(&completed) == 1 {
-				return
-			}
 			if e.Type != proto.NetworkResourceTypeDocument || e.RedirectResponse == nil {
 				return
 			}
@@ -121,11 +118,7 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 			if err != nil {
 				redirectChainMu.Unlock()
 				log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)))
-				once.Do(func() {
-					atomic.StoreInt32(&completed, 1)
-					redirectError <- err
-					close(requestComplete)
-				})
+				signalRedirectError(err, redirectError, requestComplete, once, &completed)
 				return
 			}
 			redirectChainMu.Unlock()
@@ -135,10 +128,6 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 		},
 		// Capture HTTP redirect responses at the network level
 		func(e *proto.NetworkResponseReceived) {
-			if atomic.LoadInt32(&completed) == 1 {
-				return
-			}
-
 			// Only capture redirect responses for the main document
 			if e.Type == proto.NetworkResourceTypeDocument && e.Response.Status >= 300 && e.Response.Status < 400 {
 				// Extract the Location header from the redirect response
@@ -151,11 +140,7 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 					if err != nil {
 						redirectChainMu.Unlock()
 						log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)))
-						once.Do(func() {
-							atomic.StoreInt32(&completed, 1)
-							redirectError <- err
-							close(requestComplete)
-						})
+						signalRedirectError(err, redirectError, requestComplete, once, &completed)
 						return
 					}
 					redirectChainMu.Unlock()
@@ -166,9 +151,6 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 			}
 		},
 		func(e *proto.PageFrameNavigated) {
-			if atomic.LoadInt32(&completed) == 1 {
-				return
-			}
 			if e.Frame.ParentID == "" && e.Frame.URL != "" && !utils.IsStaticAsset(e.Frame.URL) {
 				// Check for Chrome error pages
 				if strings.HasPrefix(e.Frame.URL, "chrome-error://") {
@@ -188,11 +170,7 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 				if err != nil {
 					redirectChainMu.Unlock()
 					log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)))
-					once.Do(func() {
-						atomic.StoreInt32(&completed, 1)
-						redirectError <- err
-						close(requestComplete)
-					})
+					signalRedirectError(err, redirectError, requestComplete, once, &completed)
 					return
 				}
 				chain := strings.Join(*redirectChain, " -> ")
@@ -206,10 +184,7 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 						close(requestComplete)
 					})
 				} else {
-					once.Do(func() {
-						atomic.StoreInt32(&completed, 1)
-						close(requestComplete)
-					})
+					log.Debug("Ignoring already-seen top-level frame navigation", svc1log.SafeParam("url", e.Frame.URL))
 				}
 			}
 		},
@@ -257,6 +232,17 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 			}
 		},
 	)()
+}
+
+func signalRedirectError(err error, redirectError chan error, requestComplete chan struct{}, once *sync.Once, completed *int32) {
+	select {
+	case redirectError <- err:
+	default:
+	}
+	once.Do(func() {
+		atomic.StoreInt32(completed, 1)
+		close(requestComplete)
+	})
 }
 
 func appendRedirectURLLocked(redirectChain *[]string, redirectURL string, maxRedirects int) (bool, error) {

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -85,7 +85,7 @@ func setupHeaderInterception(page *rod.Page) *NetworkHeaderCapture {
 }
 
 // handleNavigation sets up tracking for top-level frame navigations
-func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]string, requestComplete chan struct{}, once *sync.Once, maxRedirects int, redirectError chan error) {
+func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]string, redirectChainMu *sync.Mutex, requestComplete chan struct{}, once *sync.Once, maxRedirects int, redirectError chan error) {
 	log := svc1log.FromContext(ctx)
 
 	// Use a simple completion flag to prevent further event processing
@@ -99,48 +99,82 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 
 	// Set up event listeners for navigation events and network redirects
 	go page.EachEvent(
+		func(e *proto.NetworkRequestWillBeSent) {
+			if atomic.LoadInt32(&completed) == 1 {
+				return
+			}
+			if e.Type != proto.NetworkResourceTypeDocument || e.RedirectResponse == nil {
+				return
+			}
+			if e.RedirectResponse.Status < 300 || e.RedirectResponse.Status >= 400 {
+				return
+			}
+
+			locationURL := e.Request.URL
+			if location := headerValue(e.RedirectResponse.Headers, "location"); location != "" {
+				locationURL = resolveRedirectLocation(e.RedirectResponse.URL, location)
+			}
+			log.Debug("Captured HTTP redirect request", svc1log.SafeParam("from", e.RedirectResponse.URL), svc1log.SafeParam("to", locationURL), svc1log.SafeParam("status", e.RedirectResponse.Status))
+
+			redirectChainMu.Lock()
+			added, err := appendRedirectURLLocked(redirectChain, locationURL, maxRedirects)
+			if err != nil {
+				redirectChainMu.Unlock()
+				log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)))
+				once.Do(func() {
+					atomic.StoreInt32(&completed, 1)
+					redirectError <- err
+					close(requestComplete)
+				})
+				return
+			}
+			redirectChainMu.Unlock()
+			if added {
+				log.Debug("Added redirect URL to chain", svc1log.SafeParam("url", locationURL))
+			}
+		},
 		// Capture HTTP redirect responses at the network level
 		func(e *proto.NetworkResponseReceived) {
+			if atomic.LoadInt32(&completed) == 1 {
+				return
+			}
 
 			// Only capture redirect responses for the main document
 			if e.Type == proto.NetworkResourceTypeDocument && e.Response.Status >= 300 && e.Response.Status < 400 {
-				// Check if request is already complete
-				if atomic.LoadInt32(&completed) == 1 {
-					return
-				}
-
 				// Extract the Location header from the redirect response
-				if location, exists := e.Response.Headers["location"]; exists && location.Str() != "" {
-					locationURL := location.Str()
+				if location := headerValue(e.Response.Headers, "location"); location != "" {
+					locationURL := resolveRedirectLocation(e.Response.URL, location)
 					log.Debug("Captured HTTP redirect", svc1log.SafeParam("from", e.Response.URL), svc1log.SafeParam("to", locationURL), svc1log.SafeParam("status", e.Response.Status))
 
-					// Add the redirect destination to the chain if not already present
-					exists := false
-					for _, url := range *redirectChain {
-						if url == locationURL {
-							exists = true
-							break
-						}
+					redirectChainMu.Lock()
+					added, err := appendRedirectURLLocked(redirectChain, locationURL, maxRedirects)
+					if err != nil {
+						redirectChainMu.Unlock()
+						log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)))
+						once.Do(func() {
+							atomic.StoreInt32(&completed, 1)
+							redirectError <- err
+							close(requestComplete)
+						})
+						return
 					}
-					if !exists {
-						*redirectChain = append(*redirectChain, locationURL)
+					redirectChainMu.Unlock()
+					if added {
 						log.Debug("Added redirect URL to chain", svc1log.SafeParam("url", locationURL))
 					}
 				}
 			}
 		},
 		func(e *proto.PageFrameNavigated) {
-			// Check if request is already complete
 			if atomic.LoadInt32(&completed) == 1 {
 				return
 			}
-
 			if e.Frame.ParentID == "" && e.Frame.URL != "" && !utils.IsStaticAsset(e.Frame.URL) {
 				// Check for Chrome error pages
 				if strings.HasPrefix(e.Frame.URL, "chrome-error://") {
 					log.Warn("Navigation resulted in Chrome error page, indicating network/connection failure",
 						svc1log.SafeParam("errorURL", e.Frame.URL),
-						svc1log.SafeParam("originalURL", (*redirectChain)[0]))
+						svc1log.SafeParam("originalURL", firstRedirectURL(redirectChain, redirectChainMu)))
 					// Still complete the request even on error pages
 					once.Do(func() {
 						atomic.StoreInt32(&completed, 1)
@@ -149,46 +183,29 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 					return
 				}
 
-				// Check if URL is already in chain
-				exists := false
-				for _, url := range *redirectChain {
-					if url == e.Frame.URL {
-						exists = true
-						break
-					}
+				redirectChainMu.Lock()
+				added, err := appendRedirectURLLocked(redirectChain, e.Frame.URL, maxRedirects)
+				if err != nil {
+					redirectChainMu.Unlock()
+					log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)))
+					once.Do(func() {
+						atomic.StoreInt32(&completed, 1)
+						redirectError <- err
+						close(requestComplete)
+					})
+					return
 				}
-				if !exists {
-					// Check if this is just a trailing slash redirect
-					if len(*redirectChain) > 0 {
-						lastURL := (*redirectChain)[len(*redirectChain)-1]
-						if utils.IsTrailingSlashRedirect(lastURL, e.Frame.URL) {
-							log.Info("Detected trailing slash redirect, not counting as redirect",
-								svc1log.SafeParam("from", lastURL),
-								svc1log.SafeParam("to", e.Frame.URL))
-							// Update the last URL in the chain but don't add a new entry
-							(*redirectChain)[len(*redirectChain)-1] = e.Frame.URL
-							once.Do(func() {
-								atomic.StoreInt32(&completed, 1)
-								close(requestComplete)
-							})
-							return
-						}
-					}
+				chain := strings.Join(*redirectChain, " -> ")
+				redirectChainMu.Unlock()
 
-					// Check if we've exceeded max redirects
-					// Count actual redirects (excluding initial URL)
-					actualRedirects := len(*redirectChain)
-					if actualRedirects > maxRedirects && maxRedirects >= 0 {
-						log.Info("Max redirects reached", svc1log.SafeParam("maxRedirects", strconv.Itoa(maxRedirects)), svc1log.SafeParam("actualRedirects", strconv.Itoa(actualRedirects)))
-						once.Do(func() {
-							atomic.StoreInt32(&completed, 1)
-							redirectError <- fmt.Errorf("max redirects (%d) exceeded", maxRedirects)
-							close(requestComplete)
-						})
-						return
-					}
-					*redirectChain = append(*redirectChain, e.Frame.URL)
+				if added {
 					log.Info("Top-level frame navigated", svc1log.SafeParam("url", e.Frame.URL))
+					log.Info("Updated redirect chain", svc1log.SafeParam("chain", chain))
+					once.Do(func() {
+						atomic.StoreInt32(&completed, 1)
+						close(requestComplete)
+					})
+				} else {
 					once.Do(func() {
 						atomic.StoreInt32(&completed, 1)
 						close(requestComplete)
@@ -240,6 +257,87 @@ func handleNavigation(ctx context.Context, page *rod.Page, redirectChain *[]stri
 			}
 		},
 	)()
+}
+
+func appendRedirectURLLocked(redirectChain *[]string, redirectURL string, maxRedirects int) (bool, error) {
+	if chainContainsURL(*redirectChain, redirectURL) {
+		return false, nil
+	}
+
+	if len(*redirectChain) > 0 {
+		lastURL := (*redirectChain)[len(*redirectChain)-1]
+		if utils.IsTrailingSlashRedirect(lastURL, redirectURL) {
+			(*redirectChain)[len(*redirectChain)-1] = redirectURL
+			return false, nil
+		}
+	}
+
+	actualRedirects := len(*redirectChain) - 1
+	if actualRedirects >= maxRedirects && maxRedirects >= 0 {
+		return false, fmt.Errorf("max redirects (%d) exceeded", maxRedirects)
+	}
+
+	*redirectChain = append(*redirectChain, redirectURL)
+	return true, nil
+}
+
+func headerValue(headers proto.NetworkHeaders, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value.Str()
+		}
+	}
+	return ""
+}
+
+func resolveRedirectLocation(responseURL, location string) string {
+	base, err := url.Parse(responseURL)
+	if err != nil {
+		return location
+	}
+	next, err := base.Parse(location)
+	if err != nil {
+		return location
+	}
+	return next.String()
+}
+
+func firstRedirectURL(redirectChain *[]string, redirectChainMu *sync.Mutex) string {
+	redirectChainMu.Lock()
+	defer redirectChainMu.Unlock()
+	if len(*redirectChain) == 0 {
+		return ""
+	}
+	return (*redirectChain)[0]
+}
+
+func chainContainsURL(chain []string, candidate string) bool {
+	normalizedCandidate := normalizeDefaultPort(candidate)
+	for _, existing := range chain {
+		if normalizeDefaultPort(existing) == normalizedCandidate {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeDefaultPort(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if port := parsed.Port(); port != "" && isDefaultPort(strings.ToLower(parsed.Scheme), port) {
+		hostname := parsed.Hostname()
+		if strings.Contains(hostname, ":") {
+			hostname = "[" + hostname + "]"
+		}
+		parsed.Host = hostname
+	}
+	return parsed.String()
+}
+
+func isDefaultPort(scheme, port string) bool {
+	return (scheme == "http" && port == "80") || (scheme == "https" && port == "443")
 }
 
 // performNavigation handles the actual page navigation based on config


### PR DESCRIPTION
## Summary

  Fixes HEADLESS page capture redirect tracking and route URL normalization.

  ## Changes

  - Track HEADLESS redirects from both CDP network redirect events and top-level frame navigations.
  - Continue observing navigations through DOM stabilization so SPA/client-side redirects are captured.
  - Enforce `--max-redirects` consistently for HTTP redirects, frame navigations, and final URL reconciliation.
  - Avoid treating default port normalization (`:443` / `:80`) as a new redirect.
  - Detect and block client-side cross-domain redirects when `--ignore-cross-domain-redirects=true`.
  - Restore nil guards in route discovery for `RouteDetails`, `QueryParams`, `RouteQueryParam`, `ExampleValues`, and redirect chains.
  - Keep route URLs query-free by storing params only in `QueryParams`.


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect core discover route identity and headless navigation/redirect semantics used for crawling and capture; behavior shifts (cross-host links, redirect limits, timing) could alter scan coverage without being a security/data-layer change.
> 
> **Overview**
> **Route discovery** now splits each discovered URL into **origin-only** `BaseUrl` and `Path` via `SplitURLBaseAndPath`, instead of reusing the crawl `baseURL` or stuffing the full URL into `BaseUrl`. HTML/JS/network extractors and redirect handling follow that model; post-redirect extraction resolves relative links against the **full** terminal URL while stored routes still use origin + path. `fetch()` handling resolves URLs before allow-list checks, and spidering adds nil guards for routes and query params.
> 
> **Headless capture** rebuilds redirect tracking: mutex-protected chain updates, shared `appendRedirectURLLocked` (dedupe with default-port normalization, trailing-slash collapse, max-redirect enforcement), HTTP redirect capture from `NetworkRequestWillBeSent` / `NetworkResponseReceived` with resolved `Location` headers, DOM stabilization **before** final URL/headers/HTML, and a snapshot of the chain for the response and cross-domain checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6480efc5f3c37e63cf83f7d3c0a7c2d94628500b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->