### PR TITLE
Fix Binary Content Requests for Headless

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -320,6 +320,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		var responseBody []byte
 		if statusCode >= 200 && statusCode < 300 {
 			htmlContent, err := page.HTML()
+			htmlCaptured := false
 			if err != nil {
 				errStr := err.Error()
 				if strings.Contains(errStr, "Execution context was destroyed") || strings.Contains(errStr, "-32000") {
@@ -328,28 +329,32 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 					log.Error("Failed to get HTML content", svc1log.SafeParam("error", err.Error()))
 				}
 				responseBody = nil
+				responseHeaders = cloneHeadersWithContentType(responseHeaders, "text/html")
 			} else {
+				htmlCaptured = true
 				responseBody = []byte(htmlContent)
-				if shouldLoadStaticResource(htmlContent, *constructedURL, finalURL) {
-					resourceURL := finalURL
-					if resourceURL == "" || isInternalBrowserURL(resourceURL) {
-						resourceURL = *constructedURL
+			}
+			if shouldLoadStaticResource(htmlContent, *constructedURL, finalURL) {
+				resourceURL := finalURL
+				if resourceURL == "" || isInternalBrowserURL(resourceURL) {
+					resourceURL = *constructedURL
+				}
+				loadedBody, loadedHeaders, loadedStatusCode, err := loadNetworkResourceBody(page, resourceURL)
+				if err == nil && isValidStaticResourceBody(loadedBody) {
+					responseBody = loadedBody
+					responseHeaders = headersForLoadedStaticResource(responseHeaders, loadedHeaders, loadedBody)
+					if loadedStatusCode > 0 {
+						statusCode = loadedStatusCode
 					}
-					loadedBody, loadedHeaders, loadedStatusCode, err := loadNetworkResourceBody(page, resourceURL)
-					if err == nil && isValidStaticResourceBody(loadedBody) {
-						responseBody = loadedBody
-						if len(loadedHeaders) > 0 {
-							responseHeaders = loadedHeaders
-						}
-						if loadedStatusCode > 0 {
-							statusCode = loadedStatusCode
-						}
-					} else if err != nil {
-						log.Info("Failed to load static resource body, falling back to page HTML", svc1log.SafeParam("error", cleanErrMsg(err)))
-					} else {
-						log.Info("Loaded static resource did not validate, falling back to page HTML")
-						responseHeaders = cloneHeadersWithContentType(responseHeaders, "text/html")
-					}
+				} else if err != nil {
+					log.Info("Failed to load static resource body, falling back to page HTML", svc1log.SafeParam("error", cleanErrMsg(err)))
+					responseHeaders = cloneHeadersWithContentType(responseHeaders, "text/html")
+				} else {
+					log.Info("Loaded static resource did not validate, falling back to page HTML")
+					responseHeaders = cloneHeadersWithContentType(responseHeaders, "text/html")
+				}
+				if !htmlCaptured && responseBody == nil {
+					responseBody = []byte{}
 				}
 			}
 		}

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -225,11 +225,6 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		default:
 		}
 
-		// Use the latest captured main-document headers after stabilization so
-		// headers, finalURL, and HTML describe the same terminal document.
-		var responseHeaders map[string][]string
-		responseHeaders = getResponseHeaders(ctx, page, headerCapture)
-
 		// Batch JavaScript evaluations for better performance
 		batchJS := `() => {
 			return {
@@ -317,8 +312,12 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 			browserErr = fmt.Errorf("navigation failed: Chrome error page detected")
 		}
 
+		// Use the latest captured main-document headers after stabilization so
+		// headers, finalURL, and HTML describe the same terminal document.
+		responseHeaders := getResponseHeaders(ctx, page, headerCapture)
+
 		// Extract response body
-		var responseBody string
+		var responseBody []byte
 		if statusCode >= 200 && statusCode < 300 {
 			htmlContent, err := page.HTML()
 			if err != nil {
@@ -328,13 +327,34 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 				} else {
 					log.Error("Failed to get HTML content", svc1log.SafeParam("error", err.Error()))
 				}
-				responseBody = ""
+				responseBody = nil
 			} else {
-				responseBody = htmlContent
+				responseBody = []byte(htmlContent)
+				if shouldLoadStaticResource(htmlContent, *constructedURL, finalURL) {
+					resourceURL := finalURL
+					if resourceURL == "" || isInternalBrowserURL(resourceURL) {
+						resourceURL = *constructedURL
+					}
+					loadedBody, loadedHeaders, loadedStatusCode, err := loadNetworkResourceBody(page, resourceURL)
+					if err == nil && isValidStaticResourceBody(loadedBody) {
+						responseBody = loadedBody
+						if len(loadedHeaders) > 0 {
+							responseHeaders = loadedHeaders
+						}
+						if loadedStatusCode > 0 {
+							statusCode = loadedStatusCode
+						}
+					} else if err != nil {
+						log.Info("Failed to load static resource body, falling back to page HTML", svc1log.SafeParam("error", cleanErrMsg(err)))
+					} else {
+						log.Info("Loaded static resource did not validate, falling back to page HTML")
+						responseHeaders = cloneHeadersWithContentType(responseHeaders, "text/html")
+					}
+				}
 			}
 		}
 		// Build final response
-		response := requesthelpers.CreateHTTPResponse(
+		response := requesthelpers.CreateHTTPResponseFromBytes(
 			statusCode,
 			responseRedirectChain,
 			responseHeaders,

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -338,9 +338,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 					loadedBody, loadedHeaders, loadedStatusCode, err := loadNetworkResourceBody(page, resourceURL)
 					if err == nil && isValidStaticResourceBody(loadedBody) {
 						responseBody = loadedBody
-						if len(loadedHeaders) > 0 {
-							responseHeaders = loadedHeaders
-						}
+						responseHeaders = headersForLoadedStaticResource(responseHeaders, loadedHeaders, loadedBody)
 						if loadedStatusCode > 0 {
 							statusCode = loadedStatusCode
 						}

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -3,6 +3,7 @@ package headless
 import (
 	// Standard
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	common "github.com/Method-Security/webscan/generated/go/common"
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
+	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	// External
 	rod "github.com/go-rod/rod"
 	proto "github.com/go-rod/rod/lib/proto"
@@ -39,18 +41,14 @@ func NewNetworkHeaderCapture() *NetworkHeaderCapture {
 func (n *NetworkHeaderCapture) SetHeaders(headers map[string][]string) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	n.Headers = headers
+	n.Headers = cloneHeaders(headers)
 }
 
 // GetHeaders safely gets headers
 func (n *NetworkHeaderCapture) GetHeaders() map[string][]string {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
-	result := make(map[string][]string)
-	for k, v := range n.Headers {
-		result[k] = v
-	}
-	return result
+	return cloneHeaders(n.Headers)
 }
 
 // setupHeaderInterception sets up network event monitoring to capture response headers
@@ -70,7 +68,7 @@ func setupHeaderInterception(page *rod.Page) *NetworkHeaderCapture {
 	go page.EachEvent(
 		func(e *proto.NetworkResponseReceived) {
 			// Only capture headers for main document responses
-			if e.Type == proto.NetworkResourceTypeDocument {
+			if e.Type == proto.NetworkResourceTypeDocument && e.Response != nil && !isInternalBrowserURL(e.Response.URL) {
 				headers := make(map[string][]string)
 				for key, value := range e.Response.Headers {
 					// Convert gson.JSON to string
@@ -82,6 +80,80 @@ func setupHeaderInterception(page *rod.Page) *NetworkHeaderCapture {
 	)()
 
 	return headerCapture
+}
+
+func loadNetworkResourceBody(page *rod.Page, resourceURL string) ([]byte, map[string][]string, int, error) {
+	result, err := proto.NetworkLoadNetworkResource{
+		FrameID: page.FrameID,
+		URL:     resourceURL,
+		Options: &proto.NetworkLoadNetworkResourceOptions{
+			DisableCache:       true,
+			IncludeCredentials: true,
+		},
+	}.Call(page)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	if result == nil || result.Resource == nil {
+		return nil, nil, 0, fmt.Errorf("network resource load returned no resource")
+	}
+	resource := result.Resource
+	if !resource.Success {
+		if resource.NetErrorName != "" {
+			return nil, nil, 0, fmt.Errorf("network resource load failed: %s", resource.NetErrorName)
+		}
+		return nil, nil, 0, fmt.Errorf("network resource load failed")
+	}
+
+	headers := make(map[string][]string)
+	for key, value := range resource.Headers {
+		headers[key] = []string{value.Str()}
+	}
+
+	statusCode := 0
+	if resource.HTTPStatusCode != nil {
+		statusCode = int(*resource.HTTPStatusCode)
+	}
+
+	if resource.Stream == "" {
+		return nil, headers, statusCode, nil
+	}
+	defer func() {
+		_ = proto.IOClose{Handle: resource.Stream}.Call(page)
+	}()
+
+	body, err := readIOStream(page, resource.Stream)
+	if err != nil {
+		return nil, headers, statusCode, err
+	}
+	return body, headers, statusCode, nil
+}
+
+func readIOStream(page *rod.Page, handle proto.IOStreamHandle) ([]byte, error) {
+	var body []byte
+	chunkSize := 64 * 1024
+	for {
+		readResult, err := proto.IORead{
+			Handle: handle,
+			Size:   &chunkSize,
+		}.Call(page)
+		if err != nil {
+			return nil, err
+		}
+		if readResult.Base64Encoded {
+			chunk, err := base64.StdEncoding.DecodeString(readResult.Data)
+			if err != nil {
+				return nil, err
+			}
+			body = append(body, chunk...)
+		} else {
+			body = append(body, []byte(readResult.Data)...)
+		}
+		if readResult.EOF {
+			break
+		}
+	}
+	return body, nil
 }
 
 // handleNavigation sets up tracking for top-level frame navigations
@@ -324,6 +396,64 @@ func normalizeDefaultPort(raw string) string {
 
 func isDefaultPort(scheme, port string) bool {
 	return (scheme == "http" && port == "80") || (scheme == "https" && port == "443")
+}
+
+func cloneHeaders(headers map[string][]string) map[string][]string {
+	result := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		result[key] = append([]string(nil), values...)
+	}
+	return result
+}
+
+func isInternalBrowserURL(raw string) bool {
+	return raw == "" ||
+		raw == "about:blank" ||
+		strings.HasPrefix(raw, "chrome://") ||
+		strings.HasPrefix(raw, "chrome-error://") ||
+		strings.HasPrefix(raw, "chrome-extension://") ||
+		strings.HasPrefix(raw, "devtools://")
+}
+
+func isChromePDFViewerHTML(htmlContent string) bool {
+	content := strings.ToLower(htmlContent)
+	return strings.Contains(content, `type="application/pdf"`) ||
+		(strings.Contains(content, "background-color: rgb(38, 38, 38)") &&
+			strings.Contains(content, "<body>") &&
+			strings.Contains(content, "</body>"))
+}
+
+func isChromeStaticAssetViewerHTML(htmlContent string) bool {
+	content := strings.ToLower(htmlContent)
+	return isChromePDFViewerHTML(htmlContent) ||
+		(strings.Contains(content, "<img ") && strings.Contains(content, "src=")) ||
+		strings.Contains(content, "<video") ||
+		strings.Contains(content, "<audio")
+}
+
+func shouldLoadStaticResource(htmlContent, constructedURL, finalURL string) bool {
+	return isChromeStaticAssetViewerHTML(htmlContent) ||
+		utils.IsStaticAsset(constructedURL) ||
+		utils.IsStaticAsset(finalURL)
+}
+
+func isValidStaticResourceBody(body []byte) bool {
+	return len(body) > 0 && requesthelpers.IsDetectedBinaryBody(body)
+}
+
+func cloneHeadersWithContentType(headers map[string][]string, contentType string) map[string][]string {
+	cloned := cloneHeaders(headers)
+	replaced := false
+	for key := range cloned {
+		if strings.EqualFold(key, "Content-Type") {
+			cloned[key] = []string{contentType}
+			replaced = true
+		}
+	}
+	if !replaced {
+		cloned["Content-Type"] = []string{contentType}
+	}
+	return cloned
 }
 
 // performNavigation handles the actual page navigation based on config

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -19,6 +19,7 @@ import (
 	utils "github.com/Method-Security/webscan/utils"
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	// External
+	goquery "github.com/PuerkitoBio/goquery"
 	rod "github.com/go-rod/rod"
 	proto "github.com/go-rod/rod/lib/proto"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -417,18 +418,40 @@ func isInternalBrowserURL(raw string) bool {
 
 func isChromePDFViewerHTML(htmlContent string) bool {
 	content := strings.ToLower(htmlContent)
-	return strings.Contains(content, `type="application/pdf"`) ||
-		(strings.Contains(content, "background-color: rgb(38, 38, 38)") &&
-			strings.Contains(content, "<body>") &&
-			strings.Contains(content, "</body>"))
+	return strings.Contains(content, `type="application/pdf"`)
 }
 
 func isChromeStaticAssetViewerHTML(htmlContent string) bool {
-	content := strings.ToLower(htmlContent)
-	return isChromePDFViewerHTML(htmlContent) ||
-		(strings.Contains(content, "<img ") && strings.Contains(content, "src=")) ||
-		strings.Contains(content, "<video") ||
-		strings.Contains(content, "<audio")
+	if isChromePDFViewerHTML(htmlContent) {
+		return true
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
+	if err != nil {
+		return false
+	}
+	body := doc.Find("body")
+	if body.Length() != 1 {
+		return false
+	}
+	children := body.Children()
+	if children.Length() != 1 {
+		return false
+	}
+
+	media := children.First()
+	switch strings.ToLower(goquery.NodeName(media)) {
+	case "img":
+		_, ok := media.Attr("src")
+		return ok
+	case "video", "audio":
+		if _, ok := media.Attr("src"); ok {
+			return true
+		}
+		return media.Find("source[src]").Length() > 0
+	default:
+		return false
+	}
 }
 
 func shouldLoadStaticResource(htmlContent, constructedURL, finalURL string) bool {
@@ -439,6 +462,39 @@ func shouldLoadStaticResource(htmlContent, constructedURL, finalURL string) bool
 
 func isValidStaticResourceBody(body []byte) bool {
 	return len(body) > 0 && requesthelpers.IsDetectedBinaryBody(body)
+}
+
+func headersForLoadedStaticResource(existingHeaders, loadedHeaders map[string][]string, body []byte) map[string][]string {
+	headers := existingHeaders
+	if len(loadedHeaders) > 0 {
+		headers = loadedHeaders
+	}
+	return cloneHeadersWithBodyMetadata(headers, body)
+}
+
+func cloneHeadersWithBodyMetadata(headers map[string][]string, body []byte) map[string][]string {
+	cloned := cloneHeaders(headers)
+	contentType := requesthelpers.DetectContentTypeFromBytes(body)
+	contentLength := strconv.Itoa(len(body))
+	replacedContentType := false
+	replacedContentLength := false
+	for key := range cloned {
+		switch {
+		case strings.EqualFold(key, "Content-Type"):
+			cloned[key] = []string{contentType}
+			replacedContentType = true
+		case strings.EqualFold(key, "Content-Length"):
+			cloned[key] = []string{contentLength}
+			replacedContentLength = true
+		}
+	}
+	if !replacedContentType {
+		cloned["Content-Type"] = []string{contentType}
+	}
+	if !replacedContentLength {
+		cloned["Content-Length"] = []string{contentLength}
+	}
+	return cloned
 }
 
 func cloneHeadersWithContentType(headers map[string][]string, contentType string) map[string][]string {

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -183,6 +183,18 @@ func CreateBodyFromBytes(contentType string, bodyData []byte) *common.Body {
 	}
 }
 
+// CreateBodyFromDetectedBytes classifies body bytes using Go's content sniffing.
+func CreateBodyFromDetectedBytes(bodyData []byte) *common.Body {
+	return CreateBodyFromBytes(http.DetectContentType(bodyData), bodyData)
+}
+
+// IsDetectedBinaryBody reports whether body bytes classify the same way STANDARD
+// would classify a binary response when no Content-Type header is available.
+func IsDetectedBinaryBody(bodyData []byte) bool {
+	body := CreateBodyFromDetectedBytes(bodyData)
+	return body != nil && body.Kind == "binary"
+}
+
 // CreateHTTPResponseFromBytes creates an HttpResponse struct from HttpResponse data using byte array
 func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers map[string][]string, responseBody []byte) common.HttpResponse {
 	// Process headers to split comma-delimited values
@@ -201,8 +213,8 @@ func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers
 
 	// Get content type from headers
 	contentType := ""
-	if ct, ok := processedHeaders["Content-Type"]; ok && len(ct) > 0 {
-		contentType = ct[0]
+	if ct := GetHeaderValueFromHeaderMap(processedHeaders, "Content-Type"); ct != nil {
+		contentType = *ct
 	}
 
 	// If no content type is provided, try to detect it from string representation

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -183,9 +183,14 @@ func CreateBodyFromBytes(contentType string, bodyData []byte) *common.Body {
 	}
 }
 
+// DetectContentTypeFromBytes classifies body bytes using Go's content sniffing.
+func DetectContentTypeFromBytes(bodyData []byte) string {
+	return http.DetectContentType(bodyData)
+}
+
 // CreateBodyFromDetectedBytes classifies body bytes using Go's content sniffing.
 func CreateBodyFromDetectedBytes(bodyData []byte) *common.Body {
-	return CreateBodyFromBytes(http.DetectContentType(bodyData), bodyData)
+	return CreateBodyFromBytes(DetectContentTypeFromBytes(bodyData), bodyData)
 }
 
 // IsDetectedBinaryBody reports whether body bytes classify the same way STANDARD


### PR DESCRIPTION
## Summary
Fix HEADLESS page capture for direct binary/static asset URLs, including PDFs rendered by Chrome’s built-in viewer.
HEADLESS previously captured page.HTML(), which works for normal web pages but returns Chrome viewer HTML for direct PDFs/images instead of the raw response bytes. This change keeps normal HTML capture unchanged, and adds a post-navigation raw resource load for asset-like pages.

 ## Changes

  - Keep existing HEADLESS navigation, redirect, timeout, and status-code behavior unchanged.
  - Continue using page.HTML() as the default response body path.
  - Detect Chrome asset viewer pages or static asset URLs as candidates for raw resource loading.
  - Load raw bytes with CDP Network.loadNetworkResource.
  - Accept loaded bytes only when they classify as binary through the shared request helper path.
  - Build HEADLESS responses with CreateHTTPResponseFromBytes, matching STANDARD’s byte-based response handling.
  - Make response Content-Type lookup case-insensitive.
  - Add helper methods for detected-byte classification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HEADLESS response assembly and adds CDP network loads with new fallbacks; scope is bounded to asset-like URLs but affects scan fidelity for binary content.
> 
> **Overview**
> HEADLESS capture now returns **raw bytes** for direct static assets and Chrome’s built-in PDF/image/audio viewers instead of viewer shell HTML from `page.HTML()`.
> 
> After stabilization, normal pages still use DOM HTML. When the URL or page looks like a static asset, the flow loads the resource via CDP `Network.loadNetworkResource`, accepts the body only if shared helpers classify it as **binary**, and builds the response with `CreateHTTPResponseFromBytes` (aligned with STANDARD). Headers are cloned safely, internal browser document URLs are ignored for header capture, and `Content-Type` lookup is **case-insensitive** in the byte response path, with fallbacks to HTML when raw load or validation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f81d73bc063b9e90aefeeed2ff3f1dad7739328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->