### PR TITLE
Forbid extra fields in generated Pydantic models

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -14,6 +14,8 @@ groups:
     generators:
       - name: fernapi/fern-pydantic-model
         version: 1.11.2
+        config:
+          extra_fields: forbid
         output:
           location: local-file-system
           path: ../generated/python
@@ -24,6 +26,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodwebscan
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodwebscan
@@ -36,6 +39,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodwebscan
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodwebscan


### PR DESCRIPTION
## Summary

Set `extra_fields: forbid` on every `fern-pydantic-model` generator block (`pypi-local`, `pypi-test`, `pypi`) so the generated config types raise `pydantic.ValidationError` when constructed with unknown kwargs.

## Why

Today the generated models use `extra="allow"`, which silently accepts unknown kwargs and serializes them to the wire payload — that's how `stop_first_success` / `continue_on_error` slipped through the ontology compilers and broke against the v0.0.194 networkscan CLI ("unknown flag" → empty stdout → signal parse failed).

Strict mode (`extra="forbid"`) surfaces the same class of bug at **construction time** in the consumer (ontology compiler / tests), not at runtime on Jackal. Matches https://github.com/method-security/networkscan/pull/331.

## What ships

`generated/python/` is gitignored — CI regenerates from `fern/generators.yml` at publish time, so this single-file change propagates to the next `methodwebscan` wheel automatically. Verified that `fern-pydantic-model 1.11.2` accepts the `extra_fields: forbid` config option.

## Migration note for consumers

After the next wheel publishes, any consumer that still passes unknown kwargs to a generated config will start failing pydantic validation at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for all consumers of the next published wheel: unknown kwargs on generated models will raise validation errors at compile time instead of being ignored or serialized.
> 
> **Overview**
> Adds **`extra_fields: forbid`** to every `fern-pydantic-model` generator in `fern/generators.yml` (`pypi-local`, `pypi-test`, and `pypi`).
> 
> Regenerated `methodwebscan` Python config types will use Pydantic **`extra="forbid"`** instead of silently accepting unknown kwargs, so invalid field names fail at **model construction** (e.g. in ontology compilers/tests) rather than leaking into CLI payloads and failing at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ae59f8eff250aa81fcada7b7bdad8cd90d9f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->