### PR TITLE
Apply user-agent presets in headless request mode

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -372,8 +372,8 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Validate user-agent is not explicitly set with headless/browserbase
-			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodConfig.RequestMethodEnum); err != nil {
+			// Validate user-agent compatibility with the chosen request method
+			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodConfig.RequestMethodEnum, cmd.Flags().Changed("user-agent")); err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
@@ -499,8 +499,8 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Validate user-agent is not explicitly set with headless/browserbase
-			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodConfig.RequestMethodEnum); err != nil {
+			// Validate user-agent compatibility with the chosen request method
+			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodConfig.RequestMethodEnum, cmd.Flags().Changed("user-agent")); err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
@@ -607,8 +607,8 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Validate user-agent is not explicitly set with headless/browserbase
-			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodConfig.RequestMethodEnum); err != nil {
+			// Validate user-agent compatibility with the chosen request method
+			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodConfig.RequestMethodEnum, cmd.Flags().Changed("user-agent")); err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -635,7 +635,7 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgent, requestMethodConfig.RequestMethodEnum); err != nil {
+			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgent, requestMethodConfig.RequestMethodEnum, cmd.Flags().Changed("user-agent")); err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}

--- a/internal/discover/page/helpers/screenshot.go
+++ b/internal/discover/page/helpers/screenshot.go
@@ -10,6 +10,7 @@ import (
 	common "github.com/Method-Security/webscan/generated/go/common"
 	// Utils
 	headless "github.com/Method-Security/webscan/utils/request/headless"
+	useragent "github.com/Method-Security/webscan/utils/useragent"
 	// External
 	proto "github.com/go-rod/rod/lib/proto"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -40,6 +41,18 @@ func CaptureScreenshot(ctx context.Context, browser *headless.Requester, sendHTT
 	if err != nil {
 		log.Error("Failed to create page for screenshot", svc1log.SafeParam("error", err))
 		return nil, err
+	}
+
+	// Apply the same user-agent override the HTML SendRequest path uses so a
+	// single --user-agent invocation produces consistent UAs across the HTML
+	// fetch and the screenshot navigation.
+	if sendHTTPRequestConfig.UserAgent != "" && sendHTTPRequestConfig.UserAgent != common.UserAgentPresetRandom {
+		uaString := useragent.Resolve(sendHTTPRequestConfig.UserAgent)
+		if uaErr := page.SetUserAgent(&proto.NetworkSetUserAgentOverride{UserAgent: uaString}); uaErr != nil {
+			log.Warn("Failed to set user-agent override for screenshot", svc1log.SafeParam("error", uaErr.Error()))
+		} else {
+			log.Info("Set user-agent override for screenshot", svc1log.SafeParam("preset", string(sendHTTPRequestConfig.UserAgent)))
+		}
 	}
 
 	// Navigate to the URL

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -44,6 +44,7 @@ func createSendHTTPRequestConfig(targetBaseURL, targetPath string, queryParams m
 		HeadlessConfig:     config.RouteCaptureConfig.HeadlessConfig,
 		BrowserbaseConfig:  config.RouteCaptureConfig.BrowserbaseConfig,
 		BrowserbaseSecrets: browserbaseSecrets,
+		UserAgent:          config.RouteCaptureConfig.UserAgent,
 	}
 
 	return requestConfig

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -17,6 +17,7 @@ import (
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
+	useragent "github.com/Method-Security/webscan/utils/useragent"
 
 	// External
 	rod "github.com/go-rod/rod"
@@ -152,6 +153,20 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 			svc1log.SafeParam("configTimeout", config.Timeout),
 			svc1log.SafeParam("domStabilizeTime", b.MinDOMStabalizeTimeSeconds),
 			svc1log.SafeParam("totalPageTimeout", int(pageTimeout.Seconds())))
+
+		// Apply user-agent override only when an explicit non-random preset was
+		// supplied. We never override on RANDOM/empty because every browser
+		// signal beyond the UA string (navigator.platform, client hints, JS
+		// runtime) still identifies as Chromium; a mismatched UA string would
+		// be an obvious fingerprint tell.
+		if config.UserAgent != "" && config.UserAgent != common.UserAgentPresetRandom {
+			uaString := useragent.Resolve(config.UserAgent)
+			if uaErr := page.SetUserAgent(&proto.NetworkSetUserAgentOverride{UserAgent: uaString}); uaErr != nil {
+				log.Warn("Failed to set user-agent override", svc1log.SafeParam("error", uaErr.Error()))
+			} else {
+				log.Info("Set user-agent override", svc1log.SafeParam("preset", string(config.UserAgent)))
+			}
+		}
 
 		// Setup request monitoring and navigate
 		headerCapture := setupHeaderInterception(page)

--- a/utils/request/helpers/command.go
+++ b/utils/request/helpers/command.go
@@ -38,16 +38,28 @@ func GetUserAgentFlag(cmd *cobra.Command) (common.UserAgentPreset, error) {
 	return preset, nil
 }
 
-// ValidateUserAgentWithRequestMethod returns an error if the user explicitly set
-// --user-agent to a non-default value while using a request method that ignores it
-// (headless or browserbase). If --user-agent was left at the default (RANDOM),
-// no error is returned since the user didn't explicitly request a specific UA.
-func ValidateUserAgentWithRequestMethod(userAgent common.UserAgentPreset, requestMethod common.RequestMethod) error {
-	if userAgent == "" || userAgent == common.UserAgentPresetRandom {
+// ValidateUserAgentWithRequestMethod returns an error if the user explicitly
+// supplied --user-agent in a way the request method cannot honor. `explicit`
+// must be true only when the user actually typed the flag on the command line
+// (typically cmd.Flags().Changed("user-agent")); a missing flag is never an
+// error and uses the request method's default UA.
+//
+// Headless mode applies CHROME/FIREFOX/SAFARI/EDGE via CDP, but rejects RANDOM
+// because randomizing the UA string while every other browser-introspectable
+// signal still says Chromium creates an obvious fingerprint mismatch. Operators
+// who want Chrome's real UA should simply omit the flag.
+//
+// Browserbase mode does not yet wire UA overrides through to the cloud session
+// (planned follow-up), so any explicit value is rejected.
+func ValidateUserAgentWithRequestMethod(userAgent common.UserAgentPreset, requestMethod common.RequestMethod, explicit bool) error {
+	if !explicit {
 		return nil
 	}
-	if requestMethod == common.RequestMethodHeadless || requestMethod == common.RequestMethodBrowserbase {
-		return fmt.Errorf("--user-agent flag is not supported with %s request method", requestMethod)
+	if requestMethod == common.RequestMethodHeadless && userAgent == common.UserAgentPresetRandom {
+		return fmt.Errorf("--user-agent RANDOM is not supported with headless request method; omit the flag to use Chrome's native UA, or specify CHROME/FIREFOX/SAFARI/EDGE")
+	}
+	if requestMethod == common.RequestMethodBrowserbase {
+		return fmt.Errorf("--user-agent is not yet supported with browserbase request method")
 	}
 	return nil
 }


### PR DESCRIPTION
Wires UserAgentPreset through to the headless requester via CDP Network.setUserAgentOverride, so --user-agent CHROME/FIREFOX/SAFARI/EDGE now takes effect in headless mode instead of being rejected outright.

Validator behavior:
- Flag omitted: no override, no error (uses Chrome's native UA).
- Explicit RANDOM with headless: errors loudly. Randomizing the UA string while every other browser-introspectable signal still says Chromium creates an obvious fingerprint mismatch; operators who want Chrome's real UA should omit the flag.
- Explicit CHROME/FIREFOX/SAFARI/EDGE with headless: applied via CDP.
- Browserbase: still rejected; planned follow-up.

Also fixes a pre-existing bug in static-asset-takeover where config.UserAgent was set on the route-capture config but dropped from the inner takeover-detection SendHttpRequestConfig.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes headless HTTP behavior and CLI validation for a flag used across discover/pentest flows; scope is limited but affects fingerprinting consistency and operator expectations.
> 
> **Overview**
> Headless capture now honors explicit `--user-agent` presets (**CHROME**, **FIREFOX**, **SAFARI**, **EDGE**) via CDP `Network.setUserAgentOverride` in the main headless requester and in page screenshot navigation, so HTML fetch and screenshots stay aligned.
> 
> CLI validation now keys off whether the user actually set `--user-agent` (`cmd.Flags().Changed("user-agent")`): omitting the flag is allowed in headless (Chrome’s native UA); explicit **RANDOM** with headless fails with a clear message; any explicit value with **browserbase** still errors as not yet supported.
> 
> **pentest route static-asset-takeover** now forwards `UserAgent` into the inner `SendHttpRequestConfig` used for takeover checks (it was previously dropped after route capture config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bdc1cc6abe78dd14e3d623279933a9baa118f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->