### PR TITLE
Update IOT Enum Values

### DIFF
--- a/utils/nuclei/templates/discover/application/internetofthings/2n-helios-ip-intercom.yaml
+++ b/utils/nuclei/templates/discover/application/internetofthings/2n-helios-ip-intercom.yaml
@@ -6,7 +6,7 @@ info:
   description: Detects 2N Helios IP intercom web interfaces using Helios IP titles and HIP server markers.
   metadata:
     method-application-type: INTERNET_OF_THINGS
-    method-module-name: 2N_HELIOS_IP_INTERCOM
+    method-module-name: TWO_N_HELIOS_IP_INTERCOM
     cpe: cpe:2.3:h:2n:helios_ip:*:*:*:*:*:*:*:*
   tags: discovery,iot,intercom,access-control,2n
 http:

--- a/utils/nuclei/templates/discover/application/internetofthings/crestron-airmedia.yaml
+++ b/utils/nuclei/templates/discover/application/internetofthings/crestron-airmedia.yaml
@@ -6,7 +6,7 @@ info:
   description: Detects Crestron room control and presentation web interfaces using Crestron web server and AirMedia markers.
   metadata:
     method-application-type: INTERNET_OF_THINGS
-    method-module-name: CRESTRON_WEB_INTERFACE
+    method-module-name: CRESTRON_AIRMEDIA
     cpe: cpe:2.3:h:crestron:*:*:*:*:*:*:*:*:*
   tags: discovery,iot,av,crestron,airmedia
 http:
@@ -19,11 +19,6 @@ http:
     max-redirects: 5
     stop-at-first-match: true
     matchers:
-      - type: word
-        part: header
-        words:
-          - "Crestron Webserver"
-        case-insensitive: true
       - type: word
         part: body
         words:

--- a/utils/nuclei/templates/discover/application/internetofthings/dahua-oem-web-service.yaml
+++ b/utils/nuclei/templates/discover/application/internetofthings/dahua-oem-web-service.yaml
@@ -6,7 +6,7 @@ info:
   description: Detects Dahua-derived OEM camera, DVR, and NVR web interfaces using Web Service asset markers.
   metadata:
     method-application-type: INTERNET_OF_THINGS
-    method-module-name: DAHUA_OEM_WEB_SERVICE
+    method-module-name: DAHUA_WEB_SERVICE
   tags: discovery,iot,camera,dvr,nvr,dahua,oem
 http:
   - method: GET


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enum renames can break downstream mapping if consumers still expect old module names; Crestron matcher change may reduce or shift what gets classified as Crestron AirMedia.
> 
> **Overview**
> Aligns three IoT Nuclei discovery templates with **renamed `method-module-name` enum values**: `2N_HELIOS_IP_INTERCOM` → `TWO_N_HELIOS_IP_INTERCOM`, `CRESTRON_WEB_INTERFACE` → `CRESTRON_AIRMEDIA`, and `DAHUA_OEM_WEB_SERVICE` → `DAHUA_WEB_SERVICE`.
> 
> For **Crestron AirMedia**, detection is tightened by **dropping** the HTTP header matcher on `Crestron Webserver`, so matches rely on body markers (AirMedia title and related strings) instead of generic Crestron web server headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f816ee72f076712ffbbd74de4bbd18b244825522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->