### PR TITLE
Add --user-agent flag to pentest commands

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -47,6 +47,9 @@ func (a *WebScan) InitPentestCommand() {
 	}
 
 	// Dast Command
+	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
+	// which manages its own HTTP client and does not honor the UserAgentPreset.
+	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationDastCmd := &cobra.Command{
 		Use:   "dast",
 		Short: "Dast targets to discover previously unknown vulnerabilities",
@@ -182,6 +185,9 @@ func (a *WebScan) InitPentestCommand() {
 	}
 
 	// CVE Scan Command
+	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
+	// which manages its own HTTP client and does not honor the UserAgentPreset.
+	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationCveCmd := &cobra.Command{
 		Use:   "cve",
 		Short: "Scan targets for CVEs",
@@ -269,6 +275,9 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationScanCmd.AddCommand(pentestApplicationCveCmd)
 
 	// Misconfiguration Scan Command
+	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
+	// which manages its own HTTP client and does not honor the UserAgentPreset.
+	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationMisconfigurationCmd := &cobra.Command{
 		Use:   "misconfiguration",
 		Short: "Scan targets for security misconfigurations",
@@ -362,6 +371,9 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationScanCmd.AddCommand(pentestApplicationMisconfigurationCmd)
 
 	// Technologies Scan Command
+	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
+	// which manages its own HTTP client and does not honor the UserAgentPreset.
+	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationTechnologyCmd := &cobra.Command{
 		Use:   "technology",
 		Short: "Scan targets for technology-specific vulnerabilities",
@@ -513,9 +525,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgent, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Load configuration
-			config := getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets, successfulOnly, verifyTLS, timeout, retries, sleep)
+			config := getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets, successfulOnly, verifyTLS, timeout, retries, sleep, userAgent)
 
 			// Generate report
 			report := pentestcmswordpress.PerformWordpressXMLRPCFunctionsExposed(cmd.Context(), config)
@@ -533,6 +550,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().String("user-agent", "RANDOM", "User agent preset to use (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = pentestCmsWordpressXmlrpcFunctionsExposedCmd.MarkFlagRequired("targets")
@@ -612,9 +630,18 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgent, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgent, requestMethodConfig.RequestMethodEnum); err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set Config
-			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprintPaths, detect404Responses, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getPentestRouteStaticAssetTakeoverConfig(target, fingerprintPaths, detect404Responses, successfulOnly, maxRedirects, verifyTLS, timeout, threads, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig, userAgent)
 
 			// Generate a report
 			report := pentestroute.DetectStaticAssetTakeovers(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -640,6 +667,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestRouteStaticAssetTakeoverCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	pentestRouteStaticAssetTakeoverCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")
 	pentestRouteStaticAssetTakeoverCmd.Flags().StringSlice("browserbase-countries", []string{}, "List of countries to use for Browserbase proxy")
+	pentestRouteStaticAssetTakeoverCmd.Flags().String("user-agent", "RANDOM", "User agent preset to use (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = pentestRouteStaticAssetTakeoverCmd.MarkFlagRequired("target")
@@ -656,6 +684,9 @@ func (a *WebScan) InitPentestCommand() {
 			`their types, configurations, and potential bypass techniques.`,
 	}
 
+	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
+	// which manages its own HTTP client and does not honor the UserAgentPreset.
+	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestWafDetectCmd := &cobra.Command{
 		Use:   "detect",
 		Short: "Actively detect WAFs protecting web applications",
@@ -839,7 +870,7 @@ func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []p
 }
 
 // getPentestCmsWordpressXmlrpcFunctionsExposedConfig builds the config for wordpress xmlrpc function auth pentest.
-func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig {
+func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int, userAgent common.UserAgentPreset) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig {
 	config := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig{
 		Targets:        targets,
 		SuccessfulOnly: successfulOnly,
@@ -847,12 +878,13 @@ func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, succes
 		Timeout:        timeout,
 		Retries:        retries,
 		Sleep:          sleep,
+		UserAgent:      userAgent,
 	}
 	return config
 }
 
 // getPentestRouteStaticAssetTakeoverConfig builds the config for static asset takeover pentest.
-func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, detect404Responses bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
+func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePaths []string, detect404Responses bool, successfulOnly bool, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserBaseConfig *common.BrowserbaseRequestConfig, userAgent common.UserAgentPreset) pentestroutefern.PentestRouteStaticAssetTakeoverConfig {
 	// Create Route Capture Config
 	routeCaptureConfig := &discover.DiscoverRouteConfig{
 		Target:              target,
@@ -866,6 +898,7 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 		MaxRedirects:        maxRedirects,
 		HeadlessConfig:      headlessConfig,
 		BrowserbaseConfig:   browserBaseConfig,
+		UserAgent:           userAgent,
 	}
 	// Create Static Asset Takeover Config with nested route capture config
 	config := pentestroutefern.PentestRouteStaticAssetTakeoverConfig{

--- a/fern/definition/pentest/cms/wordpress/xmlrpcfunctionsexposed.yml
+++ b/fern/definition/pentest/cms/wordpress/xmlrpcfunctionsexposed.yml
@@ -1,5 +1,6 @@
 imports:
   http: ../../../common/http.yml
+  method: ../../../common/method.yml
 types:
   # Config Struct
   PentestCmsWordpressXmlrpcFunctionsExposedConfig:
@@ -10,6 +11,7 @@ types:
       timeout: integer
       retries: integer
       sleep: integer
+      userAgent: method.UserAgentPreset
   # Report Struct
   XmlrpcFunctionsExposedAttempt:
     properties:

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -36,6 +36,7 @@ func createSendHTTPRequestConfig(baseURL, path string, body string, config *pent
 		MaxRedirects:       0,
 		VerifyTls:          config.VerifyTls,
 		Timeout:            config.Timeout,
+		UserAgent:          config.UserAgent,
 		RequestMethod:      common.RequestMethodStandard,
 		HeadlessConfig:     nil,
 		BrowserbaseConfig:  nil,


### PR DESCRIPTION
Wires --user-agent to xmlrpc-functions-exposed and static-asset-takeover, which use standard HTTP. Nuclei-based commands (dast, scan cve/misconfiguration/technology, waf detect) are skipped with TODO comments since nuclei manages its own HTTP client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI/config plumbing for outbound HTTP presets on two existing pentest flows; nuclei paths unchanged aside from documentation.
> 
> **Overview**
> Adds **`--user-agent`** (preset: RANDOM, CHROME, FIREFOX, SAFARI, EDGE) to pentest commands that use the shared HTTP stack: **`cms wordpress xmlrpc-functions-exposed`** and **`route static-asset-takeover`**. Values flow through Fern config into `SendHttpRequestConfig` / nested `DiscoverRouteConfig`.
> 
> **`static-asset-takeover`** reuses the same **`ValidateUserAgentWithRequestMethod`** guard as discover routes so an explicit non-default UA is rejected when **`request-method`** is headless or browserbase.
> 
> Nuclei-backed pentest subcommands (**`application dast`**, **`scan` cve/misconfiguration/technology**, **`waf detect`**) are **not** given the flag; inline **TODO** comments note nuclei owns its HTTP client until override support exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba364da0b85a21a0f836a85258f81ac3ac9b818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->