### PR TITLE
Clean Up Discover Route Parameters

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -778,14 +778,9 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			maxRoutes, err := cmd.Flags().GetInt("max-routes")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 
 			// Set Config
-			config := getDiscoverRouteConfig(target, ignoreCrossDomain, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, userAgentPreset, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig, bundleURLs, fetchSourceMaps, maxBundles, maxRoutes)
+			config := getDiscoverRouteConfig(target, ignoreCrossDomain, collectStaticAssets, spiderDepth, maxRedirects, verifyTLS, timeout, threads, userAgentPreset, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig, bundleURLs, fetchSourceMaps, maxBundles)
 
 			// Generate a report
 			report := discoverroute.PerformRouteCapture(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -815,8 +810,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	// JS route discovery enhancement flags
 	discoverRouteCmd.Flags().StringSlice("bundle-urls", []string{}, "Explicit JS bundle URLs to scan for routes")
 	discoverRouteCmd.Flags().Bool("fetch-source-maps", true, "Fetch and scan source maps for additional routes")
-	discoverRouteCmd.Flags().Int("max-bundles", 0, "Maximum number of JS bundles to process (0 = unlimited)")
-	discoverRouteCmd.Flags().Int("max-routes", 0, "Maximum number of routes to collect (0 = unlimited)")
+	discoverRouteCmd.Flags().Int("max-bundles", -1, "Maximum number of JS bundles to process (-1 = unlimited, 0 = disabled)")
 
 	// Mark Required Flags
 	_ = discoverRouteCmd.MarkFlagRequired("target")
@@ -1155,7 +1149,7 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 }
 
 // getDiscoverRouteConfig builds the config for route discovery.
