### PR TITLE
Add --template-paths flag to all nuclei-backed commands

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -99,8 +99,14 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
+			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -118,6 +124,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().StringSlice("targets", []string{}, "URL targets to perform fingerprinting against")
 	// Config Flags
 	discoverApplicationCmd.Flags().String("resource-type", "ALL", "Type of resource to fingerprint (e.g., web, api, cms)")
+	discoverApplicationCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides --resource-type when set")
 	discoverApplicationCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverApplicationCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
 	discoverApplicationCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
@@ -1302,7 +1309,7 @@ func parseDiscoverRequestFiles(pairs []string) ([]*discover.RequestFile, error) 
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -1311,6 +1318,7 @@ func getDiscoverApplicationConfig(targets []string, resource string, timeout int
 	config := &discover.DiscoverApplicationConfig{
 		Targets:         targets,
 		ResourceType:    &resourceEnum,
+		TemplatePaths:   templatePaths,
 		Timeout:         timeout,
 		Threads:         threads,
 		Proxy:           &proxy,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -151,9 +151,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			workflowPaths, err := cmd.Flags().GetStringSlice("workflow-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, workflowPaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -171,6 +176,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().String("dast-request-params", "", "Base64 JSON blob of request parameters that will be fuzzed")
 	pentestApplicationDastCmd.Flags().StringSlice("http-methods", []string{"GET", "POST", "PUT"}, "HTTP methods to use (e.g. GET,POST,PUT)")
 	pentestApplicationDastCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides --dast-categories when set")
+	pentestApplicationDastCmd.Flags().StringSlice("workflow-paths", []string{}, "Custom nuclei workflow file or directory paths; used alongside --template-paths for workflow-backed checks")
 	// Config Flags
 	pentestApplicationDastCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestApplicationDastCmd.Flags().Int("threads", 10, "Number of threads")
@@ -1242,13 +1248,14 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, workflowPaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
 		Targets:           targets,
 		DastCategories:    dastCategories,
 		DastRequestParams: dastRequestParams,
 		HttpMethods:       httpMethods,
 		TemplatePaths:     templatePaths,
+		WorkflowPaths:     workflowPaths,
 		Timeout:           timeout,
 		Threads:           threads,
 		Proxy:             proxy,

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -146,8 +146,14 @@ func (a *WebScan) InitPentestCommand() {
 				return
 			}
 
+			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -164,6 +170,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().StringSlice("dast-categories", []string{}, "Dast Categories (ie. XSS, SQLI, RFI, etc.)")
 	pentestApplicationDastCmd.Flags().String("dast-request-params", "", "Base64 JSON blob of request parameters that will be fuzzed")
 	pentestApplicationDastCmd.Flags().StringSlice("http-methods", []string{"GET", "POST", "PUT"}, "HTTP methods to use (e.g. GET,POST,PUT)")
+	pentestApplicationDastCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides --dast-categories when set")
 	// Config Flags
 	pentestApplicationDastCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestApplicationDastCmd.Flags().Int("threads", 10, "Number of threads")
@@ -211,6 +218,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Config flags
 			timeout, err := cmd.Flags().GetInt("timeout")
@@ -249,7 +261,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestApplicationCveConfig(targets, years, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationCveConfig(targets, years, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationCveScan(cmd.Context(), config)
@@ -264,6 +276,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationCveCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Config Flags
 	pentestApplicationCveCmd.Flags().StringSlice("years", []string{}, "Restrict CVE scans to particular years")
+	pentestApplicationCveCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides --years when set")
 	pentestApplicationCveCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestApplicationCveCmd.Flags().Int("threads", 10, "Number of threads")
 	pentestApplicationCveCmd.Flags().String("proxy", "", "Optional HTTP proxy URL")
@@ -343,8 +356,14 @@ func (a *WebScan) InitPentestCommand() {
 				return
 			}
 
+			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set config
-			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationMisconfigurationScan(cmd.Context(), config)
@@ -359,6 +378,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Misconfiguration Flags
 	pentestApplicationMisconfigurationCmd.Flags().StringSlice("misconfiguration-categories", []string{}, "Categories of misconfigurations to scan for")
+	pentestApplicationMisconfigurationCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides --misconfiguration-categories when set")
 	// Config Flags
 	pentestApplicationMisconfigurationCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestApplicationMisconfigurationCmd.Flags().Int("threads", 25, "Number of threads")
@@ -438,8 +458,14 @@ func (a *WebScan) InitPentestCommand() {
 				return
 			}
 
+			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set config
-			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationTechnologyScan(cmd.Context(), config)
@@ -454,6 +480,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().StringSlice("targets", []string{}, "Targets to be scanned")
 	// Technology Flags
 	pentestApplicationTechnologyCmd.Flags().StringSlice("technology-types", []string{}, "Technologies to scan for")
+	pentestApplicationTechnologyCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides --technology-types when set")
 	// Config Flags
 	pentestApplicationTechnologyCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	pentestApplicationTechnologyCmd.Flags().Int("threads", 10, "Number of threads")
@@ -1165,8 +1192,14 @@ func (a *WebScan) InitPentestCommand() {
 				return
 			}
 
+			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set config
-			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
 
 			// Generate a report
 			rep, err := pentestwafdetect.RunPentestWafDetect(cmd.Context(), config)
@@ -1182,6 +1215,7 @@ func (a *WebScan) InitPentestCommand() {
 	// Waf Config Flags
 	pentestWafDetectCmd.Flags().String("route-request-params", "", "Base64 JSON blob of request parameters that will be injected")
 	pentestWafDetectCmd.Flags().StringSlice("http-methods", []string{"GET"}, "HTTP methods to use (e.g. GET,POST,PUT)")
+	pentestWafDetectCmd.Flags().StringSlice("template-paths", []string{}, "Custom nuclei template file or directory paths; overrides default WAF detect templates when set")
 	// Config Flags
 	pentestWafDetectCmd.Flags().Int("timeout", 5, "Timeout per request in seconds")
 	pentestWafDetectCmd.Flags().Int("threads", 25, "Number of threads")
@@ -1208,12 +1242,13 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
 		Targets:           targets,
 		DastCategories:    dastCategories,
 		DastRequestParams: dastRequestParams,
 		HttpMethods:       httpMethods,
+		TemplatePaths:     templatePaths,
 		Timeout:           timeout,
 		Threads:           threads,
 		Proxy:             proxy,
@@ -1225,10 +1260,11 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 }
 
 // getPentestApplicationCveConfig builds the config for scan pentest.
-func getPentestApplicationCveConfig(targets []string, years []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationCveConfig {
+func getPentestApplicationCveConfig(targets []string, years []string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationCveConfig {
 	config := pentestapplicationscanfern.PentestApplicationCveConfig{
 		Targets:         targets,
 		Years:           years,
+		TemplatePaths:   templatePaths,
 		Timeout:         timeout,
 		Threads:         threads,
 		Proxy:           &proxy,
@@ -1240,10 +1276,11 @@ func getPentestApplicationCveConfig(targets []string, years []string, timeout in
 }
 
 // getPentestApplicationMisconfigurationConfig builds the config for scan pentest.
-func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
+func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
 	config := pentestapplicationscanfern.PentestApplicationMisconfigurationConfig{
 		Targets:                    targets,
 		MisconfigurationCategories: misconfigurationCategories,
+		TemplatePaths:              templatePaths,
 		Timeout:                    timeout,
 		Threads:                    threads,
 		Proxy:                      &proxy,
@@ -1255,10 +1292,11 @@ func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurat
 }
 
 // getPentestApplicationTechnologiesConfig builds the config for scan pentest.
-func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
+func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
 	config := pentestapplicationscanfern.PentestApplicationTechnologyConfig{
 		Targets:         targets,
 		TechnologyTypes: technologyTypes,
+		TemplatePaths:   templatePaths,
 		Timeout:         timeout,
 		Threads:         threads,
 		Proxy:           &proxy,
@@ -1407,11 +1445,12 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 }
 
 // getPentestWafDetectConfig builds the config for waf detect pentest.
-func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) waf.PentestWafDetectConfig {
+func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) waf.PentestWafDetectConfig {
 	config := waf.PentestWafDetectConfig{
 		Targets:                targets,
 		RouteRequestParameters: routeRequestParams,
 		HttpMethods:            httpMethods,
+		TemplatePaths:          templatePaths,
 		Timeout:                timeout,
 		Threads:                threads,
 		Proxy:                  &proxy,

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -7,6 +7,7 @@ types:
       - ALL
   ApplicationResourceType:
     enum:
+      - CUSTOM_TEMPLATE
       - API_APPLICATION
       - CI_CD_PLATFORM
       - CLOUD_BUCKET

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -48,6 +48,7 @@ types:
     properties:
       targets: list<string>
       resourceType: ApplicationResourceConfigType
+      templatePaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -21,6 +21,7 @@ types:
       dastCategories: optional<list<PentestApplicationDastCategory>>
       dastRequestParams: optional<list<parameter.RequestParameter>>
       httpMethods: optional<list<http.HttpMethod>>
+      templatePaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -22,6 +22,7 @@ types:
       dastRequestParams: optional<list<parameter.RequestParameter>>
       httpMethods: optional<list<http.HttpMethod>>
       templatePaths: optional<list<string>>
+      workflowPaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/fern/definition/pentest/application/scan/cve.yml
+++ b/fern/definition/pentest/application/scan/cve.yml
@@ -6,6 +6,7 @@ types:
     properties:
       targets: list<string>
       years: optional<list<string>>
+      templatePaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/fern/definition/pentest/application/scan/misconfiguration.yml
+++ b/fern/definition/pentest/application/scan/misconfiguration.yml
@@ -10,6 +10,7 @@ types:
     properties:
       targets: list<string>
       misconfigurationCategories: optional<list<MisconfigurationCategory>>
+      templatePaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/fern/definition/pentest/application/scan/technology.yml
+++ b/fern/definition/pentest/application/scan/technology.yml
@@ -12,6 +12,7 @@ types:
     properties:
       targets: list<string>
       technologyTypes: optional<list<TechnologyType>>
+      templatePaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/fern/definition/pentest/waf/detect.yml
+++ b/fern/definition/pentest/waf/detect.yml
@@ -33,6 +33,7 @@ types:
       targets: list<string>
       routeRequestParameters: optional<list<parameter.RequestParameter>>
       httpMethods: optional<list<http.HttpMethod>>
+      templatePaths: optional<list<string>>
       timeout: integer
       threads: integer
       proxy: optional<string>

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -78,11 +78,17 @@ func convertNucleiAttemptToFingerprintAttemptStruct(nucleiAttempt *nuclei.Nuclei
 func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover.DiscoverApplicationConfig) (nuclei.NucleiConfig, error) {
 	log := svc1log.FromContext(ctx)
 
-	// Get template paths based on resource type
-	templatePaths, err := getTemplatePaths(config.ResourceType)
-	if err != nil {
-		log.Error("Failed to get template paths", svc1log.SafeParam("error", err.Error()))
-		return nuclei.NucleiConfig{}, err
+	// Get template paths — use user-supplied paths if provided, otherwise derive from resource type
+	var templatePaths []string
+	if len(config.TemplatePaths) > 0 {
+		templatePaths = config.TemplatePaths
+	} else {
+		var err error
+		templatePaths, err = getTemplatePaths(config.ResourceType)
+		if err != nil {
+			log.Error("Failed to get template paths", svc1log.SafeParam("error", err.Error()))
+			return nuclei.NucleiConfig{}, err
+		}
 	}
 
 	log.Info("Built Nuclei config for application discovery",

--- a/internal/discover/application/helpers.go
+++ b/internal/discover/application/helpers.go
@@ -81,6 +81,11 @@ func getTemplatePaths(resourceConfigType *discover.ApplicationResourceConfigType
 	// Handle specific resource type
 	resourceType := resourceConfigType.GetApplicationResourceType()
 
+	// CUSTOM_TEMPLATE has no embedded path mapping — it requires --template-paths
+	if resourceType == discover.ApplicationResourceTypeCustomTemplate {
+		return nil, fmt.Errorf("resource type CUSTOM_TEMPLATE requires --template-paths to be set")
+	}
+
 	// Validate that the resource type is supported
 	resourceTypeName, exists := resourceTypeToPath[resourceType]
 	if !exists {

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -37,7 +37,10 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 	var workflowPaths []string
 
 	if len(config.TemplatePaths) > 0 {
+		// Route to both TemplatePaths and WorkflowPaths so the runner's
+		// workflow-detection logic can place workflow YAML in workflowDir.
 		templatePaths = config.TemplatePaths
+		workflowPaths = config.TemplatePaths
 	} else {
 		for _, category := range config.DastCategories {
 			if workflowPath, hasWorkflow := dastCategoriesToWorkflowMap[category]; hasWorkflow {

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -33,23 +33,22 @@ var dastCategoriesToWorkflowMap = map[pentestapplicationfern.PentestApplicationD
 }
 
 func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDastConfig) nuclei.NucleiConfig {
-	// Get the template and workflow paths
 	var templatePaths []string
 	var workflowPaths []string
 
-	for _, category := range config.DastCategories {
-		// Check if this category has a workflow
-		if workflowPath, hasWorkflow := dastCategoriesToWorkflowMap[category]; hasWorkflow {
-			workflowPaths = append(workflowPaths, workflowPath)
-		} else {
-			// Use the template path for categories without workflows
-			templatePaths = append(templatePaths, dastCategoriesToPathMap[category])
+	if len(config.TemplatePaths) > 0 {
+		templatePaths = config.TemplatePaths
+	} else {
+		for _, category := range config.DastCategories {
+			if workflowPath, hasWorkflow := dastCategoriesToWorkflowMap[category]; hasWorkflow {
+				workflowPaths = append(workflowPaths, workflowPath)
+			} else {
+				templatePaths = append(templatePaths, dastCategoriesToPathMap[category])
+			}
 		}
-	}
-
-	// If no categories are specified, scan all categories
-	if len(config.DastCategories) == 0 {
-		templatePaths = append(templatePaths, dastBaseTemplatePath)
+		if len(config.DastCategories) == 0 {
+			templatePaths = append(templatePaths, dastBaseTemplatePath)
+		}
 	}
 
 	// Return the nuclei config

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -36,11 +36,9 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 	var templatePaths []string
 	var workflowPaths []string
 
-	if len(config.TemplatePaths) > 0 {
-		// Route to both TemplatePaths and WorkflowPaths so the runner's
-		// workflow-detection logic can place workflow YAML in workflowDir.
+	if len(config.TemplatePaths) > 0 || len(config.WorkflowPaths) > 0 {
 		templatePaths = config.TemplatePaths
-		workflowPaths = config.TemplatePaths
+		workflowPaths = config.WorkflowPaths
 	} else {
 		for _, category := range config.DastCategories {
 			if workflowPath, hasWorkflow := dastCategoriesToWorkflowMap[category]; hasWorkflow {

--- a/internal/pentest/application/scan/cve.go
+++ b/internal/pentest/application/scan/cve.go
@@ -16,14 +16,15 @@ import (
 var cveBaseTemplatePath = "pentest/scan/cve"
 
 func createCveScanNucleiConfig(config pentestapplicationscanfern.PentestApplicationCveConfig) nuclei.NucleiConfig {
-	// Add all specified years
-	templatePaths := []string{}
-	for _, year := range config.Years {
-		templatePaths = append(templatePaths, fmt.Sprintf("%s/%s", cveBaseTemplatePath, year))
-	}
-	// Default to all years if no years are specified
+	// Use user-supplied template paths if provided, otherwise build from years
+	templatePaths := config.TemplatePaths
 	if len(templatePaths) == 0 {
-		templatePaths = append(templatePaths, cveBaseTemplatePath)
+		for _, year := range config.Years {
+			templatePaths = append(templatePaths, fmt.Sprintf("%s/%s", cveBaseTemplatePath, year))
+		}
+		if len(templatePaths) == 0 {
+			templatePaths = append(templatePaths, cveBaseTemplatePath)
+		}
 	}
 
 	// Return the nuclei config

--- a/internal/pentest/application/scan/misconfiguration.go
+++ b/internal/pentest/application/scan/misconfiguration.go
@@ -20,14 +20,14 @@ var misconfigurationCategoriesToPathMap = map[pentestapplicationscanfern.Misconf
 }
 
 func createMisconfigurationScanNucleiConfig(config pentestapplicationscanfern.PentestApplicationMisconfigurationConfig) nuclei.NucleiConfig {
-	// Add all specified misconfigurations
-	templatePaths := []string{}
-	for _, misconfigurationCategory := range config.MisconfigurationCategories {
-		templatePaths = append(templatePaths, misconfigurationCategoriesToPathMap[misconfigurationCategory])
-	}
-	// If no misconfigurations are specified, scan all misconfigurations
-	if len(config.MisconfigurationCategories) == 0 {
-		templatePaths = append(templatePaths, misconfigurationBaseTemplatePath)
+	templatePaths := config.TemplatePaths
+	if len(templatePaths) == 0 {
+		for _, misconfigurationCategory := range config.MisconfigurationCategories {
+			templatePaths = append(templatePaths, misconfigurationCategoriesToPathMap[misconfigurationCategory])
+		}
+		if len(templatePaths) == 0 {
+			templatePaths = append(templatePaths, misconfigurationBaseTemplatePath)
+		}
 	}
 
 	// Return the nuclei config

--- a/internal/pentest/application/scan/technology.go
+++ b/internal/pentest/application/scan/technology.go
@@ -22,14 +22,14 @@ var technologyTypesToPathMap = map[pentestapplicationscanfern.TechnologyType]str
 }
 
 func createTechnologyScanNucleiConfig(config pentestapplicationscanfern.PentestApplicationTechnologyConfig) nuclei.NucleiConfig {
-	// Add all specified technology types
-	templatePaths := []string{}
-	for _, technologyType := range config.TechnologyTypes {
-		templatePaths = append(templatePaths, technologyTypesToPathMap[technologyType])
-	}
-	// If no technology types are specified, scan all technologies
+	templatePaths := config.TemplatePaths
 	if len(templatePaths) == 0 {
-		templatePaths = append(templatePaths, technologyBaseTemplatePath)
+		for _, technologyType := range config.TechnologyTypes {
+			templatePaths = append(templatePaths, technologyTypesToPathMap[technologyType])
+		}
+		if len(templatePaths) == 0 {
+			templatePaths = append(templatePaths, technologyBaseTemplatePath)
+		}
 	}
 
 	return nuclei.NucleiConfig{

--- a/internal/pentest/waf/detect/detect.go
+++ b/internal/pentest/waf/detect/detect.go
@@ -16,9 +16,13 @@ import (
 )
 
 func createDastNucleiConfigForWafDetect(config waf.PentestWafDetectConfig) nuclei.NucleiConfig {
+	templatePaths := config.TemplatePaths
+	if len(templatePaths) == 0 {
+		templatePaths = []string{"pentest/waf/detect"}
+	}
 	return nuclei.NucleiConfig{
 		Targets:       config.Targets,
-		TemplatePaths: []string{"pentest/waf/detect"},
+		TemplatePaths: templatePaths,
 		RunMode:       nuclei.NucleiRunModeDast,
 		Dast: &nuclei.NucleiDastConfig{
 			HttpMethods:       config.HttpMethods,

--- a/utils/nuclei/engine.go
+++ b/utils/nuclei/engine.go
@@ -43,7 +43,7 @@ func RunNucleiEngine(ctx context.Context, config nuclei.NucleiConfig) ([]*nuclei
 	var err error
 
 	// Get template file systems
-	if config.TemplatePaths != nil {
+	if len(config.TemplatePaths) > 0 {
 		templateFileSystems, err = templates.GetTemplateFileSystem(ctx, config.TemplatePaths)
 		if err != nil {
 			return nil, err
@@ -51,7 +51,7 @@ func RunNucleiEngine(ctx context.Context, config nuclei.NucleiConfig) ([]*nuclei
 	}
 
 	// Get workflow file systems
-	if config.WorkflowPaths != nil {
+	if len(config.WorkflowPaths) > 0 {
 		workflowFileSystems, err = templates.GetTemplateFileSystem(ctx, config.WorkflowPaths)
 		if err != nil {
 			return nil, err

--- a/utils/nuclei/templates/select.go
+++ b/utils/nuclei/templates/select.go
@@ -77,16 +77,15 @@ func GetTemplateFileSystem(ctx context.Context, templatePaths []string) ([]fs.FS
 }
 
 // isDiskPath reports whether path should be read from the OS filesystem.
+// Only absolute paths and explicitly relative paths (./  ../) qualify;
+// bare relative paths always resolve against the embedded archive to avoid
+// CWD shadowing of built-in template names like pentest/dast.
 func isDiskPath(path string) bool {
 	if filepath.IsAbs(path) {
 		return true
 	}
-	if strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../") ||
-		strings.HasPrefix(path, ".\\") || strings.HasPrefix(path, "..\\") {
-		return true
-	}
-	_, err := os.Stat(path)
-	return err == nil
+	return strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../") ||
+		strings.HasPrefix(path, ".\\") || strings.HasPrefix(path, "..\\")
 }
 
 // getDiskFS returns an fs.FS backed by the OS filesystem at path.

--- a/utils/nuclei/templates/select.go
+++ b/utils/nuclei/templates/select.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -25,8 +27,8 @@ var All fs.FS = compressedfs.NewLazyTarGzip(templateArchive)
 
 // GetTemplateFileSystem returns filesystem views for templates based on the provided template paths.
 // templatePaths can contain either:
-// - Complete paths to template files (e.g., "pentest/scan/cve/2024/CVE-2024-13624.yaml")
-// - Folder paths (e.g., "pentest/scan/cve") - will collect all .yaml/.yml files recursively from that folder
+// - Absolute paths or relative paths starting with ./ or ../ — read from disk
+// - Embedded paths (e.g., "pentest/scan/cve/2024/CVE-2024-13624.yaml" or "pentest/scan/cve")
 func GetTemplateFileSystem(ctx context.Context, templatePaths []string) ([]fs.FS, error) {
 	log := svc1log.FromContext(ctx)
 
@@ -36,32 +38,149 @@ func GetTemplateFileSystem(ctx context.Context, templatePaths []string) ([]fs.FS
 
 	log.Info("Using template paths", svc1log.SafeParam("templatePaths", templatePaths))
 
-	// Collect all template files from the provided paths
+	var filesystems []fs.FS
+	var embeddedPaths []string
+
+	for _, templatePath := range templatePaths {
+		if isDiskPath(templatePath) {
+			diskFS, err := getDiskFS(templatePath)
+			if err != nil {
+				log.Warn("Failed to open disk template path, skipping",
+					svc1log.SafeParam("templatePath", templatePath),
+					svc1log.SafeParam("error", err.Error()))
+				continue
+			}
+			log.Info("Using disk template path", svc1log.SafeParam("templatePath", templatePath))
+			filesystems = append(filesystems, diskFS)
+		} else {
+			embeddedPaths = append(embeddedPaths, templatePath)
+		}
+	}
+
+	if len(embeddedPaths) > 0 {
+		embeddedFSes, err := getEmbeddedFileSystems(ctx, embeddedPaths)
+		if err != nil {
+			if len(filesystems) == 0 {
+				return nil, err
+			}
+			log.Warn("Some embedded template paths failed", svc1log.SafeParam("error", err.Error()))
+		} else {
+			filesystems = append(filesystems, embeddedFSes...)
+		}
+	}
+
+	if len(filesystems) == 0 {
+		return nil, fmt.Errorf("no valid template files found")
+	}
+
+	return filesystems, nil
+}
+
+// isDiskPath reports whether path should be read from the OS filesystem.
+func isDiskPath(path string) bool {
+	if filepath.IsAbs(path) {
+		return true
+	}
+	if strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../") ||
+		strings.HasPrefix(path, ".\\") || strings.HasPrefix(path, "..\\") {
+		return true
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// getDiskFS returns an fs.FS backed by the OS filesystem at path.
+func getDiskFS(path string) (fs.FS, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path %s: %w", path, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("path not found %s: %w", abs, err)
+	}
+	if info.IsDir() {
+		return os.DirFS(abs), nil
+	}
+	return &singleFileFS{path: abs}, nil
+}
+
+// singleFileFS is an fs.FS containing exactly one file.
+type singleFileFS struct {
+	path string // absolute path to the file
+}
+
+func (s *singleFileFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return &singleFileDirHandle{fsys: s}, nil
+	}
+	if name == filepath.Base(s.path) {
+		return os.Open(s.path)
+	}
+	return nil, fs.ErrNotExist
+}
+
+type singleFileDirHandle struct {
+	fsys   *singleFileFS
+	offset int
+}
+
+func (d *singleFileDirHandle) Stat() (fs.FileInfo, error)  { return &dirInfo{name: "."}, nil }
+func (d *singleFileDirHandle) Read([]byte) (int, error)    { return 0, fmt.Errorf("is a directory") }
+func (d *singleFileDirHandle) Close() error                { return nil }
+
+func (d *singleFileDirHandle) ReadDir(n int) ([]fs.DirEntry, error) {
+	info, err := os.Stat(d.fsys.path)
+	if err != nil {
+		return nil, err
+	}
+	entries := []fs.DirEntry{fs.FileInfoToDirEntry(info)}
+
+	if n <= 0 {
+		result := entries[d.offset:]
+		d.offset = len(entries)
+		return result, nil
+	}
+	if d.offset >= len(entries) {
+		return nil, io.EOF
+	}
+	end := d.offset + n
+	if end > len(entries) {
+		end = len(entries)
+	}
+	result := entries[d.offset:end]
+	d.offset = end
+	return result, nil
+}
+
+// getEmbeddedFileSystems resolves embedded template paths against the bundled archive.
+func getEmbeddedFileSystems(ctx context.Context, templatePaths []string) ([]fs.FS, error) {
+	log := svc1log.FromContext(ctx)
+
 	var allTemplateFiles []string
 
 	for _, templatePath := range templatePaths {
-		// Clean the template path - remove utils/nuclei/templates/ prefix if present
-		cleanPath := templatePath
-		cleanPath = strings.TrimPrefix(cleanPath, "utils/nuclei/templates/")
-		// Handle both pentest/ and discover/ paths
+		cleanPath := strings.TrimPrefix(templatePath, "utils/nuclei/templates/")
 		if !strings.HasPrefix(cleanPath, "pentest/") && !strings.HasPrefix(cleanPath, "discover/") {
-			// Default to pentest for backward compatibility
 			cleanPath = filepath.Join("pentest", cleanPath)
 		}
 
-		// Check if this is a file or directory
 		if isTemplateFile(cleanPath) {
-			// It's a template file - verify it exists and add it
 			if _, err := fs.Stat(All, cleanPath); err != nil {
-				log.Warn("Template file not found, skipping", svc1log.SafeParam("templatePath", templatePath), svc1log.SafeParam("cleanPath", cleanPath), svc1log.SafeParam("error", err.Error()))
+				log.Warn("Template file not found, skipping",
+					svc1log.SafeParam("templatePath", templatePath),
+					svc1log.SafeParam("cleanPath", cleanPath),
+					svc1log.SafeParam("error", err.Error()))
 				continue
 			}
 			allTemplateFiles = append(allTemplateFiles, cleanPath)
 		} else {
-			// It's a directory - collect all template files recursively
 			templates, err := collectTemplatesFromDirectory(cleanPath)
 			if err != nil {
-				log.Warn("Failed to collect templates from directory, skipping", svc1log.SafeParam("templatePath", templatePath), svc1log.SafeParam("cleanPath", cleanPath), svc1log.SafeParam("error", err.Error()))
+				log.Warn("Failed to collect templates from directory, skipping",
+					svc1log.SafeParam("templatePath", templatePath),
+					svc1log.SafeParam("cleanPath", cleanPath),
+					svc1log.SafeParam("error", err.Error()))
 				continue
 			}
 			allTemplateFiles = append(allTemplateFiles, templates...)
@@ -72,11 +191,9 @@ func GetTemplateFileSystem(ctx context.Context, templatePaths []string) ([]fs.FS
 		return nil, fmt.Errorf("no valid template files found")
 	}
 
-	log.Info("Found template files", svc1log.SafeParam("templateCount", len(allTemplateFiles)))
+	log.Info("Found embedded template files", svc1log.SafeParam("templateCount", len(allTemplateFiles)))
 
-	// Group template files by their directory to create minimal filesystems
 	dirToFiles := make(map[string][]string)
-
 	for _, templateFile := range allTemplateFiles {
 		templateDir := filepath.Dir(templateFile)
 		templateName := filepath.Base(templateFile)
@@ -85,20 +202,17 @@ func GetTemplateFileSystem(ctx context.Context, templatePaths []string) ([]fs.FS
 
 	var filesystems []fs.FS
 	for templateDir, templateFiles := range dirToFiles {
-		// Create a base filesystem for the directory
 		baseFS, err := fs.Sub(All, templateDir)
 		if err != nil {
-			log.Warn("Template directory not found, skipping", svc1log.SafeParam("templateDir", templateDir), svc1log.SafeParam("error", err.Error()))
+			log.Warn("Template directory not found, skipping",
+				svc1log.SafeParam("templateDir", templateDir),
+				svc1log.SafeParam("error", err.Error()))
 			continue
 		}
-
-		// Create a filtered filesystem that only exposes the specific template files
-		filteredFS := &specificTemplateFS{
+		filesystems = append(filesystems, &specificTemplateFS{
 			baseFS:        baseFS,
 			templateFiles: templateFiles,
-		}
-
-		filesystems = append(filesystems, filteredFS)
+		})
 	}
 
 	if len(filesystems) == 0 {

--- a/utils/nuclei/templates/select.go
+++ b/utils/nuclei/templates/select.go
@@ -99,9 +99,31 @@ func getDiskFS(path string) (fs.FS, error) {
 		return nil, fmt.Errorf("path not found %s: %w", abs, err)
 	}
 	if info.IsDir() {
+		count, err := countDiskTemplateFiles(abs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan directory %s: %w", abs, err)
+		}
+		if count == 0 {
+			return nil, fmt.Errorf("no .yaml/.yml files found in %s", abs)
+		}
 		return os.DirFS(abs), nil
 	}
 	return &singleFileFS{path: abs}, nil
+}
+
+// countDiskTemplateFiles counts .yaml/.yml files recursively under dir.
+func countDiskTemplateFiles(dir string) (int, error) {
+	count := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && isTemplateFile(path) {
+			count++
+		}
+		return nil
+	})
+	return count, err
 }
 
 // singleFileFS is an fs.FS containing exactly one file.


### PR DESCRIPTION
Allows users to supply custom nuclei template files or directories for discover application, pentest application dast, cve, misconfiguration, technology, and waf detect. Disk paths (absolute or ./-prefixed) are read directly from the OS filesystem; embedded paths continue to use the bundled archive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom templates change which checks run against live targets; disk path handling is new surface area, though default behavior is unchanged when flags are omitted.
> 
> **Overview**
> Adds **`--template-paths`** (and **`--workflow-paths`** on DAST) across nuclei-backed **discover application** and **pentest** commands (DAST, CVE, misconfiguration, technology, WAF detect). When set, those paths **override** the usual category/year/resource-type template selection.
> 
> Fern configs gain optional `templatePaths` / `workflowPaths`; discover adds **`CUSTOM_TEMPLATE`** as a resource type that **requires** `--template-paths`.
> 
> **`GetTemplateFileSystem`** now loads **disk** templates for absolute or `./` / `../` paths while **bare** names like `pentest/dast` still use the embedded archive (avoids CWD shadowing). Nuclei config builders prefer user paths when non-empty; the engine uses `len(...) > 0` instead of nil checks for template/workflow FS setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854a7ebcfba5cd09a6444533181a780f55f22086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->