### PR TITLE
Fix empty response header serialization

### DIFF
--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -489,11 +489,7 @@ func IsTransientHeadlessError(err error) bool {
 }
 
 func cloneHeaders(headers map[string][]string) map[string][]string {
-	result := make(map[string][]string, len(headers))
-	for key, values := range headers {
-		result[key] = append([]string(nil), values...)
-	}
-	return result
+	return requesthelpers.NormalizeHeaders(headers)
 }
 
 func isInternalBrowserURL(raw string) bool {

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -81,6 +81,31 @@ func BuildAuthHeaders(headers map[string]string, cookies map[string]string) map[
 	return result
 }
 
+// NormalizeHeaders trims and drops empty response header values so serialized
+// header maps always conform to map<string, list<string>> without null values.
+func NormalizeHeaders(headers map[string][]string) map[string][]string {
+	normalized := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		var normalizedValues []string
+		for _, value := range values {
+			// CDP can expose duplicate response headers as newline-delimited
+			// strings. Content-Type parameters may contain commas, so only split
+			// on line breaks.
+			splitValues := splitHeaderValue(key, value)
+			for _, v := range splitValues {
+				trimmed := strings.TrimSpace(v)
+				if trimmed != "" {
+					normalizedValues = append(normalizedValues, trimmed)
+				}
+			}
+		}
+		if len(normalizedValues) > 0 {
+			normalized[key] = normalizedValues
+		}
+	}
+	return normalized
+}
+
 // ParseCookiePairs converts a slice of "name=value" strings (as supplied via a
 // repeated --cookie CLI flag) into a map[string]string. Pairs that do not
 // contain an equals sign are silently ignored. Leading and trailing whitespace is
@@ -322,24 +347,7 @@ func IsDetectedBinaryBody(bodyData []byte) bool {
 
 // CreateHTTPResponseFromBytes creates an HttpResponse struct from HttpResponse data using byte array
 func CreateHTTPResponseFromBytes(statusCode int, redirectChain []string, headers map[string][]string, responseBody []byte) common.HttpResponse {
-	// Process headers to split newline-delimited duplicate values from CDP.
-	processedHeaders := make(map[string][]string)
-	for key, values := range headers {
-		var processedValues []string
-		for _, value := range values {
-			// CDP can expose duplicate response headers as newline-delimited
-			// strings. Content-Type parameters may contain commas, so only split
-			// that header on line breaks.
-			splitValues := splitHeaderValue(key, value)
-			for _, v := range splitValues {
-				trimmed := strings.TrimSpace(v)
-				if trimmed != "" {
-					processedValues = append(processedValues, trimmed)
-				}
-			}
-		}
-		processedHeaders[key] = processedValues
-	}
+	processedHeaders := NormalizeHeaders(headers)
 
 	// Get content type from headers
 	contentType := GetContentTypeFromHeaderMap(processedHeaders)


### PR DESCRIPTION
## Summary
- omit response headers whose normalized values are empty
- reuse the same normalization for headless header cloning
- prevents `responseHeaders` entries such as `"Server": null` that violate the Fern `map<string, list<string>>` shape

## Test
- `go test ./utils/request/... ./internal/discover/...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of header shaping for API serialization; no auth or critical-path logic changes.
> 
> **Overview**
> Fixes **invalid `responseHeaders` serialization** (e.g. `"Server": null`) by centralizing CDP/header cleanup in **`NormalizeHeaders`**.
> 
> That helper **splits newline-delimited duplicate values**, **trims** entries, and **drops header keys** when every value is empty so maps stay **`map<string, list<string>>`**-shaped for Fern.
> 
> **`CreateHTTPResponseFromBytes`** now calls this helper instead of inlined logic. Headless **`cloneHeaders`** delegates to the same path, so network-captured headers are normalized when stored/cloned—not only shallow-copied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7999f6db25c411484725d30ee286fbf21365b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->