### PR TITLE
Add --user-agent flag to enumerate commands

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"errors"
 	// Generated
+	common "github.com/Method-Security/webscan/generated/go/common"
 	enumerateapiapplicationfern "github.com/Method-Security/webscan/generated/go/enumerate/apiapplication"
 	enumeratecmsdrupalfern "github.com/Method-Security/webscan/generated/go/enumerate/cms/drupal"
 	enumeratecmswordpressfern "github.com/Method-Security/webscan/generated/go/enumerate/cms/wordpress"
@@ -22,6 +23,7 @@ import (
 	"github.com/Method-Security/webscan/configs"
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
+	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	// External
 	cobra "github.com/spf13/cobra"
 )
@@ -72,6 +74,8 @@ func (a *WebScan) InitEnumerateCommand() {
 
 	// Target Flags
 	enumerateAPIApplicationGraphqlCmd.Flags().String("target", "", "URL target to perform GraphQL enumeration against")
+	// TODO: Add --user-agent flag here once graphql is migrated to the standard HTTP client.
+	// Skipped for now because graphql uses http.Post directly instead of SendHTTPRequest.
 
 	// Mark required flags
 	_ = enumerateAPIApplicationGraphqlCmd.MarkFlagRequired("target")
@@ -108,9 +112,17 @@ func (a *WebScan) InitEnumerateCommand() {
 				return
 			}
 
+			// User Agent flag
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			config := enumerateapiapplicationfern.EnumerateSwaggerConfig{
-				Target:  target,
-				Timeout: timeout,
+				Target:    target,
+				Timeout:   timeout,
+				UserAgent: userAgentPreset,
 			}
 
 			// Generate report
@@ -123,6 +135,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateAPIApplicationSwaggerCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	enumerateAPIApplicationSwaggerCmd.Flags().String("headless-path", "", "Path to headless browser executable")
+	// User Agent Flag
+	enumerateAPIApplicationSwaggerCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	_ = enumerateAPIApplicationSwaggerCmd.MarkFlagRequired("target")
 
@@ -159,8 +173,15 @@ func (a *WebScan) InitEnumerateCommand() {
 				return
 			}
 
+			// User Agent flag
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set Config
-			config := getEnumerateKubeConfig(target, verifyTLS, timeout)
+			config := getEnumerateKubeConfig(target, verifyTLS, timeout, userAgentPreset)
 
 			// Generate report
 			report := enumeratekube.PerformAppEnumerateKube(cmd.Context(), &config)
@@ -172,6 +193,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateKubeCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateKubeCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	// User Agent Flag
+	enumerateKubeCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark required flags
 	_ = enumerateKubeCmd.MarkFlagRequired("target")
@@ -273,8 +296,15 @@ func (a *WebScan) InitEnumerateCommand() {
 				return
 			}
 
+			// User Agent flag
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Generate config
-			config := getEnumerateWordpressPluginsConfig(targets, plugins, PluginsFileSizeEnum, verifyTLS, timeout, threads)
+			config := getEnumerateWordpressPluginsConfig(targets, plugins, PluginsFileSizeEnum, verifyTLS, timeout, threads, userAgentPreset)
 
 			// Generate report
 			report := enumeratecms.PerformAppEnumerateCMSWordpressPlugins(cmd.Context(), config)
@@ -290,6 +320,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateCMSWordpressPluginsCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
+	// User Agent Flag
+	enumerateCMSWordpressPluginsCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark required flags
 	_ = enumerateCMSWordpressPluginsCmd.MarkFlagRequired("targets")
@@ -386,8 +418,15 @@ func (a *WebScan) InitEnumerateCommand() {
 				return
 			}
 
+			// User Agent flag
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Generate config
-			config := getEnumerateDrupalModulesConfig(targets, modules, modulesFileSizeEnum, verifyTLS, timeout, threads)
+			config := getEnumerateDrupalModulesConfig(targets, modules, modulesFileSizeEnum, verifyTLS, timeout, threads, userAgentPreset)
 
 			// Generate report
 			report := enumeratecms.PerformAppEnumerateCMSDrupalModules(cmd.Context(), config)
@@ -403,6 +442,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateCMSDrupalModulesCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSDrupalModulesCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	enumerateCMSDrupalModulesCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
+	// User Agent Flag
+	enumerateCMSDrupalModulesCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark required flags
 	_ = enumerateCMSDrupalModulesCmd.MarkFlagRequired("targets")
@@ -466,8 +507,15 @@ func (a *WebScan) InitEnumerateCommand() {
 				return
 			}
 
+			// User Agent flag
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Generate config
-			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, sleep, verifyTLS, timeout, threads)
+			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, sleep, verifyTLS, timeout, threads, userAgentPreset)
 
 			// Generate report
 			report := enumerategeneral.PerformGeneralRatelimit(cmd.Context(), &config)