-func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig, bundleURLs []string, fetchSourceMaps bool, maxBundles int, maxRoutes int) discover.DiscoverRouteConfig {
+func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStaticAssets bool, spiderDepth int, maxRedirects int, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig, bundleURLs []string, fetchSourceMaps bool, maxBundles int) discover.DiscoverRouteConfig {
 	config := discover.DiscoverRouteConfig{
 		Target:              target,
 		CollectStaticAssets: collectStaticAssets,
@@ -1169,22 +1163,12 @@ func getDiscoverRouteConfig(target string, ignoreCrossDomain bool, collectStatic
 		RequestMethod:       requestMethod,
 		HeadlessConfig:      headlessConfig,
 		BrowserbaseConfig:   browserbaseConfig,
-		FetchSourceMaps:     &fetchSourceMaps,
+		FetchSourceMaps:     fetchSourceMaps,
+		MaxBundles:          maxBundles,
 	}
 
-	// Only set BundleUrls if any were provided
 	if len(bundleURLs) > 0 {
 		config.BundleUrls = bundleURLs
-	}
-
-	// Only set MaxBundles if non-zero
-	if maxBundles > 0 {
-		config.MaxBundles = &maxBundles
-	}
-
-	// Only set MaxRoutes if non-zero
-	if maxRoutes > 0 {
-		config.MaxRoutes = &maxRoutes
 	}
 
 	return config

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -1013,6 +1013,8 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 		HeadlessConfig:      headlessConfig,
 		BrowserbaseConfig:   browserBaseConfig,
 		UserAgent:           userAgent,
+		FetchSourceMaps:     true,
+		MaxBundles:          -1,
 	}
 	// Create Static Asset Takeover Config with nested route capture config
 	config := pentestroutefern.PentestRouteStaticAssetTakeoverConfig{

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -18,9 +18,8 @@ types:
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>
       bundleUrls: optional<list<string>>
-      fetchSourceMaps: optional<boolean>
-      maxBundles: optional<integer>
-      maxRoutes: optional<integer>
+      fetchSourceMaps: boolean
+      maxBundles: integer
   # Report Struct
   RouteBodyParam:
     properties:

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -697,12 +697,8 @@ func fetchSourceMapRoutes(ctx context.Context, sourceMapURL string, baseURL stri
 	return routes, urls, errors
 }
 
-// shouldFetchSourceMaps returns true when source map fetching is enabled (default: true).
 func shouldFetchSourceMaps(routeCaptureConfig discover.DiscoverRouteConfig) bool {
-	if routeCaptureConfig.FetchSourceMaps == nil {
-		return true
-	}
-	return *routeCaptureConfig.FetchSourceMaps
+	return routeCaptureConfig.FetchSourceMaps
 }
 
 // ExtractScriptRoutes finds script elements with a src attribute, fetches the JavaScript data, parses it, and extracts routes.
@@ -712,11 +708,15 @@ func ExtractScriptRoutes(ctx context.Context, doc *goquery.Document, baseURL str
 	urls := make(map[string]struct{})
 	errors := []string{}
 
+	if routeCaptureConfig.MaxBundles == 0 {
+		return routes, discoverroutehelpers.SetToListString(urls), errors
+	}
+
 	bundleCount := 0
 
 	doc.Find("script[src]").Each(func(i int, s *goquery.Selection) {
 		// Honor MaxBundles limit
-		if routeCaptureConfig.MaxBundles != nil && *routeCaptureConfig.MaxBundles > 0 && bundleCount >= *routeCaptureConfig.MaxBundles {
+		if routeCaptureConfig.MaxBundles > 0 && bundleCount >= routeCaptureConfig.MaxBundles {
 			return
 		}
 
@@ -799,10 +799,14 @@ func ExtractBundleURLRoutes(ctx context.Context, bundleURLs []string, baseURL st
 	urls := make(map[string]struct{})
 	errors := []string{}
 
+	if routeCaptureConfig.MaxBundles == 0 {
+		return routes, discoverroutehelpers.SetToListString(urls), errors
+	}
+
 	bundleCount := 0
 	for _, bundleURL := range bundleURLs {
 		// Honor MaxBundles limit (count successful fetches only, consistent with ExtractScriptRoutes)
-		if routeCaptureConfig.MaxBundles != nil && *routeCaptureConfig.MaxBundles > 0 && bundleCount >= *routeCaptureConfig.MaxBundles {
+		if routeCaptureConfig.MaxBundles > 0 && bundleCount >= routeCaptureConfig.MaxBundles {
 			break
 		}
 

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -505,7 +505,7 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 	sort.SliceStable(report.Result.Routes, func(i, j int) bool {
 		ri := report.Result.Routes[i]
 		rj := report.Result.Routes[j]
-		// Evidence-tagged routes survive MaxRoutes cap before untagged routes
+		// Prefer evidence-tagged routes while keeping output deterministic.
 		hasEvi := ri.Evidence != nil
 		hasEvj := rj.Evidence != nil
 		if hasEvi != hasEvj {
@@ -514,9 +514,6 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 		// Same evidence tier: lexical for determinism
 		return ri.BaseUrl+ri.Path < rj.BaseUrl+rj.Path
 	})
-	if config.MaxRoutes != nil && *config.MaxRoutes > 0 && len(report.Result.Routes) > *config.MaxRoutes {
-		report.Result.Routes = report.Result.Routes[:*config.MaxRoutes]
-	}
 	report.Result.StaticAssets = discoverroutehelpers.MergeStaticAssets(allStaticAssets)
 	report.Errors = append(report.Errors, errors...)
 	return report


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema and CLI semantics changed (max-bundles 0 vs -1, removed max-routes), which can break API consumers and increase route/bundle scan volume versus prior capped behavior.
> 
> **Overview**
> **Discover route** config is simplified: **`--max-routes`** and **`MaxRoutes`** are removed, so route discovery no longer truncates the merged route list (evidence-first sorting remains for deterministic output).
> 
> **`fetchSourceMaps`** and **`maxBundles`** are required fields in the Fern **`DiscoverRouteConfig`** (not optional pointers). The CLI always passes them through **`getDiscoverRouteConfig`**; **`--max-bundles`** now defaults to **`-1`** (unlimited) and **`0`** disables JS bundle scanning in **`ExtractScriptRoutes`** / **`ExtractBundleURLRoutes`**.
> 
> **`pentest route static-asset-takeover`** sets **`FetchSourceMaps: true`** and **`MaxBundles: -1`** on the nested route capture config so bundle behavior matches discover defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7596e60e5b4bd5c699856d44b53d622303d14f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->