### PR TITLE
Update Network Navigation + Headless Error Handling

### DIFF
--- a/internal/discover/page/helpers/screenshot.go
+++ b/internal/discover/page/helpers/screenshot.go
@@ -97,7 +97,6 @@ func captureScreenshotOnce(ctx context.Context, browser *headless.Requester, sen
 	err = page.Navigate(fullURL)
 	if err != nil {
 		log.Warn("Navigation encountered error but continuing", svc1log.SafeParam("error", err.Error()))
-		return nil, err
 	}
 
 	// Wait for the page to load

--- a/internal/discover/page/helpers/screenshot.go
+++ b/internal/discover/page/helpers/screenshot.go
@@ -20,6 +20,38 @@ import (
 
 // CaptureScreenshot uses a headless browser to capture a screenshot of the given URL and returns the image bytes.
 func CaptureScreenshot(ctx context.Context, browser *headless.Requester, sendHTTPRequestConfig *common.SendHttpRequestConfig) ([]byte, error) {
+	log := svc1log.FromContext(ctx)
+	const maxScreenshotAttempts = 3
+
+	var lastErr error
+	for attempt := 1; attempt <= maxScreenshotAttempts; attempt++ {
+		if attempt > 1 {
+			delay := time.Duration(attempt-1) * 250 * time.Millisecond
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			log.Warn("Retrying transient screenshot capture failure",
+				svc1log.SafeParam("attempt", attempt),
+				svc1log.SafeParam("maxAttempts", maxScreenshotAttempts))
+		}
+
+		img, err := captureScreenshotOnce(ctx, browser, sendHTTPRequestConfig)
+		if err == nil {
+			return img, nil
+		}
+		lastErr = err
+		if !headless.IsTransientHeadlessError(err) || ctx.Err() != nil {
+			return nil, err
+		}
+		browser.ResetOwnedBrowser(ctx, err.Error())
+	}
+
+	return nil, lastErr
+}
+
+func captureScreenshotOnce(ctx context.Context, browser *headless.Requester, sendHTTPRequestConfig *common.SendHttpRequestConfig) ([]byte, error) {
 	// Get the logger from the context
 	log := svc1log.FromContext(ctx)
 
@@ -43,6 +75,11 @@ func CaptureScreenshot(ctx context.Context, browser *headless.Requester, sendHTT
 		log.Error("Failed to create page for screenshot", svc1log.SafeParam("error", err))
 		return nil, err
 	}
+	defer func() {
+		if closeErr := page.Close(); closeErr != nil {
+			log.Debug("Failed to close screenshot page", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
 
 	// Apply the same user-agent override the HTML SendRequest path uses so a
 	// single --user-agent invocation produces consistent UAs across the HTML
@@ -60,6 +97,7 @@ func CaptureScreenshot(ctx context.Context, browser *headless.Requester, sendHTT
 	err = page.Navigate(fullURL)
 	if err != nil {
 		log.Warn("Navigation encountered error but continuing", svc1log.SafeParam("error", err.Error()))
+		return nil, err
 	}
 
 	// Wait for the page to load
@@ -85,12 +123,6 @@ func CaptureScreenshot(ctx context.Context, browser *headless.Requester, sendHTT
 		return nil, err
 	}
 	log.Info("Screenshot captured")
-
-	err = page.Close()
-	if err != nil {
-		log.Error("Failed to close page", svc1log.SafeParam("url", fmt.Sprintf("%s%s", sendHTTPRequestConfig.Request.BaseUrl, sendHTTPRequestConfig.Request.Path)), svc1log.SafeParam("error", err))
-		return nil, err
-	}
 
 	return img, nil
 }

--- a/internal/discover/route/helpers/extractors/networkExtractors.go
+++ b/internal/discover/route/helpers/extractors/networkExtractors.go
@@ -3,7 +3,11 @@ package discoverroute
 import (
 	// Standard
 	"context"
+	stderrors "errors"
+	"fmt"
 	"net/url"
+	"sync"
+	"time"
 
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
@@ -21,6 +25,39 @@ import (
 // ExtractNetworkRoutes uses a headless browser to capture network requests and extract route details from them.
 // Returns a slice of RouteDetails, a slice of URLs, and a slice of errors.
 func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, target string, ignoreCrossDomain bool, captureStaticAssets bool) ([]*discover.RouteDetails, []string, []string) {
+	log := svc1log.FromContext(ctx)
+	const maxNetworkCaptureAttempts = 3
+
+	var lastRoutes []*discover.RouteDetails
+	var lastUrls []string
+	var lastErrors []string
+	for attempt := 1; attempt <= maxNetworkCaptureAttempts; attempt++ {
+		if attempt > 1 {
+			if !sleepBeforeNetworkCaptureRetry(ctx, attempt) {
+				break
+			}
+			log.Warn("Retrying transient network route capture failure",
+				svc1log.SafeParam("attempt", attempt),
+				svc1log.SafeParam("maxAttempts", maxNetworkCaptureAttempts),
+				svc1log.SafeParam("target", target))
+		}
+
+		routes, urls, errors := extractNetworkRoutesOnce(ctx, browser, target, ignoreCrossDomain, captureStaticAssets)
+		lastRoutes = routes
+		lastUrls = urls
+		lastErrors = errors
+		if len(routes) > 0 || !networkCaptureErrorsAreTransient(errors) || ctx.Err() != nil {
+			return routes, urls, errors
+		}
+		if len(errors) > 0 {
+			browser.ResetOwnedBrowser(ctx, errors[0])
+		}
+	}
+
+	return lastRoutes, lastUrls, lastErrors
+}
+
+func extractNetworkRoutesOnce(ctx context.Context, browser *headless.Requester, target string, ignoreCrossDomain bool, captureStaticAssets bool) ([]*discover.RouteDetails, []string, []string) {
 	// Get the logger from the context
 	log := svc1log.FromContext(ctx)
 
@@ -38,62 +75,80 @@ func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, targ
 		}
 	}
 
-	var page *rod.Page
-	pageErr := rod.Try(func() {
-		page = browser.Browser.MustPage(target).Context(ctx)
-	})
-	if pageErr != nil {
-		log.Error("Failed to create page", svc1log.SafeParam("url", target), svc1log.SafeParam("error", pageErr))
-		errors = append(errors, pageErr.Error())
+	page, err := browser.Browser.Page(proto.TargetCreateTarget{})
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to create page: %s", cleanNetworkCaptureError(err))
+		log.Error("Failed to create page", svc1log.SafeParam("url", target), svc1log.SafeParam("error", errMsg))
+		errors = append(errors, errMsg)
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
+	createdPage := page
+	defer func() {
+		if closeErr := createdPage.Close(); closeErr != nil {
+			log.Debug("Failed to close network capture page", svc1log.SafeParam("error", cleanNetworkCaptureError(closeErr)))
+		}
+	}()
+
+	captureCtx, stopNetworkCapture := context.WithCancel(ctx)
+	defer stopNetworkCapture()
+	page = page.Context(captureCtx)
 	log.Debug("Successfully connected to page for network capture")
 
 	// Enable network event tracking
 	networkEventErr := proto.NetworkEnable{}.Call(page)
 	if networkEventErr != nil {
-		log.Error("Failed to enable network tracking", svc1log.SafeParam("error", networkEventErr))
-		errors = append(errors, networkEventErr.Error())
+		errMsg := fmt.Sprintf("failed to enable network tracking: %s", cleanNetworkCaptureError(networkEventErr))
+		log.Error("Failed to enable network tracking", svc1log.SafeParam("error", errMsg))
+		errors = append(errors, errMsg)
 		return routes, discoverroutehelpers.SetToListString(urls), errors
 	}
 
 	log.Info("Capturing network events")
-	// Capture network requests of type 'fetch' which are typical of API calls
+	// Capture API-style requests that may only appear during browser execution.
 	networkEvents := []*proto.NetworkRequestWillBeSent{}
+	var networkEventsMu sync.Mutex
 	waitForNetworkEvents := page.EachEvent(func(e *proto.NetworkRequestWillBeSent) {
 		log.Debug("Captured network event", svc1log.SafeParam("url", e.Request.URL), svc1log.SafeParam("type", e.Type))
-		// Only capture fetch requests
-		if e.Type == proto.NetworkResourceTypeFetch {
+		if isRouteNetworkResourceType(e.Type) {
+			networkEventsMu.Lock()
 			networkEvents = append(networkEvents, e)
+			networkEventsMu.Unlock()
 		}
 	})
+	networkEventsDone := make(chan struct{})
+	go func() {
+		waitForNetworkEvents()
+		close(networkEventsDone)
+	}()
 
 	// Navigate to the page
-	err := page.Navigate(target)
+	err = page.Navigate(target)
 	if err != nil {
-		log.Error("Failed to navigate to page", svc1log.SafeParam("url", target), svc1log.SafeParam("error", err))
-		errors = append(errors, err.Error())
-		return routes, discoverroutehelpers.SetToListString(urls), errors
-	}
-	// Wait for the page to load
-	err = page.WaitLoad()
-	if err != nil {
-		log.Debug("Failed to wait for page load", svc1log.SafeParam("url", target), svc1log.SafeParam("error", err))
-		errors = append(errors, err.Error())
-		// Reload the page if it can't load, possible redirect
-		reloadErr := page.Reload()
-		if reloadErr != nil {
-			log.Error("Failed to reload page", svc1log.SafeParam("url", target), svc1log.SafeParam("error", reloadErr))
-			errors = append(errors, reloadErr.Error())
-			return routes, discoverroutehelpers.SetToListString(urls), errors
+		errMsg := fmt.Sprintf("failed to navigate to page: %s", cleanNetworkCaptureError(err))
+		log.Warn("Failed to navigate to page, processing captured network events", svc1log.SafeParam("url", target), svc1log.SafeParam("error", errMsg))
+		errors = append(errors, errMsg)
+	} else {
+		// Wait for the page to load. If this fails, keep any events already captured.
+		err = page.WaitLoad()
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to wait for page load: %s", cleanNetworkCaptureError(err))
+			log.Debug("Failed to wait for page load, processing captured network events", svc1log.SafeParam("url", target), svc1log.SafeParam("error", errMsg))
+			errors = append(errors, errMsg)
 		}
 	}
+
+	waitForNetworkStabilization(ctx, browser.MinDOMStabalizeTimeSeconds)
+
 	// Wait for network events to be captured
-	waitForNetworkEvents()
+	stopNetworkCapture()
+	<-networkEventsDone
 
 	log.Info("Processing network events")
 	// Process network events and populate the WebRoute structure
-	for _, event := range networkEvents {
+	networkEventsMu.Lock()
+	capturedNetworkEvents := append([]*proto.NetworkRequestWillBeSent(nil), networkEvents...)
+	networkEventsMu.Unlock()
+	for _, event := range capturedNetworkEvents {
 		request := event.Request
 
 		// Filter requests by base domain if required
@@ -148,4 +203,67 @@ func ExtractNetworkRoutes(ctx context.Context, browser *headless.Requester, targ
 	}
 
 	return discoverroutehelpers.MergeWebRoutes(routes), discoverroutehelpers.SetToListString(urls), errors
+}
+
+func isRouteNetworkResourceType(resourceType proto.NetworkResourceType) bool {
+	return resourceType == proto.NetworkResourceTypeFetch || resourceType == proto.NetworkResourceTypeXHR
+}
+
+func waitForNetworkStabilization(ctx context.Context, minDOMStabalizeTimeSeconds int) {
+	waitSeconds := minDOMStabalizeTimeSeconds
+	if waitSeconds <= 0 {
+		waitSeconds = 2
+	}
+
+	select {
+	case <-time.After(time.Duration(waitSeconds) * time.Second):
+	case <-ctx.Done():
+	}
+}
+
+func sleepBeforeNetworkCaptureRetry(ctx context.Context, attempt int) bool {
+	delay := time.Duration(attempt-1) * 250 * time.Millisecond
+	select {
+	case <-time.After(delay):
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func networkCaptureErrorsAreTransient(errorMessages []string) bool {
+	if len(errorMessages) == 0 {
+		return false
+	}
+	for _, msg := range errorMessages {
+		if headless.IsTransientHeadlessError(fmt.Errorf("%s", msg)) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanNetworkCaptureError(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+
+	var navErr *rod.NavigationError
+	if stderrors.As(err, &navErr) {
+		return navErr.Reason
+	}
+
+	var tryErr *rod.TryError
+	if stderrors.As(err, &tryErr) {
+		return fmt.Sprintf("%v", tryErr.Value)
+	}
+
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		return "network route capture timed out"
+	}
+	if stderrors.Is(err, context.Canceled) {
+		return "network route capture canceled"
+	}
+
+	return err.Error()
 }

--- a/utils/request/headless/browserbase/browserbase.go
+++ b/utils/request/headless/browserbase/browserbase.go
@@ -41,8 +41,14 @@ func NewBrowserbaseRequester(
 		return nil
 	}
 	client := cdp.New().Start(websocket)
+	headlessRequester, err := headless.NewRequesterWithClient(client, timeout, minDOMStabalizeTime)
+	if err != nil {
+		svc1log.FromContext(ctx).Error("Failed to connect to browserbase CDP session", svc1log.SafeParam("error", err.Error()))
+		return nil
+	}
+
 	return &Requester{
-		Requester: headless.NewRequesterWithClient(client, timeout, minDOMStabalizeTime),
+		Requester: headlessRequester,
 		Client:    browserbaseClient,
 	}
 }

--- a/utils/request/headless/client.go
+++ b/utils/request/headless/client.go
@@ -14,6 +14,7 @@ type Requester struct {
 	PathToBrowser              *string
 	TimeoutSeconds             int
 	MinDOMStabalizeTimeSeconds int
+	ownsBrowser                bool
 }
 
 // NewRequester creates a new Requester with the given timeout and headless configuration.
@@ -42,8 +43,11 @@ func NewRequesterwithBrowser(timeout int, config *common.HeadlessRequestConfig) 
 
 // NewRequesterWithClient creates a new Requester using an existing rod cdp.Client.
 func NewRequesterWithClient(client *cdp.Client, timeout int, minDOMStabalizeTime int) *Requester {
+	browser := rod.New().Client(client)
+	_ = browser.Connect()
+
 	return &Requester{
-		Browser:                    rod.New().Client(client).MustConnect(),
+		Browser:                    browser,
 		PathToBrowser:              nil,
 		TimeoutSeconds:             timeout,
 		MinDOMStabalizeTimeSeconds: minDOMStabalizeTime,

--- a/utils/request/headless/client.go
+++ b/utils/request/headless/client.go
@@ -1,6 +1,9 @@
 package headless
 
 import (
+	// Standard
+	"fmt"
+
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	// External
@@ -42,14 +45,16 @@ func NewRequesterwithBrowser(timeout int, config *common.HeadlessRequestConfig) 
 }
 
 // NewRequesterWithClient creates a new Requester using an existing rod cdp.Client.
-func NewRequesterWithClient(client *cdp.Client, timeout int, minDOMStabalizeTime int) *Requester {
+func NewRequesterWithClient(client *cdp.Client, timeout int, minDOMStabalizeTime int) (*Requester, error) {
 	browser := rod.New().Client(client)
-	_ = browser.Connect()
+	if err := browser.Connect(); err != nil {
+		return nil, fmt.Errorf("browser connection failed: %v", err)
+	}
 
 	return &Requester{
 		Browser:                    browser,
 		PathToBrowser:              nil,
 		TimeoutSeconds:             timeout,
 		MinDOMStabalizeTimeSeconds: minDOMStabalizeTime,
-	}
+	}, nil
 }

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -78,12 +78,47 @@ func (b *Requester) InitializeBrowser(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("browser connection failed: %v", err)
 	}
+	b.ownsBrowser = true
 
 	return nil
 }
 
 // SendRequest navigates to a URL using the headless browser and captures the response
 func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpRequestConfig) (common.HttpRequestResponse, error) {
+	log := svc1log.FromContext(ctx)
+	attempts := headlessCaptureAttempts(config.Request.Method)
+	var lastReport common.HttpRequestResponse
+	var lastErr error
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			if !sleepBeforeHeadlessRetry(ctx, attempt) {
+				break
+			}
+		}
+
+		report, err := b.sendRequestOnce(ctx, config)
+		if err == nil {
+			return report, nil
+		}
+
+		lastReport = report
+		lastErr = err
+		if attempt == attempts || !IsTransientHeadlessError(err) || ctx.Err() != nil {
+			return report, err
+		}
+
+		log.Warn("Retrying transient headless capture failure",
+			svc1log.SafeParam("attempt", attempt+1),
+			svc1log.SafeParam("maxAttempts", attempts),
+			svc1log.SafeParam("error", cleanErrMsg(err)))
+		b.restartOwnedBrowser(ctx, cleanErrMsg(err))
+	}
+
+	return lastReport, lastErr
+}
+
+func (b *Requester) sendRequestOnce(ctx context.Context, config common.SendHttpRequestConfig) (common.HttpRequestResponse, error) {
 	// =========================================================================================
 	// SETUP
 	// =========================================================================================
@@ -125,6 +160,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		redirectChain   = []string{*constructedURL}
 		redirectChainMu sync.Mutex
 		browserErr      error
+		navigationErr   error
 		statusCode      int
 	)
 
@@ -169,12 +205,12 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		}
 
 		// Setup request monitoring and navigate
-		headerCapture := setupHeaderInterception(page)
+		headerCapture := setupHeaderInterception(page, log)
 		handleNavigation(ctx, page, &redirectChain, &redirectChainMu, requestComplete, &once, config.MaxRedirects, browsersErr)
 
-		navErr := performNavigation(ctx, page, constructedURL, config)
-		if navErr != nil {
-			log.Info("Unexpected navigation error, but continuing to extract data anyway", svc1log.SafeParam("error", cleanErrMsg(navErr)))
+		navigationErr = performNavigation(ctx, page, constructedURL, config)
+		if navigationErr != nil {
+			log.Info("Unexpected navigation error, but continuing to extract data anyway", svc1log.SafeParam("error", cleanErrMsg(navigationErr)))
 		}
 
 		// Wait for navigation completion or timeout
@@ -205,7 +241,13 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 			redirectChainMu.Lock()
 			chain := strings.Join(redirectChain, " -> ")
 			redirectChainMu.Unlock()
-			if ctx.Err() == context.DeadlineExceeded {
+			if navigationErr != nil {
+				log.Warn("Request did not complete after navigation error",
+					svc1log.SafeParam("url", *constructedURL),
+					svc1log.SafeParam("error", cleanErrMsg(navigationErr)),
+					svc1log.SafeParam("redirectChain", chain))
+				browserErr = navigationErr
+			} else if ctx.Err() == context.DeadlineExceeded {
 				log.Warn("Request timed out",
 					svc1log.SafeParam("url", *constructedURL),
 					svc1log.SafeParam("timeout", config.Timeout),
@@ -267,7 +309,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 				statusCode = 200
 			} else {
 				statusCode = getStatusCodeFromPage(page)
-				if statusCode == 0 && browserErr == nil {
+				if statusCode == 0 && browserErr == nil && navigationErr == nil {
 					statusCode = 200
 				}
 			}
@@ -290,7 +332,7 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 				} else if val, ok := resultMap["performanceStatus"]; ok && val.Int() > 0 {
 					statusCode = val.Int()
 				}
-				if statusCode == 0 && browserErr == nil {
+				if statusCode == 0 && browserErr == nil && navigationErr == nil {
 					statusCode = 200 // Default for successful navigation
 				}
 			}
@@ -324,7 +366,14 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		// Check if Chrome error page using batch result
 		if isErrorPage {
 			log.Warn("Detected Chrome error page, treating as navigation failure")
-			browserErr = fmt.Errorf("navigation failed: Chrome error page detected")
+			if navigationErr != nil {
+				browserErr = navigationErr
+			} else {
+				browserErr = fmt.Errorf("navigation failed: Chrome error page detected")
+			}
+		}
+		if browserErr == nil && navigationErr != nil && statusCode == 0 {
+			browserErr = navigationErr
 		}
 
 		// Use the latest captured main-document headers after stabilization so
@@ -388,9 +437,9 @@ func (b *Requester) SendRequest(ctx context.Context, config common.SendHttpReque
 		)
 		report.Response = &response
 	}); err != nil {
-		log.Error("Browser operation failed with panic", svc1log.SafeParam("error", err.Error()))
+		log.Error("Browser operation failed with panic", svc1log.SafeParam("error", cleanErrMsg(err)))
 		if browserErr == nil {
-			browserErr = fmt.Errorf("browser operation panicked: %v", err)
+			browserErr = fmt.Errorf("browser operation panicked: %w", err)
 		}
 	}
 

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -241,22 +241,26 @@ func (b *Requester) sendRequestOnce(ctx context.Context, config common.SendHttpR
 			redirectChainMu.Lock()
 			chain := strings.Join(redirectChain, " -> ")
 			redirectChainMu.Unlock()
-			if navigationErr != nil {
-				log.Warn("Request did not complete after navigation error",
-					svc1log.SafeParam("url", *constructedURL),
-					svc1log.SafeParam("error", cleanErrMsg(navigationErr)),
-					svc1log.SafeParam("redirectChain", chain))
-				browserErr = navigationErr
-			} else if ctx.Err() == context.DeadlineExceeded {
-				log.Warn("Request timed out",
+			if ctx.Err() == context.DeadlineExceeded {
+				logParams := []svc1log.Param{
 					svc1log.SafeParam("url", *constructedURL),
 					svc1log.SafeParam("timeout", config.Timeout),
-					svc1log.SafeParam("redirectChain", chain))
+					svc1log.SafeParam("redirectChain", chain),
+				}
+				if navigationErr != nil {
+					logParams = append(logParams, svc1log.SafeParam("navigationError", cleanErrMsg(navigationErr)))
+				}
+				log.Warn("Request timed out", logParams...)
 				browserErr = fmt.Errorf("request timeout after %d seconds", config.Timeout)
 			} else {
-				log.Warn("Request cancelled",
+				logParams := []svc1log.Param{
 					svc1log.SafeParam("url", *constructedURL),
-					svc1log.SafeParam("error", ctx.Err()))
+					svc1log.SafeParam("error", ctx.Err()),
+				}
+				if navigationErr != nil {
+					logParams = append(logParams, svc1log.SafeParam("navigationError", cleanErrMsg(navigationErr)))
+				}
+				log.Warn("Request cancelled", logParams...)
 				browserErr = fmt.Errorf("request cancelled: %v", ctx.Err())
 			}
 			return

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -55,14 +55,16 @@ func (n *NetworkHeaderCapture) GetHeaders() map[string][]string {
 }
 
 // setupHeaderInterception sets up network event monitoring to capture response headers
-func setupHeaderInterception(page *rod.Page) *NetworkHeaderCapture {
+func setupHeaderInterception(page *rod.Page, log svc1log.Logger) *NetworkHeaderCapture {
 	headerCapture := NewNetworkHeaderCapture()
 
-	// Enable network domain to capture network events
-	page.MustEval(`() => {
+	// Keep the legacy JS fallback best-effort; network events are the primary source.
+	if _, err := page.Eval(`() => {
 		// Store for backward compatibility, but we'll use network events for actual capture
 		window.responseHeaders = new Map();
-	}`)
+	}`); err != nil {
+		log.Debug("Failed to initialize response header fallback", svc1log.SafeParam("error", cleanErrMsg(err)))
+	}
 
 	// Enable network domain
 	page.EnableDomain(proto.NetworkEnable{})
@@ -401,6 +403,91 @@ func isDefaultPort(scheme, port string) bool {
 	return (scheme == "http" && port == "80") || (scheme == "https" && port == "443")
 }
 
+func headlessCaptureAttempts(method common.HttpMethod) int {
+	switch method {
+	case "", common.HttpMethodGet, common.HttpMethodHead, common.HttpMethodOptions, common.HttpMethodTrace:
+		return 3
+	default:
+		return 1
+	}
+}
+
+func sleepBeforeHeadlessRetry(ctx context.Context, attempt int) bool {
+	delay := time.Duration(attempt-1) * 250 * time.Millisecond
+	if delay <= 0 {
+		return true
+	}
+
+	select {
+	case <-time.After(delay):
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (b *Requester) restartOwnedBrowser(ctx context.Context, reason string) {
+	if b == nil || b.Browser == nil || !b.ownsBrowser {
+		return
+	}
+
+	log := svc1log.FromContext(ctx)
+	log.Warn("Restarting owned headless browser after transient failure", svc1log.SafeParam("reason", reason))
+	if err := b.Browser.Close(); err != nil {
+		log.Debug("Failed to close owned headless browser", svc1log.SafeParam("error", cleanErrMsg(err)))
+	}
+	b.Browser = nil
+	b.ownsBrowser = false
+}
+
+// ResetOwnedBrowser closes a browser launched by this requester so the next
+// operation can start from a fresh browser process. Caller-owned browsers and
+// externally supplied CDP clients are left untouched.
+func (b *Requester) ResetOwnedBrowser(ctx context.Context, reason string) {
+	b.restartOwnedBrowser(ctx, reason)
+}
+
+// IsTransientHeadlessError returns true for browser/network failures worth retrying
+// with a fresh page or, when owned by this requester, a fresh browser.
+func IsTransientHeadlessError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	errStr := strings.ToUpper(err.Error())
+	cleaned := strings.ToUpper(cleanErrMsg(err))
+	transientMarkers := []string{
+		"ERR_NETWORK_CHANGED",
+		"ERR_CONNECTION_RESET",
+		"ERR_CONNECTION_CLOSED",
+		"ERR_CONNECTION_ABORTED",
+		"ERR_CONNECTION_TIMED_OUT",
+		"ERR_TIMED_OUT",
+		"ERR_NAME_NOT_RESOLVED",
+		"ERR_INTERNET_DISCONNECTED",
+		"ERR_ADDRESS_UNREACHABLE",
+		"ERR_PROXY_CONNECTION_FAILED",
+		"ERR_TUNNEL_CONNECTION_FAILED",
+		"ERR_SOCKS_CONNECTION_FAILED",
+		"CONNECTION TIMEOUT",
+		"DNS RESOLUTION FAILED",
+		"NO INTERNET CONNECTION",
+		"ADDRESS UNREACHABLE",
+		"REQUEST TIMEOUT",
+		"NETWORK ROUTE CAPTURE TIMED OUT",
+		"CHROME ERROR PAGE DETECTED",
+		"TARGET CLOSED",
+		"CONNECTION CLOSED",
+		"WEBSOCKET",
+	}
+	for _, marker := range transientMarkers {
+		if strings.Contains(errStr, marker) || strings.Contains(cleaned, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 func cloneHeaders(headers map[string][]string) map[string][]string {
 	result := make(map[string][]string, len(headers))
 	for key, values := range headers {
@@ -563,10 +650,10 @@ func performNavigation(ctx context.Context, page *rod.Page, constructedURL *stri
 		var navErr *rod.NavigationError
 		if errors.As(err, &navErr) {
 			log.Warn("Navigation encountered error but continuing", svc1log.SafeParam("error", navErr.Reason))
-			return nil // Don't fail - page might still be partially loaded
+			return err // Let the caller process partial state and decide whether to retry.
 		}
 		log.Warn("Navigation encountered error but continuing", svc1log.SafeParam("error", err.Error()))
-		return nil // Don't fail - page might still be partially loaded
+		return err // Let the caller process partial state and decide whether to retry.
 	}
 
 	// Skip the WaitLoad here - waitForPageLoad will handle this more efficiently
@@ -744,6 +831,14 @@ func isCrossDomainRedirect(originalURL, redirectURL string) bool {
 func cleanErrMsg(err error) string {
 	if err == nil {
 		return "unknown error"
+	}
+
+	var tryErr *rod.TryError
+	if errors.As(err, &tryErr) {
+		if valueErr, ok := tryErr.Value.(error); ok {
+			return cleanErrMsg(valueErr)
+		}
+		return fmt.Sprintf("%v", tryErr.Value)
 	}
 
 	// Check for rod.NavigationError

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -413,7 +413,7 @@ func headlessCaptureAttempts(method common.HttpMethod) int {
 }
 
 func sleepBeforeHeadlessRetry(ctx context.Context, attempt int) bool {
-	delay := time.Duration(attempt-1) * 250 * time.Millisecond
+	delay := 3 * time.Second
 	if delay <= 0 {
 		return true
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core headless HTTP capture and route discovery behavior (retries, partial-success paths, and navigation error propagation), which can change scan outcomes and timing without affecting auth or data stores directly.
> 
> **Overview**
> Adds **transient failure recovery** across headless flows: `SendRequest` (up to 3 retries for GET-like methods), screenshot capture, and network route extraction retry when errors look like flaky network/browser issues, optionally **restarting only locally owned browser processes** via `ResetOwnedBrowser` / `ownsBrowser` (external CDP/Browserbase sessions are not torn down).
> 
> **Network route discovery** is reworked to create pages explicitly, always **defer-close** pages, capture **Fetch and XHR** (not only Fetch), wait for DOM stabilization before stopping listeners, and **keep processing events** when navigation or `WaitLoad` fails instead of bailing (reload-on-fail removed). Errors are normalized with helpers like `cleanNetworkCaptureError`.
> 
> **Headless request capture** splits single-shot logic into `sendRequestOnce`, surfaces **navigation errors** separately for timeouts/status handling, returns navigation errors from `performNavigation` for retry decisions, and replaces panicking `MustConnect` in `NewRequesterWithClient` with a proper `Connect` error (Browserbase wiring updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afaebba8576712a8fcd1baa7d9e854c8f976ef1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->