### PR TITLE
browserbase user agent support

### DIFF
--- a/utils/request/helpers/command.go
+++ b/utils/request/helpers/command.go
@@ -44,22 +44,19 @@ func GetUserAgentFlag(cmd *cobra.Command) (common.UserAgentPreset, error) {
 // (typically cmd.Flags().Changed("user-agent")); a missing flag is never an
 // error and uses the request method's default UA.
 //
-// Headless mode applies CHROME/FIREFOX/SAFARI/EDGE via CDP, but rejects RANDOM
-// because randomizing the UA string while every other browser-introspectable
-// signal still says Chromium creates an obvious fingerprint mismatch. Operators
-// who want Chrome's real UA should simply omit the flag.
-//
-// Browserbase mode does not yet wire UA overrides through to the cloud session
-// (planned follow-up), so any explicit value is rejected.
+// Headless and browserbase modes apply CHROME/FIREFOX/SAFARI/EDGE via CDP, but
+// reject RANDOM because randomizing the UA string while every other
+// browser-introspectable signal still says Chromium creates an obvious
+// fingerprint mismatch. Operators who want Chrome's real UA should simply omit
+// the flag.
 func ValidateUserAgentWithRequestMethod(userAgent common.UserAgentPreset, requestMethod common.RequestMethod, explicit bool) error {
 	if !explicit {
 		return nil
 	}
-	if requestMethod == common.RequestMethodHeadless && userAgent == common.UserAgentPresetRandom {
-		return fmt.Errorf("--user-agent RANDOM is not supported with headless request method; omit the flag to use Chrome's native UA, or specify CHROME/FIREFOX/SAFARI/EDGE")
-	}
-	if requestMethod == common.RequestMethodBrowserbase {
-		return fmt.Errorf("--user-agent is not yet supported with browserbase request method")
+	if requestMethod == common.RequestMethodHeadless || requestMethod == common.RequestMethodBrowserbase {
+		if userAgent == common.UserAgentPresetRandom {
+			return fmt.Errorf("--user-agent RANDOM is not supported with %s request method; omit the flag to use Chrome's native UA, or specify CHROME/FIREFOX/SAFARI/EDGE", requestMethod)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Lifts the blanket `--user-agent` rejection from `ValidateUserAgentWithRequestMethod` for browserbase requests, mirroring the rule already in place for headless: explicit `CHROME/FIREFOX/SAFARI/EDGE` are now allowed and applied via CDP, while explicit `RANDOM` is still rejected because randomizing the UA string while every other browser-introspectable signal still identifies as Chromium creates an obvious fingerprint mismatch. No browserbase-specific code change is needed — `browserbase.Requester.SendRequest` already delegates to the local `headless.Requester.SendRequest` patched in PR 1, so the CDP override fires automatically for Browserbase-hosted sessions. Verified the validator end-to-end against all three flag states (omitted, explicit `RANDOM`, explicit `CHROME`); the on-the-wire UA propagation through Browserbase needs one live test with real credentials before merge since this environment doesn't have them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI validation change; behavior depends on existing headless/CDP wiring for browserbase sessions rather than new request-path logic.
> 
> **Overview**
> **Browserbase** now follows the same `--user-agent` rules as **headless**: explicit `CHROME`/`FIREFOX`/`SAFARI`/`EDGE` are allowed, while explicit `RANDOM` is still rejected to avoid a UA string that does not match other Chromium-visible signals.
> 
> The change is in `ValidateUserAgentWithRequestMethod` in `command.go`: the old error that blocked *any* explicit `--user-agent` for browserbase is removed, and headless/browserbase share one branch that only errors on `RANDOM`, with a message that includes the request method name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b553d20b2a7fdbe5982e2a014f5c0cb5117ee012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->