### PR TITLE
Fix Content Parsing When Wrapped in Chrome View Page

### DIFF
--- a/utils/request/headless/client.go
+++ b/utils/request/headless/client.go
@@ -3,7 +3,6 @@ package headless
 import (
 	// Standard
 	"fmt"
-
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	// External

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -546,6 +546,42 @@ func isChromeStaticAssetViewerHTML(htmlContent string) bool {
 	}
 }
 
+func isChromeTextDocumentViewerHTML(htmlContent string) bool {
+	if htmlContent == "" || len(htmlContent) > 256*1024 {
+		return false
+	}
+
+	content := strings.ToLower(htmlContent)
+	if !strings.Contains(content, "<pre") || !strings.Contains(content, `name="color-scheme"`) {
+		return false
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
+	if err != nil {
+		return false
+	}
+	if doc.Find(`head meta[name="color-scheme"]`).Length() == 0 {
+		return false
+	}
+	body := doc.Find("body")
+	if body.Length() != 1 {
+		return false
+	}
+	children := body.Children()
+	switch children.Length() {
+	case 1:
+		return strings.EqualFold(goquery.NodeName(children.First()), "pre")
+	case 2:
+		first := children.First()
+		second := children.Last()
+		return strings.EqualFold(goquery.NodeName(first), "pre") &&
+			strings.EqualFold(goquery.NodeName(second), "div") &&
+			second.HasClass("json-formatter-container")
+	default:
+		return false
+	}
+}
+
 func shouldParseStaticAssetViewerHTML(htmlContent string) bool {
 	const maxViewerShellHTMLBytes = 256 * 1024
 	if htmlContent == "" || len(htmlContent) > maxViewerShellHTMLBytes {
@@ -563,11 +599,11 @@ func shouldLoadStaticResource(htmlContent, constructedURL, finalURL string) bool
 	if utils.IsStaticAsset(constructedURL) || utils.IsStaticAsset(finalURL) {
 		return true
 	}
-	return isChromeStaticAssetViewerHTML(htmlContent)
+	return isChromeStaticAssetViewerHTML(htmlContent) || isChromeTextDocumentViewerHTML(htmlContent)
 }
 
 func isValidStaticResourceBody(body []byte) bool {
-	return len(body) > 0 && (requesthelpers.IsDetectedBinaryBody(body) || json.Valid(body))
+	return len(body) > 0
 }
 
 func headersForLoadedStaticResource(existingHeaders, loadedHeaders map[string][]string, body []byte) map[string][]string {

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -273,11 +273,10 @@ func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers
 	for key, values := range headers {
 		var processedValues []string
 		for _, value := range values {
-			// Split each value by comma and line breaks. CDP can expose duplicate
-			// response headers as newline-delimited strings.
-			splitValues := strings.FieldsFunc(value, func(r rune) bool {
-				return r == ',' || r == '\n' || r == '\r'
-			})
+			// CDP can expose duplicate response headers as newline-delimited
+			// strings. Content-Type parameters may contain commas, so only split
+			// that header on line breaks.
+			splitValues := splitHeaderValue(key, value)
 			for _, v := range splitValues {
 				trimmed := strings.TrimSpace(v)
 				if trimmed != "" {
@@ -311,6 +310,15 @@ func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers
 		ReceivedAt:      &receivedAt,
 		SizeBytes:       &sizeBytes,
 	}
+}
+
+func splitHeaderValue(key, value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		if r == '\n' || r == '\r' {
+			return true
+		}
+		return r == ',' && !strings.EqualFold(key, "Content-Type")
+	})
 }
 
 // CreateHTTPResponse creates an HttpResponse struct from HttpResponse data (string version)

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -123,6 +123,24 @@ func GetHeaderValueFromHeaderMap(headers map[string][]string, name string) *stri
 	return nil
 }
 
+func GetContentTypeFromHeaderMap(headers map[string][]string) string {
+	if headers == nil {
+		return ""
+	}
+
+	for headerName, values := range headers {
+		if !strings.EqualFold(headerName, "Content-Type") {
+			continue
+		}
+		for i := len(values) - 1; i >= 0; i-- {
+			if value := strings.TrimSpace(values[i]); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
 // GetResponseBodyStringFromBodyStruct extracts string content from a Body struct
 func GetResponseBodyStringFromBodyStruct(body *common.Body) *string {
 	if body == nil {
@@ -255,20 +273,23 @@ func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers
 	for key, values := range headers {
 		var processedValues []string
 		for _, value := range values {
-			// Split each value by comma and trim spaces
-			splitValues := strings.Split(value, ",")
+			// Split each value by comma and line breaks. CDP can expose duplicate
+			// response headers as newline-delimited strings.
+			splitValues := strings.FieldsFunc(value, func(r rune) bool {
+				return r == ',' || r == '\n' || r == '\r'
+			})
 			for _, v := range splitValues {
-				processedValues = append(processedValues, strings.TrimSpace(v))
+				trimmed := strings.TrimSpace(v)
+				if trimmed != "" {
+					processedValues = append(processedValues, trimmed)
+				}
 			}
 		}
 		processedHeaders[key] = processedValues
 	}
 
 	// Get content type from headers
-	contentType := ""
-	if ct := GetHeaderValueFromHeaderMap(processedHeaders, "Content-Type"); ct != nil {
-		contentType = *ct
-	}
+	contentType := GetContentTypeFromHeaderMap(processedHeaders)
 
 	// If no content type is provided, try to detect it from string representation
 	if contentType == "" {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how headless responses are classified and how bodies/headers are built from CDP data, which can alter stored content types and bodies for edge-case navigations.
> 
> **Overview**
> Headless capture now treats **Chrome’s text/JSON document viewer** (the `<pre>` + `color-scheme` shell, including JSON formatter) like other built-in viewers: when that HTML is detected, the scanner **reloads the real response body** via CDP instead of keeping the wrapper page.
> 
> **Response header handling** for CDP-sourced headers is tightened: values split on **newlines** for duplicated headers, but **`Content-Type` is not split on commas** (so parameters like `charset` stay intact). **`GetContentTypeFromHeaderMap`** picks the last non-empty `Content-Type` when multiple values exist.
> 
> Loaded static/text resources are accepted when the body is **any non-empty payload**, not only binary or JSON-detected bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75a6eeb4f294e03e96c1986ed2df01afc3b4c23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->