@@ -482,6 +530,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateGeneralRatelimitCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateGeneralRatelimitCmd.Flags().Int("timeout", 5, "Timeout per request in seconds")
 	enumerateGeneralRatelimitCmd.Flags().Int("threads", 100, "Number of concurrent threads for scanning")
+	// User Agent Flag
+	enumerateGeneralRatelimitCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark required flags
 	_ = enumerateGeneralRatelimitCmd.MarkFlagRequired("targets")
@@ -532,8 +582,15 @@ func (a *WebScan) InitEnumerateCommand() {
 				return
 			}
 
+			// User Agent flag
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Generate config
-			config := getEnumerateDockerConfig(targets, verifyTLS, timeout, threads)
+			config := getEnumerateDockerConfig(targets, verifyTLS, timeout, threads, userAgentPreset)
 
 			// Generate report
 			report := enumeratedocker.PerformAppEnumerateContainerRegistryDocker(cmd.Context(), &config)
@@ -546,6 +603,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateContainerRegistryDockerCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateContainerRegistryDockerCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	enumerateContainerRegistryDockerCmd.Flags().Int("threads", 50, "Number of concurrent manifest requests per repository")
+	// User Agent Flag
+	enumerateContainerRegistryDockerCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark required flags
 	_ = enumerateContainerRegistryDockerCmd.MarkFlagRequired("targets")
@@ -561,7 +620,7 @@ func (a *WebScan) InitEnumerateCommand() {
 }
 
 // getEnumerateWordpressPluginsConfig builds the config for WordPress plugin enumeration.
-func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, PluginsFileSizeEnum enumeratecmswordpressfern.PluginsFileSize, verifyTLS bool, timeout int, threads int) enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
+func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, PluginsFileSizeEnum enumeratecmswordpressfern.PluginsFileSize, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
 	config := enumeratecmswordpressfern.EnumerateWordpressPluginsConfig{
 		Targets:         targets,
 		Plugins:         plugins,
@@ -569,22 +628,24 @@ func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, Plug
 		VerifyTls:       verifyTLS,
 		Timeout:         max(timeout, 0),
 		Threads:         max(threads, 0),
+		UserAgent:       userAgent,
 	}
 	return config
 }
 
 // getEnumerateKubeConfig builds the config for Kubernetes enumeration.
-func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int) enumeratekubefern.EnumerateKubeConfig {
+func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) enumeratekubefern.EnumerateKubeConfig {
 	config := enumeratekubefern.EnumerateKubeConfig{
 		Target:    target,
 		VerifyTls: verifyTLS,
 		Timeout:   max(timeout, 0),
+		UserAgent: userAgent,
 	}
 	return config
 }
 
 // getEnumerateGeneralRateLimitConfig builds the config for general rate limit enumeration.
-func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, sleep int, verifyTLS bool, timeout int, threads int) enumerategeneralfern.EnumerateRateLimitConfig {
+func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, sleep int, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) enumerategeneralfern.EnumerateRateLimitConfig {
 	config := enumerategeneralfern.EnumerateRateLimitConfig{
 		Targets:     targets,
 		MaxRequests: maxRequests,
@@ -592,23 +653,25 @@ func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, sleep
 		VerifyTls:   verifyTLS,
 		Timeout:     max(timeout, 0),
 		Threads:     max(threads, 0),
+		UserAgent:   userAgent,
 	}
 	return config
 }
 
 // getEnumerateDockerConfig builds the config for Docker registry enumeration.
