### PR TITLE
Update Final URL Redirect

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -361,11 +361,10 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 	redirectChainMu.Unlock()
 	if finalErr == nil && config.IgnoreCrossDomainRedirects && len(finalRedirectChain) > 1 {
 		originalURL := finalRedirectChain[0]
-		for _, chainURL := range finalRedirectChain[1:] {
-			if isCrossDomainRedirect(originalURL, chainURL) {
-				log.Info("Cross-domain redirect detected in redirect chain", svc1log.SafeParam("from", originalURL), svc1log.SafeParam("to", chainURL))
-				return common.HttpRequestResponse{Request: config.Request}, fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, chainURL)
-			}
+		finalURL := finalRedirectChain[len(finalRedirectChain)-1]
+		if isCrossDomainRedirect(originalURL, finalURL) {
+			log.Info("Cross-domain redirect detected in redirect chain", svc1log.SafeParam("from", originalURL), svc1log.SafeParam("to", finalURL))
+			return common.HttpRequestResponse{Request: config.Request}, fmt.Errorf("cross-domain redirect blocked: %s -> %s", originalURL, finalURL)
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes redirect policy behavior for headless requests when IgnoreCrossDomainRedirects is enabled, which can allow or block captures differently than before for multi-hop chains.
> 
> **Overview**
> When **`IgnoreCrossDomainRedirects`** is on, headless capture no longer scans every hop in the redirect chain for a cross-domain move. It now compares only the **first** URL in the chain to the **last** (final) URL and blocks only if that pair is cross-domain.
> 
> Same-domain redirects in the middle no longer trigger a block on their own; only the net origin→destination domain change matters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2dcc2a65ce90ba343c92656d7f1d362c385362. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->