### PR TITLE
Gbear/saas user agent flag

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -752,8 +752,20 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Validate user-agent compatibility with the chosen request method
+			if err := requesthelpers.ValidateUserAgentWithRequestMethod(userAgentPreset, requestMethodEnum, cmd.Flags().Changed("user-agent")); err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Get the config
-			config := getDiscoverSaasConfig(orgs, saasCompanies, ssoCompanies, maxRedirects, verifyTLS, timeout, threads, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverSaasConfig(orgs, saasCompanies, ssoCompanies, maxRedirects, verifyTLS, timeout, threads, userAgentPreset, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate the report
 			report, err := discoversaas.LaunchDiscoverSaas(cmd.Context(), config, *filteredSaasFingerprints, *filteredSsoFingerprints, requestMethodConfig.BrowserbaseSecrets)
@@ -775,8 +787,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverSaasCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverSaasCmd.Flags().Int("timeout", 90, "Timeout in seconds for the capture")
 	discoverSaasCmd.Flags().Int("threads", 25, "Number of concurrent threads for discovery")
-	// TODO: Add --user-agent flag here once headless/browserbase paths support UserAgentPreset.
-	// Skipped for now because saas only supports headless/browserbase, not the standard HTTP client.
+	discoverSaasCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 	// Request Method Flags for all capture subcommands
 	discoverSaasCmd.Flags().String("request-method", "HEADLESS", "Request method (headless, browserbase)")
 	discoverSaasCmd.Flags().String("headless-path", "", "Path to a headless browser executable")
@@ -889,7 +900,7 @@ func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStatic
 }
 
 // getDiscoverSaasConfig builds the config for SaaS active discovery.
-func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies []string, maxRedirects int, verifyTLS bool, timeout int, threads int, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverSaasConfig {
+func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies []string, maxRedirects int, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverSaasConfig {
 	config := discover.DiscoverSaasConfig{
 		Orgs:              orgs,
 		SaasCompanies:     saasCompanies,
@@ -898,6 +909,7 @@ func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies [
 		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		Threads:           max(threads, 0),
+		UserAgent:         userAgent,
 		RequestMethod:     requestMethod,
 		HeadlessConfig:    headlessConfig,
 		BrowserbaseConfig: browserbaseConfig,

--- a/fern/definition/discover/saas.yml
+++ b/fern/definition/discover/saas.yml
@@ -28,6 +28,7 @@ types:
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>
+      userAgent: method.UserAgentPreset
   # Report
   SaasActiveFinding:
     properties:

--- a/internal/discover/saas/active/active.go
+++ b/internal/discover/saas/active/active.go
@@ -43,6 +43,7 @@ func createSendHTTPRequestConfig(baseURL, path string, config discover.DiscoverS
 		HeadlessConfig:     config.HeadlessConfig,
 		BrowserbaseConfig:  config.BrowserbaseConfig,
 		BrowserbaseSecrets: browserbaseSecrets,
+		UserAgent:          config.UserAgent,
 	}
 }
 

--- a/utils/request/helpers/command.go
+++ b/utils/request/helpers/command.go
@@ -44,22 +44,19 @@ func GetUserAgentFlag(cmd *cobra.Command) (common.UserAgentPreset, error) {
 // (typically cmd.Flags().Changed("user-agent")); a missing flag is never an
 // error and uses the request method's default UA.
 //
-// Headless mode applies CHROME/FIREFOX/SAFARI/EDGE via CDP, but rejects RANDOM
-// because randomizing the UA string while every other browser-introspectable
-// signal still says Chromium creates an obvious fingerprint mismatch. Operators
-// who want Chrome's real UA should simply omit the flag.
-//
-// Browserbase mode does not yet wire UA overrides through to the cloud session
-// (planned follow-up), so any explicit value is rejected.
+// Headless and browserbase modes apply CHROME/FIREFOX/SAFARI/EDGE via CDP, but
+// reject RANDOM because randomizing the UA string while every other
+// browser-introspectable signal still says Chromium creates an obvious
+// fingerprint mismatch. Operators who want Chrome's real UA should simply omit
+// the flag.
 func ValidateUserAgentWithRequestMethod(userAgent common.UserAgentPreset, requestMethod common.RequestMethod, explicit bool) error {
 	if !explicit {
 		return nil
 	}
-	if requestMethod == common.RequestMethodHeadless && userAgent == common.UserAgentPresetRandom {
-		return fmt.Errorf("--user-agent RANDOM is not supported with headless request method; omit the flag to use Chrome's native UA, or specify CHROME/FIREFOX/SAFARI/EDGE")
-	}
-	if requestMethod == common.RequestMethodBrowserbase {
-		return fmt.Errorf("--user-agent is not yet supported with browserbase request method")
+	if requestMethod == common.RequestMethodHeadless || requestMethod == common.RequestMethodBrowserbase {
+		if userAgent == common.UserAgentPresetRandom {
+			return fmt.Errorf("--user-agent RANDOM is not supported with %s request method; omit the flag to use Chrome's native UA, or specify CHROME/FIREFOX/SAFARI/EDGE", requestMethod)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI and config wiring for an existing request option; validation is tightened for RANDOM only, with no auth or data-path changes.
> 
> **Overview**
> Adds **`--user-agent`** to **`discover saas`**, aligned with other discover commands that use headless or browserbase. The preset is read and validated (same rules as page/probe/route), stored on **`DiscoverSaasConfig`**, and passed through SaaS active HTTP requests via **`SendHttpRequestConfig.UserAgent`**.
> 
> The Fern schema and generated config now include **`userAgent`**. Validation no longer blocks *any* explicit `--user-agent` for browserbase—only **`RANDOM`** is rejected for headless and browserbase, with browserbase treated like headless for CHROME/FIREFOX/SAFARI/EDGE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f6ad4ee6f10a18853e9322108ae0f4fff8b25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->