-func getEnumerateDockerConfig(targets []string, verifyTLS bool, timeout int, threads int) enumeratedockerfern.EnumerateDockerConfig {
+func getEnumerateDockerConfig(targets []string, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) enumeratedockerfern.EnumerateDockerConfig {
 	config := enumeratedockerfern.EnumerateDockerConfig{
 		Targets:   targets,
 		VerifyTls: verifyTLS,
 		Timeout:   max(timeout, 0),
 		Threads:   max(threads, 1),
+		UserAgent: userAgent,
 	}
 	return config
 }
 
 // getEnumerateDrupalModulesConfig builds the config for Drupal module enumeration.
-func getEnumerateDrupalModulesConfig(targets []string, modules []string, modulesFileSizeEnum enumeratecmsdrupalfern.ModulesFileSize, verifyTLS bool, timeout int, threads int) enumeratecmsdrupalfern.EnumerateDrupalModulesConfig {
+func getEnumerateDrupalModulesConfig(targets []string, modules []string, modulesFileSizeEnum enumeratecmsdrupalfern.ModulesFileSize, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) enumeratecmsdrupalfern.EnumerateDrupalModulesConfig {
 	config := enumeratecmsdrupalfern.EnumerateDrupalModulesConfig{
 		Targets:         targets,
 		Modules:         modules,
@@ -616,6 +679,7 @@ func getEnumerateDrupalModulesConfig(targets []string, modules []string, modules
 		VerifyTls:       verifyTLS,
 		Timeout:         max(timeout, 0),
 		Threads:         max(threads, 0),
+		UserAgent:       userAgent,
 	}
 	return config
 }

--- a/fern/definition/enumerate/apiapplication/swagger.yml
+++ b/fern/definition/enumerate/apiapplication/swagger.yml
@@ -1,10 +1,12 @@
 imports:
   common: ./common.yml
+  method: ../../common/method.yml
 types:
   EnumerateSwaggerConfig:
     properties:
       target: string
       timeout: integer
+      userAgent: method.UserAgentPreset
   EnumerateSwaggerResult:
     properties:
       apiType: common.ApiType

--- a/fern/definition/enumerate/cms/drupal/modules.yml
+++ b/fern/definition/enumerate/cms/drupal/modules.yml
@@ -1,3 +1,5 @@
+imports:
+    method: ../../../common/method.yml
 types:
     # Enums
     ModulesFileSize:
@@ -34,6 +36,7 @@ types:
             verifyTls: boolean
             timeout: integer
             threads: integer
+            userAgent: method.UserAgentPreset
     # Result
     EnumerateDrupalModulesResult:
         properties:

--- a/fern/definition/enumerate/cms/wordpress/plugins.yml
+++ b/fern/definition/enumerate/cms/wordpress/plugins.yml
@@ -1,3 +1,5 @@
+imports:
+    method: ../../../common/method.yml
 types:
     # Function Config Struct
     PluginsFileSize:
@@ -12,6 +14,7 @@ types:
             verifyTls: boolean
             timeout: integer
             threads: integer
+            userAgent: method.UserAgentPreset
     # Fingerprint File Struct
     DetectionSource:
         enum:

--- a/fern/definition/enumerate/containerregistry/docker.yml
+++ b/fern/definition/enumerate/containerregistry/docker.yml
@@ -1,5 +1,6 @@
 imports:
   http: ../../common/http.yml
+  method: ../../common/method.yml
 types:
   # Config Struct
   EnumerateDockerConfig:
@@ -8,6 +9,7 @@ types:
       verifyTls: boolean
       timeout: integer
       threads: integer
+      userAgent: method.UserAgentPreset
   # Docker Registry V2 API Response Objects
   DockerManifestDescriptor:
     properties:

--- a/fern/definition/enumerate/general/ratelimit.yml
+++ b/fern/definition/enumerate/general/ratelimit.yml
@@ -1,5 +1,6 @@
 imports:
   http: ../../common/http.yml
+  method: ../../common/method.yml
   wafdetect: ../../pentest/waf/detect.yml
 types:
   # Config Struct
@@ -11,6 +12,7 @@ types:
       verifyTls: boolean
       timeout: integer
       threads: integer
+      userAgent: method.UserAgentPreset
   # Report Struct
   RateLimitAttempt:
     properties:

--- a/fern/definition/enumerate/kube/kube.yml
+++ b/fern/definition/enumerate/kube/kube.yml
@@ -1,5 +1,6 @@
 imports:
   http: ../../common/http.yml
+  method: ../../common/method.yml
 types:
   # Function Config Struct
   EnumerateKubeConfig:
@@ -7,6 +8,7 @@ types:
       target: string
       verifyTls: boolean
       timeout: integer
+      userAgent: method.UserAgentPreset
   EnumerateKubeResult:
     properties:
       target: string

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -109,7 +109,7 @@ func generateSpecPaths() []string {
 	return paths
 }
 
-func createSendHTTPRequestConfig(baseURL, path string, timeout int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, timeout int, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -121,6 +121,7 @@ func createSendHTTPRequestConfig(baseURL, path string, timeout int, requestMetho
 		MaxRedirects:       1,
 		VerifyTls:          false,
 		Timeout:            timeout,
+		UserAgent:          userAgent,
 		RequestMethod:      requestMethod,
 		HeadlessConfig:     headlessConfig,
 		BrowserbaseConfig:  nil,
@@ -209,7 +210,7 @@ func isLikelySpecURL(url string) bool {
 // findOpenAPISpec attempts to locate a valid OpenAPI/Swagger specification
 // First checks if target is a Swagger UI page, then uses headless if needed,
 // otherwise falls back to trying common endpoint paths.
-func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPath string) (string, []byte, map[string]interface{}, error) {
+func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPath string, userAgent common.UserAgentPreset) (string, []byte, map[string]interface{}, error) {
 	baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(target)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to split target URL: %w", err)
@@ -220,7 +221,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPa
 	}
 
 	// STEP 1: Make a standard request to check if target is a Swagger UI page
-	requestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, common.RequestMethodStandard, nil)
+	requestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, userAgent, common.RequestMethodStandard, nil)
 	response, err := request.SendRequest(ctx, requestConfig)
 
 	if err == nil && response.Response != nil && response.Response.StatusCode != nil &&
@@ -236,7 +237,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPa
 					MinDomStabalizeTime: 5,
 				}
 
-				headlessRequestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, common.RequestMethodHeadless, headlessConfig)
+				headlessRequestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, userAgent, common.RequestMethodHeadless, headlessConfig)
 				headlessResponse, err := request.SendRequest(ctx, headlessRequestConfig)
 
 				if err == nil && headlessResponse.Response != nil && headlessResponse.Response.StatusCode != nil &&
