### PR TITLE
Fix New Route Discover Functionality to Abide by Domain Flag

### DIFF
--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -34,7 +34,7 @@ types:
     properties:
       baseURL: string
       path: string
-      method: optional<http.HttpMethod>
+      method: http.HttpMethod
       queryParams: optional<list<RouteQueryParam>>
       bodyParams: optional<list<RouteBodyParam>>
       evidence: optional<string>

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -67,7 +67,7 @@ func ExtractFormRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 		} else {
 			method = strings.ToUpper(method)
 		}
-		routeVar.Method = common.HttpMethod(method).Ptr()
+		routeVar.Method = common.HttpMethod(method)
 
 		// Collect input names
 		var queryParams []*discover.RouteQueryParam
@@ -148,7 +148,7 @@ func ExtractAnchorRoutes(doc *goquery.Document, baseURL string, routeCaptureConf
 			routeVar := &discover.RouteDetails{
 				BaseUrl: routeBaseURL,
 				Path:    routePath,
-				Method:  common.HttpMethodGet.Ptr(), // Anchor links are accessed via GET
+				Method:  common.HttpMethodGet, // Anchor links are accessed via GET
 			}
 
 			// Add query parameters if any were found
@@ -177,8 +177,9 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 
 			// Skip if this is a static asset
 			if utils.IsStaticAsset(fullURL) {
-				// Only add to URLs if we're not ignoring static assets
-				if routeCaptureConfig.CollectStaticAssets {
+				// Only collect static assets that are in scope.
+				if routeCaptureConfig.CollectStaticAssets &&
+					discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
 					urls[fullURL] = struct{}{}
 				}
 				return
@@ -208,7 +209,7 @@ func ExtractLinkRoutes(doc *goquery.Document, baseURL string, routeCaptureConfig
 			routeVar := &discover.RouteDetails{
 				BaseUrl: routeBaseURL,
 				Path:    routePath,
-				Method:  common.HttpMethodGet.Ptr(), // Link elements are accessed via GET
+				Method:  common.HttpMethodGet, // Link elements are accessed via GET
 			}
 
 			routes = append(routes, routeVar)

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -171,7 +171,7 @@ func extractRoutesFromPatterns(content string, baseURL string, routeCaptureConfi
 			route := &discover.RouteDetails{
 				BaseUrl: routeBaseURL,
 				Path:    routePath,
-				Method:  common.HttpMethod(method).Ptr(),
+				Method:  common.HttpMethod(method),
 			}
 
 			// Apply path templating if the path has dynamic segments
@@ -393,7 +393,7 @@ func (v *visitor) handleVariableStatement(node *ast.VariableStatement) {
 						route := &discover.RouteDetails{
 							BaseUrl:      routeBaseURL,
 							Path:         routePath,
-							Method:       common.HttpMethodGet.Ptr(),
+							Method:       common.HttpMethodGet,
 							Evidence:     &evidence,
 							PathTemplate: &tmpl,
 						}
@@ -502,7 +502,7 @@ func (v *visitor) addRoute(urlStr, method string, bodyParams []*discover.RouteBo
 	route := &discover.RouteDetails{
 		BaseUrl:     routeBaseURL,
 		Path:        routePath,
-		Method:      common.HttpMethod(method).Ptr(),
+		Method:      common.HttpMethod(method),
 		BodyParams:  bodyParams,
 		QueryParams: queryParams,
 	}
@@ -523,6 +523,10 @@ func fetchSourceMapRoutes(ctx context.Context, sourceMapURL string, baseURL stri
 	routes := []*discover.RouteDetails{}
 	urls := []string{}
 	errors := []string{}
+
+	if routeCaptureConfig.IgnoreCrossDomain && !discoverroutehelpers.IsSubdomain(baseURL, sourceMapURL) {
+		return routes, urls, errors
+	}
 
 	resp, err := http.Get(sourceMapURL) //nolint:noctx
 	if err != nil {
@@ -615,12 +619,11 @@ func ExtractScriptRoutes(ctx context.Context, doc *goquery.Document, baseURL str
 				return
 			}
 
-			// If onlybaseURLs is set, only request script src that are relative
-			if routeCaptureConfig.IgnoreCrossDomain && discoverroutehelpers.IsAbsoluteURL(src) {
+			fullURL := discoverroutehelpers.ResolveURL(baseURL, src)
+
+			if routeCaptureConfig.IgnoreCrossDomain && !discoverroutehelpers.IsSubdomain(baseURL, fullURL) {
 				return
 			}
-
-			fullURL := discoverroutehelpers.ResolveURL(baseURL, src)
 
 			// Check if the URL is allowed
 			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
@@ -710,6 +713,10 @@ func ExtractBundleURLRoutes(ctx context.Context, bundleURLs []string, baseURL st
 
 		// Resolve relative bundle URLs
 		fullURL := discoverroutehelpers.ResolveURL(baseURL, bundleURL)
+
+		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
+			continue
+		}
 
 		// Fetch the JS bundle
 		resp, err := http.Get(fullURL) //nolint:noctx

--- a/internal/discover/route/helpers/extractors/networkExtractors.go
+++ b/internal/discover/route/helpers/extractors/networkExtractors.go
@@ -127,7 +127,7 @@ func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, targ
 		webRoute := &discover.RouteDetails{
 			BaseUrl: routeBaseURL,
 			Path:    routePath,
-			Method:  common.HttpMethod(request.Method).Ptr(),
+			Method:  common.HttpMethod(request.Method),
 		}
 
 		// Capture query parameters

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -52,9 +52,9 @@ func MergeWebRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
 
 	for _, route := range routes {
 		// Create a unique key based on method and URL
-		method := string(common.HttpMethodGet)
-		if route.Method != nil {
-			method = string(*route.Method)
+		method := route.Method
+		if method == "" {
+			method = common.HttpMethodGet
 		}
 
 		// Normalize path: treat empty path "" and root path "/" as equivalent
@@ -201,6 +201,9 @@ func MergeBodyParams(params1 []*discover.RouteBodyParam, params2 []*discover.Rou
 func ParseQueryParams(reqURL *url.URL) []*discover.RouteQueryParam {
 	var queryParams []*discover.RouteQueryParam
 	for key, values := range reqURL.Query() {
+		if key == "" {
+			continue
+		}
 		queryParams = append(queryParams, &discover.RouteQueryParam{
 			Name:          key,
 			ExampleValues: values,
@@ -219,6 +222,9 @@ func ParseBodyParams(postData string) ([]*discover.RouteBodyParam, error) {
 		var jsonData map[string]interface{}
 		if err := json.Unmarshal([]byte(postData), &jsonData); err == nil {
 			for key, value := range jsonData {
+				if key == "" {
+					continue
+				}
 				// Stringify the value to ensure it's a string
 				valueStr, err := json.Marshal(value)
 				if err == nil {
@@ -238,6 +244,9 @@ func ParseBodyParams(postData string) ([]*discover.RouteBodyParam, error) {
 		formData, err := url.ParseQuery(postData)
 		if err == nil {
 			for key, values := range formData {
+				if key == "" {
+					continue
+				}
 				bodyParams = append(bodyParams, &discover.RouteBodyParam{
 					Name:          key,
 					ExampleValues: values,
@@ -292,19 +301,12 @@ func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 	return strings.TrimRight(baseURL, "/"), parsedURL.Path, nil
 }
 
-// IsURLAllowed checks if a target URL is allowed based on base URL, static asset rules, and domain matching.
-func IsURLAllowed(baseURL string, targetURL string, ignoreCrossDomain bool, collectStaticAssets bool) bool {
-	if collectStaticAssets {
-		if utils.IsStaticAsset(targetURL) {
-			return true
-		}
+// IsURLAllowed checks if a target URL is allowed based on base URL and domain matching.
+func IsURLAllowed(baseURL string, targetURL string, ignoreCrossDomain bool, _ bool) bool {
+	if ignoreCrossDomain {
+		return IsSubdomain(baseURL, targetURL)
 	}
-
-	if !ignoreCrossDomain {
-		return true
-	}
-
-	return IsSubdomain(baseURL, targetURL)
+	return true
 }
 
 // ExtractDomain extracts the domain from a URL up to a specified domain level.

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -100,7 +100,7 @@ func ExtractRedirectRoutes(redirectChain []string, baseURL string, routeCaptureC
 		routeVar := &discover.RouteDetails{
 			BaseUrl:     routeBaseURL,
 			Path:        routePath,
-			Method:      common.HttpMethodGet.Ptr(), // Redirects are typically GET
+			Method:      common.HttpMethodGet, // Redirects are typically GET
 			QueryParams: queryParams,
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes discovery scope and filtering behavior (fewer cross-domain routes/assets when the flag is set) and makes `method` required in the API, which may affect downstream consumers.
> 
> **Overview**
> **Route discovery now respects `ignoreCrossDomain` consistently**, instead of treating static assets as always in scope. `IsURLAllowed` only enforces subdomain checks when the flag is set; static `<link>` assets are collected only when `collectStaticAssets` is on **and** the URL passes that check. **Script/source-map/bundle fetching** resolves URLs first and skips out-of-scope hosts via `IsSubdomain` / `IsURLAllowed` (replacing the old “skip any absolute `src`” rule).
> 
> **API/schema:** `RouteDetails.method` is **required** (`http.HttpMethod`); all extractors assign a non-optional method, and route merging defaults empty method to GET.
> 
> **Small hardening:** query/body param parsing skips empty keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95694787b6ff44d8edd2c312f81e69bdd573eb2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->