### PR TITLE
Align webscan CLI defaults with golden task

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -167,23 +167,14 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 			wordlistSize = strings.ToUpper(wordlistSize)
 
-			wordlistTypeChanged := cmd.Flags().Changed("wordlist-type")
-			wordlistSizeChanged := cmd.Flags().Changed("wordlist-size")
-			if !wordlistTypeChanged {
-				wordlistType = ""
-			}
-			if !wordlistSizeChanged {
-				wordlistSize = ""
-			}
-
 			// Validation: at least one input method must be specified
-			if len(paths) == 0 && !wordlistTypeChanged {
+			if len(paths) == 0 && wordlistType == "" {
 				a.OutputSignal.AddError(fmt.Errorf("at least one of flags 'paths' or 'wordlist-type' must be provided"))
 				return
 			}
 
 			// If wordlist-type is specified, wordlist-size is required
-			if wordlistTypeChanged && !wordlistSizeChanged {
+			if wordlistType != "" && wordlistSize == "" {
 				a.OutputSignal.AddError(fmt.Errorf("when 'wordlist-type' is specified, 'wordlist-size' must also be provided"))
 				return
 			}
@@ -275,8 +266,8 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverDirectoryCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Directory Discovery Flags
 	discoverDirectoryCmd.Flags().StringSlice("paths", []string{}, "Paths to scan")
-	discoverDirectoryCmd.Flags().String("wordlist-type", "DIRECTORIES", "Type of wordlist to use automatically (directories, files)")
-	discoverDirectoryCmd.Flags().String("wordlist-size", "SMALL", "Size of wordlist to use (TINY, SMALL, MEDIUM, LARGE)")
+	discoverDirectoryCmd.Flags().String("wordlist-type", "", "Type of wordlist to use automatically (DIRECTORIES, FILES)")
+	discoverDirectoryCmd.Flags().String("wordlist-size", "", "Size of wordlist to use (TINY, SMALL, MEDIUM, LARGE)")
 	discoverDirectoryCmd.Flags().StringSlice("http-methods", []string{"GET"}, "HTTP methods to use (e.g. GET,POST,PUT)")
 	// Config Flags
 	discoverDirectoryCmd.Flags().String("response-codes", "200-299", "Response codes to consider as valid responses")

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -39,7 +39,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	}
 
 	// General Discover Flags
-	discoverCmd.PersistentFlags().Bool("ignore-cross-domain-redirects", false, "If true, do not follow redirects to a different domain and treat them as errors")
+	discoverCmd.PersistentFlags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 
 	// Application Command
 	discoverApplicationCmd := &cobra.Command{
@@ -120,8 +120,8 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	discoverApplicationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	discoverApplicationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 means no limit)")
-	discoverApplicationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
+	discoverApplicationCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
+	discoverApplicationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")
@@ -167,14 +167,23 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 			wordlistSize = strings.ToUpper(wordlistSize)
 
+			wordlistTypeChanged := cmd.Flags().Changed("wordlist-type")
+			wordlistSizeChanged := cmd.Flags().Changed("wordlist-size")
+			if !wordlistTypeChanged {
+				wordlistType = ""
+			}
+			if !wordlistSizeChanged {
+				wordlistSize = ""
+			}
+
 			// Validation: at least one input method must be specified
-			if len(paths) == 0 && wordlistType == "" {
+			if len(paths) == 0 && !wordlistTypeChanged {
 				a.OutputSignal.AddError(fmt.Errorf("at least one of flags 'paths' or 'wordlist-type' must be provided"))
 				return
 			}
 
 			// If wordlist-type is specified, wordlist-size is required
-			if wordlistType != "" && wordlistSize == "" {
+			if wordlistTypeChanged && !wordlistSizeChanged {
 				a.OutputSignal.AddError(fmt.Errorf("when 'wordlist-type' is specified, 'wordlist-size' must also be provided"))
 				return
 			}
@@ -266,18 +275,18 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverDirectoryCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Directory Discovery Flags
 	discoverDirectoryCmd.Flags().StringSlice("paths", []string{}, "Paths to scan")
-	discoverDirectoryCmd.Flags().String("wordlist-type", "", "Type of wordlist to use automatically (directories, files)")
-	discoverDirectoryCmd.Flags().String("wordlist-size", "", "Size of wordlist to use (TINY, SMALL, MEDIUM, LARGE)")
+	discoverDirectoryCmd.Flags().String("wordlist-type", "DIRECTORIES", "Type of wordlist to use automatically (directories, files)")
+	discoverDirectoryCmd.Flags().String("wordlist-size", "SMALL", "Size of wordlist to use (TINY, SMALL, MEDIUM, LARGE)")
 	discoverDirectoryCmd.Flags().StringSlice("http-methods", []string{"GET"}, "HTTP methods to use (e.g. GET,POST,PUT)")
 	// Config Flags
 	discoverDirectoryCmd.Flags().String("response-codes", "200-299", "Response codes to consider as valid responses")
 	discoverDirectoryCmd.Flags().Bool("ignore-base-content-match", true, "Ignores valid responses with identical size and word length to the base path, typically signifying a web backend redirect")
 	discoverDirectoryCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverDirectoryCmd.Flags().Float64("threshold", 0.25, "Threshold for successful results")
-	discoverDirectoryCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	discoverDirectoryCmd.Flags().Int("timeout", 20, "Timeout per request in seconds")
 	discoverDirectoryCmd.Flags().Int("max-redirects-baseline-request", 10, "Maximum number of redirects to follow for the baseline request")
-	discoverDirectoryCmd.Flags().Int("max-runtime", 0, "Maximum time to run the engagement (seconds) (Default is 0, which will run indefinitely)")
-	discoverDirectoryCmd.Flags().Int("threads", 0, "Number of threads to use")
+	discoverDirectoryCmd.Flags().Int("max-runtime", 650, "Maximum time to run the engagement in seconds")
+	discoverDirectoryCmd.Flags().Int("threads", 25, "Number of threads to use")
 	discoverDirectoryCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	discoverDirectoryCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 
@@ -393,15 +402,15 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverPageCmd.Flags().String("target", "", "URL target to capture and analyze")
 	// Config Flags
-	discoverPageCmd.Flags().Bool("sensitive-content-detection", false, "Enable sensitive content detection")
-	discoverPageCmd.Flags().String("sensitive-content-fingerprints-path", "", "Path to a custom sensitive content fingerprints file (uses built-in fingerprints by default)")
+	discoverPageCmd.Flags().Bool("sensitive-content-detection", true, "Enable sensitive content detection")
+	discoverPageCmd.Flags().String("sensitive-content-fingerprints-path", "", "Path to a custom sensitive content fingerprints file")
 	discoverPageCmd.Flags().String("response-codes", "200-299", "Response codes to consider as valid responses")
 	discoverPageCmd.Flags().Bool("screenshot", false, "Capture a screenshot of the page")
 	discoverPageCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverPageCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
-	discoverPageCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	discoverPageCmd.Flags().Int("timeout", 180, "Timeout per request in seconds")
 	// Request Method Flags for all capture subcommands
-	discoverPageCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
+	discoverPageCmd.Flags().String("request-method", "HEADLESS", "Request method to use (standard, headless, browserbase)")
 	discoverPageCmd.Flags().String("headless-path", "", "Path to headless browser executable")
 	discoverPageCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	discoverPageCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
@@ -483,7 +492,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Config Flags
 	discoverProbeCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverProbeCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
-	discoverProbeCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	discoverProbeCmd.Flags().Int("timeout", 180, "Timeout per request in seconds")
 	// Request Method Flags
 	discoverProbeCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
 	discoverProbeCmd.Flags().String("headless-path", "", "Path to headless browser executable")
@@ -569,15 +578,15 @@ func (a *WebScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverRouteCmd.Flags().String("target", "", "URL target to discover routes from")
 	// Config Flags
-	discoverRouteCmd.Flags().Bool("ignore-cross-domain", false, "Ignore routes that do not share the target's base URL")
+	discoverRouteCmd.Flags().Bool("ignore-cross-domain", true, "Ignore routes that do not share the target's base URL")
 	discoverRouteCmd.Flags().Bool("collect-static-assets", false, "Collect static assets from route discovery")
-	discoverRouteCmd.Flags().Int("spider-depth", 3, "Maximum depth for route spidering")
-	discoverRouteCmd.Flags().Int("max-redirects", 100, "Maximum number of redirects to follow")
+	discoverRouteCmd.Flags().Int("spider-depth", 1, "Maximum depth for route spidering")
+	discoverRouteCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverRouteCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
-	discoverRouteCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	discoverRouteCmd.Flags().Int("timeout", 90, "Timeout per request in seconds")
 	discoverRouteCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 	// Request Method Flags
-	discoverRouteCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
+	discoverRouteCmd.Flags().String("request-method", "HEADLESS", "Request method to use (standard, headless, browserbase)")
 	discoverRouteCmd.Flags().String("headless-path", "", "Path to headless browser executable")
 	discoverRouteCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	discoverRouteCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
@@ -716,8 +725,8 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverSaasCmd.Flags().StringSlice("sso-companies", []string{}, "The specific SSO companies to use for discovery (Must be present in the SSO fingerprints file)")
 	discoverSaasCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverSaasCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
-	discoverSaasCmd.Flags().Int("timeout", 30, "Timeout in seconds for the capture")
-	discoverSaasCmd.Flags().Int("threads", 0, "Number of concurrent threads for discovery (default: number of CPUs)")
+	discoverSaasCmd.Flags().Int("timeout", 90, "Timeout in seconds for the capture")
+	discoverSaasCmd.Flags().Int("threads", 25, "Number of concurrent threads for discovery")
 	// Request Method Flags for all capture subcommands
 	discoverSaasCmd.Flags().String("request-method", "HEADLESS", "Request method (headless, browserbase)")
 	discoverSaasCmd.Flags().String("headless-path", "", "Path to a headless browser executable")

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -289,7 +289,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateCMSWordpressPluginsCmd.Flags().String("plugins-file-size", "SMALL", "Size of the WordPress plugin list to use")
 	enumerateCMSWordpressPluginsCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	enumerateCMSWordpressPluginsCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
+	enumerateCMSWordpressPluginsCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
 
 	// Mark required flags
 	_ = enumerateCMSWordpressPluginsCmd.MarkFlagRequired("targets")
@@ -402,7 +402,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateCMSDrupalModulesCmd.Flags().String("modules-file-size", string(enumeratecmsdrupalfern.ModulesFileSizeSmall), "Size of the Drupal module list to use")
 	enumerateCMSDrupalModulesCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSDrupalModulesCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	enumerateCMSDrupalModulesCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
+	enumerateCMSDrupalModulesCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
 
 	// Mark required flags
 	_ = enumerateCMSDrupalModulesCmd.MarkFlagRequired("targets")
@@ -477,11 +477,11 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Target Flags
 	enumerateGeneralRatelimitCmd.Flags().StringSlice("targets", []string{}, "URL targets to perform rate limit enumeration against")
 	// Config Flags
-	enumerateGeneralRatelimitCmd.Flags().Int("max-requests", 10, "Maximum number of requests to send")
+	enumerateGeneralRatelimitCmd.Flags().Int("max-requests", 100, "Maximum number of requests to send")
 	enumerateGeneralRatelimitCmd.Flags().Int("sleep", 0, "Time window between requests in seconds")
 	enumerateGeneralRatelimitCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
-	enumerateGeneralRatelimitCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	enumerateGeneralRatelimitCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
+	enumerateGeneralRatelimitCmd.Flags().Int("timeout", 5, "Timeout per request in seconds")
+	enumerateGeneralRatelimitCmd.Flags().Int("threads", 100, "Number of concurrent threads for scanning")
 
 	// Mark required flags
 	_ = enumerateGeneralRatelimitCmd.MarkFlagRequired("targets")
@@ -545,7 +545,7 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateContainerRegistryDockerCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateContainerRegistryDockerCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	enumerateContainerRegistryDockerCmd.Flags().Int("threads", 25, "Number of concurrent manifest requests per repository")
+	enumerateContainerRegistryDockerCmd.Flags().Int("threads", 50, "Number of concurrent manifest requests per repository")
 
 	// Mark required flags
 	_ = enumerateContainerRegistryDockerCmd.MarkFlagRequired("targets")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -157,14 +157,14 @@ func (a *WebScan) InitPentestCommand() {
 	// Dast Config Flags
 	pentestApplicationDastCmd.Flags().StringSlice("dast-categories", []string{}, "Dast Categories (ie. XSS, SQLI, RFI, etc.)")
 	pentestApplicationDastCmd.Flags().String("dast-request-params", "", "Base64 JSON blob of request parameters that will be fuzzed")
-	pentestApplicationDastCmd.Flags().StringSlice("http-methods", []string{}, "HTTP methods to use (e.g. GET,POST,PUT)")
+	pentestApplicationDastCmd.Flags().StringSlice("http-methods", []string{"GET", "POST", "PUT"}, "HTTP methods to use (e.g. GET,POST,PUT)")
 	// Config Flags
 	pentestApplicationDastCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	pentestApplicationDastCmd.Flags().Int("threads", 25, "Number of threads")
+	pentestApplicationDastCmd.Flags().Int("threads", 10, "Number of threads")
 	pentestApplicationDastCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationDastCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
+	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
+	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
 
 	// Mark Required Flags
 	_ = pentestApplicationDastCmd.MarkFlagRequired("targets")
@@ -254,13 +254,13 @@ func (a *WebScan) InitPentestCommand() {
 	// Target Flags
 	pentestApplicationCveCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Config Flags
-	pentestApplicationCveCmd.Flags().StringSlice("years", []string{}, "Restrict CVE scans to particular years (default is all available years)")
+	pentestApplicationCveCmd.Flags().StringSlice("years", []string{}, "Restrict CVE scans to particular years")
 	pentestApplicationCveCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	pentestApplicationCveCmd.Flags().Int("threads", 25, "Number of threads")
+	pentestApplicationCveCmd.Flags().Int("threads", 10, "Number of threads")
 	pentestApplicationCveCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationCveCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
+	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
+	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
 
 	// Mark Required Flags
 	_ = pentestApplicationCveCmd.MarkFlagRequired("targets")
@@ -352,8 +352,8 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestApplicationMisconfigurationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationMisconfigurationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
+	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 25, "Global rate limit in requests per second")
+	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 650, "Maximum total scan time in seconds")
 
 	// Mark Required Flags
 	_ = pentestApplicationMisconfigurationCmd.MarkFlagRequired("targets")
@@ -441,11 +441,11 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().StringSlice("technology-types", []string{}, "Technologies to scan for")
 	// Config Flags
 	pentestApplicationTechnologyCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	pentestApplicationTechnologyCmd.Flags().Int("threads", 25, "Number of threads")
+	pentestApplicationTechnologyCmd.Flags().Int("threads", 10, "Number of threads")
 	pentestApplicationTechnologyCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestApplicationTechnologyCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
+	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit in requests per second")
+	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
 
 	// Mark Required Flags
 	_ = pentestApplicationTechnologyCmd.MarkFlagRequired("targets")
@@ -631,9 +631,9 @@ func (a *WebScan) InitPentestCommand() {
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
-	pentestRouteStaticAssetTakeoverCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
+	pentestRouteStaticAssetTakeoverCmd.Flags().Int("threads", 100, "Number of concurrent threads for scanning")
 	// Request Method Flags for all capture subcommands
-	pentestRouteStaticAssetTakeoverCmd.Flags().String("request-method", "STANDARD", "Request method to use (standard, headless, browserbase)")
+	pentestRouteStaticAssetTakeoverCmd.Flags().String("request-method", "HEADLESS", "Request method to use (standard, headless, browserbase)")
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("headless-path", "", "Path to headless browser executable")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Int("min-dom-stabalize-time", 20, "Minimum time to wait for DOM stabilization in seconds")
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("browserbase-token", "", "Browserbase API token for cloud browser access")
@@ -750,14 +750,14 @@ func (a *WebScan) InitPentestCommand() {
 	pentestWafDetectCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Waf Config Flags
 	pentestWafDetectCmd.Flags().String("route-request-params", "", "Base64 JSON blob of request parameters that will be injected")
-	pentestWafDetectCmd.Flags().StringSlice("http-methods", []string{}, "HTTP methods to use (e.g. GET,POST,PUT)")
+	pentestWafDetectCmd.Flags().StringSlice("http-methods", []string{"GET"}, "HTTP methods to use (e.g. GET,POST,PUT)")
 	// Config Flags
-	pentestWafDetectCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	pentestWafDetectCmd.Flags().Int("timeout", 5, "Timeout per request in seconds")
 	pentestWafDetectCmd.Flags().Int("threads", 25, "Number of threads")
 	pentestWafDetectCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
 	pentestWafDetectCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
-	pentestWafDetectCmd.Flags().Int("global-rate-limit", 0, "Global rate limit (requests per second, 0 = no limit)")
-	pentestWafDetectCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds (0 means no timout)")
+	pentestWafDetectCmd.Flags().Int("global-rate-limit", 0, "Global rate limit in requests per second")
+	pentestWafDetectCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
 
 	// Mark Required Flags
 	_ = pentestWafDetectCmd.MarkFlagRequired("targets")

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -21,7 +21,7 @@ webscan discover [command]
 
 The following flag is available on all `discover` subcommands:
 
-- `--ignore-cross-domain-redirects` (bool, default: `false`) — Do not follow redirects to a different domain and treat them as errors
+- `--ignore-cross-domain-redirects` (bool, default: `true`) — Do not follow redirects to a different domain and treat them as errors
 
 ## Commands
 
@@ -43,8 +43,8 @@ Usage:
   webscan discover application [flags]
 
 Flags:
-      --global-rate-limit int   Global rate limit (requests per second, 0 = no limit)
-      --global-timeout int      Maximum total scan time in seconds (0 means no timeout)
+      --global-rate-limit int   Global rate limit in requests per second (default 10)
+      --global-timeout int      Maximum total scan time in seconds
   -h, --help                    help for application
       --proxy string            Optional HTTP proxy URL
       --resource-type string    Type of resource to fingerprint (e.g., web, api, cms) (default "ALL")
@@ -82,18 +82,18 @@ Flags:
       --http-methods strings                 HTTP methods to use (e.g. GET,POST,PUT) (default [GET])
       --ignore-base-content-match            Ignores valid responses with identical size and word length to the base path, typically signifying a web backend redirect (default true)
       --max-redirects-baseline-request int   Maximum number of redirects to follow for the baseline request (default 10)
-      --max-runtime int                      Maximum time to run the engagement (seconds) (Default is 0, which will run indefinitely)
+      --max-runtime int                      Maximum time to run the engagement in seconds (default 650)
       --paths strings                        Paths to scan
       --response-codes string                Response codes to consider as valid responses (default "200-299")
       --retries int                          Number of times to retry a request if it fails
       --sleep int                            Number of seconds to sleep between requests
       --targets strings                      Targets to be scanned
-      --threads int                          Number of threads to use
+      --threads int                          Number of threads to use (default 25)
       --threshold float                      Threshold for successful results (default 0.25)
-      --timeout int                          Timeout per request in seconds (default 30)
+      --timeout int                          Timeout per request in seconds (default 20)
       --verify-tls                           Verify TLS certificates when making HTTPS requests
-      --wordlist-size string                 Size of wordlist to use (TINY, SMALL, MEDIUM, LARGE)
-      --wordlist-type string                 Type of wordlist to use automatically (directories, files)
+      --wordlist-size string                 Size of wordlist to use (TINY, SMALL, MEDIUM, LARGE) (default "SMALL")
+      --wordlist-type string                 Type of wordlist to use automatically (directories, files) (default "DIRECTORIES")
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -128,13 +128,13 @@ Flags:
   -h, --help                                       help for page
       --max-redirects int                          Maximum number of redirects to follow (default 10)
       --min-dom-stabalize-time int                 Minimum time to wait for DOM stabilization in seconds (default 20)
-      --request-method string                      Request method to use (standard, headless, browserbase) (default "STANDARD")
+      --request-method string                      Request method to use (standard, headless, browserbase) (default "HEADLESS")
       --response-codes string                      Response codes to consider as valid responses (default "200-299")
       --screenshot                                 Capture a screenshot of the page
-      --sensitive-content-detection                Enable sensitive content detection
-      --sensitive-content-fingerprints-path string Path to a custom sensitive content fingerprints file (uses built-in fingerprints by default)
+      --sensitive-content-detection                Enable sensitive content detection (default true)
+      --sensitive-content-fingerprints-path string Path to a custom sensitive content fingerprints file
       --target string                              URL target to capture and analyze
-      --timeout int                                Timeout per request in seconds (default 30)
+      --timeout int                                Timeout per request in seconds (default 180)
       --verify-tls                                 Verify TLS certificates when making HTTPS requests
 
 Global Flags:
@@ -173,7 +173,7 @@ Flags:
       --protocol string                 Protocol to use for the probe (HTTP, HTTPS)
       --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
       --targets strings                 URL targets to probe for web applications
-      --timeout int                     Timeout per request in seconds (default 30)
+      --timeout int                     Timeout per request in seconds (default 180)
       --verify-tls                      Verify TLS certificates when making HTTPS requests
 
 Global Flags:
@@ -208,14 +208,14 @@ Flags:
       --collect-static-assets           Collect static assets from route discovery
       --headless-path string            Path to headless browser executable
   -h, --help                            help for route
-      --ignore-cross-domain              Ignore routes that do not share the target's base URL (default false)
-      --max-redirects int               Maximum number of redirects to follow (default 100)
+      --ignore-cross-domain              Ignore routes that do not share the target's base URL (default true)
+      --max-redirects int               Maximum number of redirects to follow (default 10)
       --min-dom-stabalize-time int      Minimum time to wait for DOM stabilization in seconds (default 20)
-      --request-method string           Request method to use (standard, headless, browserbase) (default "STANDARD")
-      --spider-depth int                Maximum depth for route spidering (default 3)
+      --request-method string           Request method to use (standard, headless, browserbase) (default "HEADLESS")
+      --spider-depth int                Maximum depth for route spidering (default 1)
       --target string                   URL target to discover routes from
       --threads int                     Number of concurrent threads for scanning
-      --timeout int                     Timeout per request in seconds (default 30)
+      --timeout int                     Timeout per request in seconds (default 90)
       --verify-tls                      Verify TLS certificates when making HTTPS requests
 
 Global Flags:
@@ -257,8 +257,8 @@ Flags:
       --saas-file-paths strings         Files containing SaaS application fingerprints
       --sso-companies strings           The specific SSO companies to use for discovery (Must be present in the SSO fingerprints file)
       --sso-file-paths strings          Files containing SSO application fingerprints
-      --threads int                     Number of concurrent threads for discovery (default: number of CPUs)
-      --timeout int                     Timeout in seconds for the capture (default 30)
+      --threads int                     Number of concurrent threads for discovery (default 25)
+      --timeout int                     Timeout in seconds for the capture (default 90)
       --verify-tls                      Verify TLS certificates when making HTTPS requests
 
 Global Flags:
@@ -267,4 +267,3 @@ Global Flags:
   -q, --quiet                Suppress output
   -v, --verbose              Verbose output
 ```
-

--- a/docs/docs/enumerate.md
+++ b/docs/docs/enumerate.md
@@ -116,7 +116,7 @@ Flags:
       --plugins-file-paths strings  Paths to files containing WordPress plugin lists
       --plugins-file-size string    Size of the WordPress plugin list to use (default "SMALL")
       --targets strings             URL targets to perform WordPress plugin enumeration against
-      --threads int                 Number of concurrent threads for scanning
+      --threads int                 Number of concurrent threads for scanning (default 50)
       --timeout int                 Timeout per request in seconds (default 30)
       --verify-tls                  Verify TLS certificates when making HTTPS requests
 
@@ -145,7 +145,7 @@ Flags:
       --modules-file-paths strings   Paths to files containing Drupal module lists
       --modules-file-size string     Size of the Drupal module list to use (default "SMALL")
       --targets strings              URL targets to perform Drupal module enumeration against
-      --threads int                  Number of concurrent threads for scanning
+      --threads int                  Number of concurrent threads for scanning (default 50)
       --timeout int                  Timeout per request in seconds (default 30)
       --verify-tls                   Verify TLS certificates when making HTTPS requests
 
@@ -176,7 +176,7 @@ Usage:
 Flags:
   -h, --help              help for docker
       --targets strings   URLs of Docker Container Registries to enumerate
-      --threads int       Number of concurrent manifest requests per repository (default 25)
+      --threads int       Number of concurrent manifest requests per repository (default 50)
       --timeout int       Timeout per request in seconds (default 30)
       --verify-tls        Verify TLS certificates when making HTTPS requests
 
@@ -205,11 +205,11 @@ Usage:
 
 Flags:
   -h, --help                help for ratelimit
-      --max-requests int    Maximum number of requests to send (default 10)
+      --max-requests int    Maximum number of requests to send (default 100)
       --sleep int           Time window between requests in seconds
       --targets strings     URL targets to perform rate limit enumeration against
-      --threads int         Number of concurrent threads for scanning
-      --timeout int         Timeout per request in seconds (default 30)
+      --threads int         Number of concurrent threads for scanning (default 100)
+      --timeout int         Timeout per request in seconds (default 5)
       --verify-tls          Verify TLS certificates when making HTTPS requests
 
 Global Flags:
@@ -218,4 +218,3 @@ Global Flags:
   -q, --quiet                Suppress output
   -v, --verbose              Verbose output
 ```
-

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -36,13 +36,13 @@ Usage:
 Flags:
       --dast-categories strings      Dast Categories (ie. XSS, SQLI, RFI, etc.)
       --dast-request-params string   Base64 JSON blob of request parameters that will be fuzzed
-      --global-rate-limit int        Global rate limit (requests per second, 0 = no limit)
-      --global-timeout int           Maximum total scan time in seconds (0 means no timeout)
+      --global-rate-limit int        Global rate limit in requests per second (default 10)
+      --global-timeout int           Maximum total scan time in seconds
   -h, --help                         help for dast
-      --http-methods strings         HTTP methods to use (e.g. GET,POST,PUT)
+      --http-methods strings         HTTP methods to use (e.g. GET,POST,PUT) (default [GET,POST,PUT])
       --proxy string                 Optional HTTP proxy URL
       --targets strings              Targets to be scanned
-      --threads int                  Number of threads (default 25)
+      --threads int                  Number of threads (default 10)
       --timeout int                  Timeout per request in seconds (default 30)
       --verbose-logs                 Verbose logs
 
@@ -70,15 +70,15 @@ Usage:
   webscan pentest application scan cve [flags]
 
 Flags:
-      --global-rate-limit int  Global rate limit (requests per second, 0 = no limit)
-      --global-timeout int     Maximum total scan time in seconds (0 means no timeout)
+      --global-rate-limit int  Global rate limit in requests per second (default 10)
+      --global-timeout int     Maximum total scan time in seconds
   -h, --help                   help for cve
       --proxy string           Optional HTTP proxy URL
       --targets strings        Targets to be scanned
-      --threads int            Number of threads (default 25)
+      --threads int            Number of threads (default 10)
       --timeout int            Timeout per request in seconds (default 30)
       --verbose-logs           Verbose logs
-      --years strings          Restrict CVE scans to particular years (default is all available years)
+      --years strings          Restrict CVE scans to particular years
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -103,8 +103,8 @@ Usage:
   webscan pentest application scan misconfiguration [flags]
 
 Flags:
-      --global-rate-limit int               Global rate limit (requests per second, 0 = no limit)
-      --global-timeout int                  Maximum total scan time in seconds (0 means no timeout)
+      --global-rate-limit int               Global rate limit in requests per second (default 25)
+      --global-timeout int                  Maximum total scan time in seconds (default 650)
   -h, --help                                help for misconfiguration
       --misconfiguration-categories strings Categories of misconfigurations to scan for
       --proxy string                        Optional HTTP proxy URL
@@ -136,13 +136,13 @@ Usage:
   webscan pentest application scan technology [flags]
 
 Flags:
-      --global-rate-limit int     Global rate limit (requests per second, 0 = no limit)
-      --global-timeout int        Maximum total scan time in seconds (0 means no timeout)
+      --global-rate-limit int     Global rate limit in requests per second
+      --global-timeout int        Maximum total scan time in seconds
   -h, --help                      help for technology
       --proxy string              Optional HTTP proxy URL
       --targets strings           Targets to be scanned
       --technology-types strings  Technologies to scan for
-      --threads int               Number of threads (default 25)
+      --threads int               Number of threads (default 10)
       --timeout int               Timeout per request in seconds (default 30)
       --verbose-logs              Verbose logs
 
@@ -222,10 +222,10 @@ Flags:
   -h, --help                              help for static-asset-takeover
       --max-redirects int                 Maximum number of redirects to follow (default 10)
       --min-dom-stabalize-time int        Minimum time to wait for DOM stabilization in seconds (default 20)
-      --request-method string             Request method to use (standard, headless, browserbase) (default "STANDARD")
+      --request-method string             Request method to use (standard, headless, browserbase) (default "HEADLESS")
       --successful-only                   Only show successful takeover attempts
       --target string                     URL target to analyze for static asset takeover
-      --threads int                       Number of concurrent threads for scanning
+      --threads int                       Number of concurrent threads for scanning (default 100)
       --timeout int                       Timeout per request in seconds (default 30)
       --verify-tls                        Verify TLS certificates when making HTTPS requests
 
@@ -256,15 +256,15 @@ Usage:
   webscan pentest waf detect [flags]
 
 Flags:
-      --global-rate-limit int         Global rate limit (requests per second, 0 = no limit)
-      --global-timeout int            Maximum total scan time in seconds (0 means no timeout)
+      --global-rate-limit int         Global rate limit in requests per second
+      --global-timeout int            Maximum total scan time in seconds
   -h, --help                          help for detect
-      --http-methods strings          HTTP methods to use (e.g. GET,POST,PUT)
+      --http-methods strings          HTTP methods to use (e.g. GET,POST,PUT) (default [GET])
       --proxy string                  Optional HTTP proxy URL
       --route-request-params string   Base64 JSON blob of request parameters that will be injected
       --targets strings               Targets to be scanned
       --threads int                   Number of threads (default 25)
-      --timeout int                   Timeout per request in seconds (default 30)
+      --timeout int                   Timeout per request in seconds (default 5)
       --verbose-logs                  Verbose logs
 
 Global Flags:
@@ -273,4 +273,3 @@ Global Flags:
   -q, --quiet                Suppress output
   -v, --verbose              Verbose output
 ```
-


### PR DESCRIPTION
## Summary
- align webscan CLI defaults with golden task parameters
- preserve explicit CLI validation for directory wordlists and required flags
- clean stale default prose from CLI help

## Tests
- go test ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-only changes alter scan aggressiveness, concurrency, and capture mode without touching auth code, but can surprise operators and increase load on targets when flags are omitted.
> 
> **Overview**
> This PR retunes **default CLI flag values** across `discover`, `enumerate`, and `pentest` (and matching docs) so bare invocations match the golden task profile instead of older “unlimited / standard HTTP” defaults.
> 
> **Discover** defaults now favor **headless** capture and stricter scope on **page** and **route** (e.g. sensitive content on, longer timeouts, `ignore-cross-domain` / cross-domain redirect handling on). **Directory** gets bounded runtime (**650s**), **25** threads, **20s** timeout, and clearer wordlist-type wording. **Application** / several flows pick a **10 req/s** global rate limit where it was previously unlimited.
> 
> **Enumerate** raises default **thread** counts (e.g. **50** for CMS/Docker, **100** for ratelimit) and makes ratelimit tests heavier by default (**100** max requests, **5s** timeout).
> 
> **Pentest** adjusts DAST/CVE (**10** threads, rate limit **10**), misconfiguration scan caps (**25** rps, **650s** timeout), static-asset takeover (**100** threads, headless), and WAF detect (**GET** only, **5s** timeout). Help text drops stale “0 = unlimited” style notes.
> 
> Directory **wordlist** behavior is unchanged: users still must pass **`paths` or `wordlist-type`** (and size when using wordlists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7b0c69116b904676d519612d8e280681182896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->