@@ -261,7 +262,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPa
 							}
 
 							// Make request to the extracted spec URL
-							specRequestConfig := createSendHTTPRequestConfig(baseURL, specPath, timeout, common.RequestMethodStandard, nil)
+							specRequestConfig := createSendHTTPRequestConfig(baseURL, specPath, timeout, userAgent, common.RequestMethodStandard, nil)
 							specResponse, err := request.SendRequest(ctx, specRequestConfig)
 							if err != nil {
 								continue
@@ -286,7 +287,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPa
 
 						// If no extracted URLs worked, try common paths as fallback
 						for _, path := range generateSpecPaths() {
-							specRequestConfig := createSendHTTPRequestConfig(baseURL, path, timeout, common.RequestMethodStandard, nil)
+							specRequestConfig := createSendHTTPRequestConfig(baseURL, path, timeout, userAgent, common.RequestMethodStandard, nil)
 							specResponse, err := request.SendRequest(ctx, specRequestConfig)
 							if err != nil {
 								continue
@@ -322,7 +323,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, headlessPa
 		}
 
 		// Create a request config for the Swagger/OpenAPI spec and send the request
-		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), timeout, common.RequestMethodStandard, nil)
+		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), timeout, userAgent, common.RequestMethodStandard, nil)
 		request, err := request.SendRequest(ctx, requestConfig)
 		if err != nil {
 			continue // Try next path on request failure
@@ -359,7 +360,7 @@ func PerformAppEnumerateSwagger(ctx context.Context, config enumerateapiapplicat
 	target := strings.TrimSuffix(config.Target, "/")
 
 	// Try to find a valid Swagger/OpenAPI spec
-	swaggerURL, bodyBytes, docType, err := findOpenAPISpec(ctx, target, config.Timeout, headlessPath)
+	swaggerURL, bodyBytes, docType, err := findOpenAPISpec(ctx, target, config.Timeout, headlessPath, config.UserAgent)
 	if err != nil {
 		report.Errors = append(report.Errors, err.Error())
 		return report

--- a/internal/enumerate/cms/drupal.go
+++ b/internal/enumerate/cms/drupal.go
@@ -57,6 +57,7 @@ func createDrupalSendHTTPRequestConfig(baseURL, path string, method common.HttpM
 		MaxRedirects:       0,
 		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
+		UserAgent:          config.UserAgent,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,
 		BrowserbaseConfig:  nil,

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -41,6 +41,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratecmswordp
 		MaxRedirects:       0,
 		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
+		UserAgent:          config.UserAgent,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,
 		BrowserbaseConfig:  nil,

--- a/internal/enumerate/containerregistry/docker.go
+++ b/internal/enumerate/containerregistry/docker.go
@@ -84,7 +84,7 @@ func selectPlatformDigest(manifests []interface{}) string {
 
 // fetchPlatformManifestSize resolves a manifest list entry by fetching the
 // platform-specific v2 manifest and computing total size from config + layers.
-func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platformDigest string, verifyTLS bool, timeout int) *int {
+func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platformDigest string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) *int {
 	log := svc1log.FromContext(ctx)
 
 	manifestURL := strings.TrimSuffix(targetURL, "/") + "/v2/" + repository + "/manifests/" + platformDigest
@@ -98,7 +98,7 @@ func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platf
 		"application/vnd.docker.distribution.manifest.v2+json",
 		"application/vnd.oci.image.manifest.v1+json",
 	}
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, acceptHeaders)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, acceptHeaders)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -120,7 +120,7 @@ func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platf
 	return nil
 }
 
-func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]string, verifyTLS bool, timeout int, acceptHeaders []string) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset, acceptHeaders []string) common.SendHttpRequestConfig {
 	// Base Headers
 	headers := map[string][]string{
 		"Accept": {"application/json"},
@@ -144,6 +144,7 @@ func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]st
 		MaxRedirects:       0,
 		VerifyTls:          verifyTLS,
 		Timeout:            timeout,
+		UserAgent:          userAgent,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,
 		BrowserbaseConfig:  nil,
@@ -152,7 +153,7 @@ func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]st
 }
 
 // enumerateRepositories gets the list of repositories from the registry
