### PR TITLE
Add base64 transport for discover request JSON bodies

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	// Standard
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -531,14 +532,35 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 			headers := requesthelpers.ParseHeaderPairs(headerPairs)
 
-			// JSON body flag
+			// JSON body flags. json-body-base64 is transport-safe for callers that
+			// construct commands through an intermediate shell string; when supplied,
+			// decode it into JsonBody and preserve the decoded JSON in the report.
 			jsonBodyStr, err := cmd.Flags().GetString("json-body")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			jsonBodyBase64Str, err := cmd.Flags().GetString("json-body-base64")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if jsonBodyStr != "" && jsonBodyBase64Str != "" {
+				a.OutputSignal.AddError(fmt.Errorf("only one of --json-body or --json-body-base64 may be provided"))
+				return
+			}
 			var jsonBody *string
-			if jsonBodyStr != "" {
+			var jsonBodyBase64 *string
+			if jsonBodyBase64Str != "" {
+				decoded, decodeErr := base64.StdEncoding.DecodeString(jsonBodyBase64Str)
+				if decodeErr != nil {
+					a.OutputSignal.AddError(fmt.Errorf("invalid --json-body-base64 value: %w", decodeErr))
+					return
+				}
+				decodedStr := string(decoded)
+				jsonBody = &decodedStr
+				jsonBodyBase64 = &jsonBodyBase64Str
+			} else if jsonBodyStr != "" {
 				jsonBody = &jsonBodyStr
 			}
 
@@ -638,6 +660,7 @@ func (a *WebScan) InitDiscoverCommand() {
 				HttpMethod:                 httpMethod,
 				Headers:                    headers,
 				JsonBody:                   jsonBody,
+				JsonBodyBase64:             jsonBodyBase64,
 				TextBody:                   textBody,
 				FormData:                   formData,
 				Files:                      files,
@@ -662,6 +685,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverRequestCmd.Flags().String("http-method", "GET", "HTTP method (GET,POST,PUT,DELETE,PATCH,HEAD,OPTIONS)")
 	discoverRequestCmd.Flags().StringArray("header", []string{}, "Request headers as 'Key: Value' pairs (repeatable)")
 	discoverRequestCmd.Flags().String("json-body", "", "Request body as JSON string")
+	discoverRequestCmd.Flags().String("json-body-base64", "", "Request body as base64-encoded JSON string")
 	discoverRequestCmd.Flags().String("text-body", "", "Request body as plain text")
 	discoverRequestCmd.Flags().StringArray("form-data", []string{}, "Form data as 'key=value' pairs (repeatable)")
 	discoverRequestCmd.Flags().StringArray("file", []string{}, "Multipart file part as 'fieldName|fileName|contentType|base64' (repeatable; contentType may be empty)")

--- a/fern/definition/discover/request.yml
+++ b/fern/definition/discover/request.yml
@@ -26,6 +26,7 @@ types:
       httpMethod: http.HttpMethod
       headers: optional<map<string, string>>
       jsonBody: optional<string>
+      jsonBodyBase64: optional<string>
       textBody: optional<string>
       formData: optional<map<string, string>>
       files: optional<list<RequestFile>>


### PR DESCRIPTION
## Summary
- Adds a new `--json-body-base64` flag to `discover request`.
- If supplied, webscan base64-decodes the value into `JsonBody` before building/sending the request, preserving the decoded JSON in the report output.
- Rejects callers that supply both `--json-body` and `--json-body-base64`.

## Why
Ontology's `httprequest` compiler currently has to embed raw JSON inside a single command string. That is brittle across method-server / cloud-agent execution parsing: JSON quotes either get stripped (`{username: alice}`) or preserved as literal backslashes (`{\\username\\: ...}`) depending on the quoting strategy.

A base64 transport avoids shell quoting entirely. Ontology can emit a simple alphanumeric `--json-body-base64 <payload>` value, and webscan reconstructs the exact JSON string before sending the HTTP request.

## What changed
- `fern/definition/discover/request.yml`
  - Added `jsonBodyBase64: optional<string>` to `DiscoverRequestConfig`.
- `cmd/discover.go`
  - Added `--json-body-base64` flag.
  - Decodes base64 into `JsonBody`.
  - Preserves the original base64 string in `JsonBodyBase64` on the report config.
  - Rejects `--json-body` + `--json-body-base64` together.

## Direct CLI verification
Built webscan locally and ran:

```sh
/tmp/webscan-base64 discover request \
  --target http://batcave-vampi.resources.wayneindustries.xyz:80/users/v1/register \
  --http-method POST \
  --json-body-base64 eyJ1c2VybmFtZSI6ImFsaWNlX3BlbnRlc3RfYmFzZTY0X3ZlcmlmeSIsImVtYWlsIjoiYWxpY2VfcGVudGVzdF9iYXNlNjRfdmVyaWZ5QHRlc3QuaW52YWxpZCIsInBhc3N3b3JkIjoiQWxpY2VQYXNzMTIzISJ9 \
  --header 'Content-Type: application/json' \
  --timeout 30 \
  --user-agent RANDOM \
  --verify-tls=false \
  --output signal \
  --output-file /tmp/webscan-base64-verify.json
```

Decoded signal output:

```json
{
  "config_jsonBody": "{\"username\":\"alice_pentest_base64_verify\",\"email\":\"alice_pentest_base64_verify@test.invalid\",\"password\":\"AlicePass123!\"}",
  "config_jsonBodyBase64": "eyJ1c2VybmFtZSI6ImFsaWNlX3BlbnRlc3RfYmFzZTY0X3ZlcmlmeSIsImVtYWlsIjoiYWxpY2VfcGVudGVzdF9iYXNlNjRfdmVyaWZ5QHRlc3QuaW52YWxpZCIsInBhc3N3b3JkIjoiQWxpY2VQYXNzMTIzISJ9",
  "request_body": "{\"username\":\"alice_pentest_base64_verify\",\"email\":\"alice_pentest_base64_verify@test.invalid\",\"password\":\"AlicePass123!\"}",
  "status": 200,
  "response_body": "{\"message\": \"Successfully registered. Login to receive an auth token.\", \"status\": \"success\"}"
}
```

## Test plan
- [x] `fern generate`
- [x] `go generate ./configs`
- [x] `./godelw verify`
- [x] Direct VAmPI CLI verification with `--json-body-base64` — 200, valid JSON body preserved
- [ ] After ontology wiring lands, re-run the platform `httprequest` tool against VAmPI and confirm the raw output preserves valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI and schema change; request sending still uses the existing JsonBody path after decode.
> 
> **Overview**
> Adds **`--json-body-base64`** to `discover request` so callers can pass JSON without shell-quoting issues. The flag value is standard-base64 decoded into **`JsonBody`** for the outgoing request (same path as **`--json-body`**), while the original base64 string is stored on **`JsonBodyBase64`** in **`DiscoverRequestConfig`** / report output.
> 
> **`--json-body`** and **`--json-body-base64`** cannot be used together; invalid base64 fails with a clear error. The Fern **`DiscoverRequestConfig`** type gains **`jsonBodyBase64`** for generated bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9076265d9d86517574e79d78808347ca93a9ec63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->