-func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool, timeout int) ([]string, *common.HttpRequestResponse, error) {
+func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) ([]string, *common.HttpRequestResponse, error) {
 	log := svc1log.FromContext(ctx)
 
 	catalogURL := strings.TrimSuffix(targetURL, "/") + "/v2/_catalog"
@@ -163,7 +164,7 @@ func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool
 		return nil, nil, err
 	}
 
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, nil)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, nil)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -194,7 +195,7 @@ func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool
 }
 
 // getImageTags retrieves tags for a specific image repository
-func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS bool, timeout int) ([]string, []*common.HttpRequestResponse, error) {
+func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) ([]string, []*common.HttpRequestResponse, error) {
 	log := svc1log.FromContext(ctx)
 	var requests []*common.HttpRequestResponse
 
@@ -206,7 +207,7 @@ func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS b
 		return nil, requests, err
 	}
 
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, nil)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, nil)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -237,7 +238,7 @@ func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS b
 }
 
 // getImageManifest retrieves the manifest for a specific image:tag and returns the digest, manifest content, size, and requests.
-func getImageManifest(ctx context.Context, targetURL, repository, tag string, verifyTLS bool, timeout int) (string, string, *int, []*common.HttpRequestResponse, error) {
+func getImageManifest(ctx context.Context, targetURL, repository, tag string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) (string, string, *int, []*common.HttpRequestResponse, error) {
 	log := svc1log.FromContext(ctx)
 	var requests []*common.HttpRequestResponse
 
@@ -254,7 +255,7 @@ func getImageManifest(ctx context.Context, targetURL, repository, tag string, ve
 		"application/vnd.oci.image.manifest.v1+json",
 		"application/vnd.oci.image.index.v1+json",
 	}
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, acceptHeaders)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, acceptHeaders)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -294,7 +295,7 @@ func getImageManifest(ctx context.Context, targetURL, repository, tag string, ve
 								svc1log.SafeParam("repository", repository),
 								svc1log.SafeParam("tag", tag),
 								svc1log.SafeParam("platformDigest", platformDigest))
-							totalSize = fetchPlatformManifestSize(ctx, targetURL, repository, platformDigest, verifyTLS, timeout)
+							totalSize = fetchPlatformManifestSize(ctx, targetURL, repository, platformDigest, verifyTLS, timeout, userAgent)
 						}
 					}
 				}
@@ -306,13 +307,13 @@ func getImageManifest(ctx context.Context, targetURL, repository, tag string, ve
 }
 
 // processRepository handles enumeration for a single repository: fetching tags, manifests, and computing sizes.
-func processRepository(ctx context.Context, targetURL, repoName string, verifyTLS bool, timeout int, wg *sync.WaitGroup, results chan<- *enumeratedockerfern.ContainerRepository, errors chan<- string) {
+func processRepository(ctx context.Context, targetURL, repoName string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset, wg *sync.WaitGroup, results chan<- *enumeratedockerfern.ContainerRepository, errors chan<- string) {
 	defer wg.Done()
 	log := svc1log.FromContext(ctx)
 	log.Info("Processing repository", svc1log.SafeParam("repository", repoName))
 
 	// Step 2: Retrieve available tags
-	tags, _, err := getImageTags(ctx, targetURL, repoName, verifyTLS, timeout)
+	tags, _, err := getImageTags(ctx, targetURL, repoName, verifyTLS, timeout, userAgent)
 	if err != nil {
 		errors <- fmt.Sprintf("Failed to get tags for repository %s: %v", repoName, err)
 		return
@@ -331,7 +332,7 @@ func processRepository(ctx context.Context, targetURL, repoName string, verifyTL
 
 	// Step 3: For each tag, fetch the manifest and digest
 	for _, tag := range tags {
-		digest, manifestContent, size, _, err := getImageManifest(ctx, targetURL, repoName, tag, verifyTLS, timeout)
+		digest, manifestContent, size, _, err := getImageManifest(ctx, targetURL, repoName, tag, verifyTLS, timeout, userAgent)
 		if err != nil {
 			errors <- fmt.Sprintf("Failed to get manifest for %s:%s: %v", repoName, tag, err)
 			continue
@@ -384,11 +385,11 @@ func processRepository(ctx context.Context, targetURL, repoName string, verifyTL
 // Step 2: For each repository, hit /v2/{repo}/tags/list to retrieve available tags.
 // Step 3: For each tag, hit /v2/{repo}/manifests/{tag} to fetch the manifest and digest.
 // Step 4: Group images by digest so tags pointing to the same image are consolidated.
-func enumerateTarget(ctx context.Context, targetURL string, verifyTLS bool, timeout int, threads int) (*enumeratedockerfern.EnumerateDockerResult, []string) {
+func enumerateTarget(ctx context.Context, targetURL string, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) (*enumeratedockerfern.EnumerateDockerResult, []string) {
 	log := svc1log.FromContext(ctx)
 
 	// Step 1: Hit /v2/_catalog to list all repositories
-	repositories, catalogRequest, err := enumerateRepositories(ctx, targetURL, verifyTLS, timeout)
+	repositories, catalogRequest, err := enumerateRepositories(ctx, targetURL, verifyTLS, timeout, userAgent)
 	if err != nil {
 		return nil, []string{fmt.Sprintf("Failed to enumerate repositories: %v", err)}
 	}
@@ -424,7 +425,7 @@ func enumerateTarget(ctx context.Context, targetURL string, verifyTLS bool, time
 		semaphore <- struct{}{}
 		go func(repo string) {
 			defer func() { <-semaphore }()
-			processRepository(ctx, targetURL, repo, verifyTLS, timeout, &wg, results, errorsChan)
+			processRepository(ctx, targetURL, repo, verifyTLS, timeout, userAgent, &wg, results, errorsChan)
 		}(repoName)
 	}
 
@@ -475,7 +476,7 @@ func PerformAppEnumerateContainerRegistryDocker(ctx context.Context, config *enu
 	errors := []string{}
 
 	for _, targetURL := range config.Targets {
-		result, errs := enumerateTarget(ctx, targetURL, config.VerifyTls, config.Timeout, config.Threads)
+		result, errs := enumerateTarget(ctx, targetURL, config.VerifyTls, config.Timeout, config.Threads, config.UserAgent)
 		if result != nil {
 			targets = append(targets, result)
 		}

--- a/internal/enumerate/general/ratelimit.go
+++ b/internal/enumerate/general/ratelimit.go
@@ -69,6 +69,7 @@ func createRateLimitRequestConfig(baseURL, path string, queryParams map[string]s
 		MaxRedirects:       0,
 		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
+		UserAgent:          config.UserAgent,
 		RequestMethod:      common.RequestMethodStandard,
 		BrowserbaseSecrets: nil,
 		HeadlessConfig:     nil,

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -16,7 +16,7 @@ import (
 
 var commonKubepaths = []string{"/api", "/livez", "/version"}
 
-func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -28,6 +28,7 @@ func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout i
 		MaxRedirects:       0,
 		VerifyTls:          verifyTLS,
 		Timeout:            timeout,
+		UserAgent:          userAgent,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,
 		BrowserbaseConfig:  nil,
@@ -53,7 +54,7 @@ func PerformAppEnumerateKube(ctx context.Context, config *enumeratekubefern.Enum
 	requests := []*common.HttpRequestResponse{}
 	for _, path := range commonKubepaths {
 		// Create Request Config
-		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.VerifyTls, config.Timeout)
+		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.VerifyTls, config.Timeout, config.UserAgent)
 
 		// Send Request
 		request, err := request.SendRequest(ctx, requestConfig)


### PR DESCRIPTION
Extends the UserAgentPreset flag (introduced in #379) to all enumerate commands that use the standard HTTP client:
- enumerate api-application swagger
- enumerate cms wordpress plugins
- enumerate cms drupal modules
- enumerate kube
- enumerate general ratelimit
- enumerate container-registry docker

Skipped with a TODO comment:
- enumerate api-application graphql (uses http.Post directly, not the standard request helper)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and HTTP client header configuration across enumeration modules; GraphQL intentionally unchanged.
> 
> **Overview**
> Adds a **`--user-agent`** CLI flag (default **`RANDOM`**, presets **CHROME / FIREFOX / SAFARI / EDGE**) to most **`enumerate`** subcommands that use the standard HTTP stack, and threads the chosen **`UserAgentPreset`** through Fern configs into **`SendHttpRequestConfig`** for outbound scans.
> 
> **Covered:** `api-application swagger`, `cms wordpress plugins`, `cms drupal modules`, `kube`, `general ratelimit`, and `container-registry docker` (CLI in `cmd/enumerate.go`, schema in `fern/definition/enumerate/*`, implementation in matching `internal/enumerate/*` packages).
> 
> **Not covered:** `enumerate api-application graphql` — left with a **TODO** until it moves off direct `http.Post` to the shared request helper.
> 
> **Risk:** Low — additive request metadata and CLI/config plumbing; no auth or data-model changes beyond new config fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f491205138b996dc9f45e0c14e3d9e80bc5582d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->