### PR TITLE
Static Asset Endpoint Bug

### DIFF
--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -647,9 +647,11 @@ func fetchSourceMapRoutes(ctx context.Context, sourceMapURL string, baseURL stri
 	urls := []string{}
 	errors := []string{}
 
-	if routeCaptureConfig.IgnoreCrossDomain && !discoverroutehelpers.IsSubdomain(baseURL, sourceMapURL) {
-		return routes, urls, errors
-	}
+	// The source map is fetched only as a source to mine for endpoints; its URL
+	// is never recorded as a route. Like the bundle it belongs to, fetching is
+	// exempt from cross-domain policy so CDN-hosted maps are honored. Endpoints
+	// discovered inside the map remain scoped to the target domain by
+	// extractScriptContentRoutes.
 
 	bodyBytes, _, statusCode, err := fetchJSResource(ctx, sourceMapURL, routeCaptureConfig)
 	if err != nil {
@@ -743,14 +745,12 @@ func ExtractScriptRoutes(ctx context.Context, doc *goquery.Document, baseURL str
 
 			fullURL := discoverroutehelpers.ResolveURL(baseURL, src)
 
-			if routeCaptureConfig.IgnoreCrossDomain && !discoverroutehelpers.IsSubdomain(baseURL, fullURL) {
-				return
-			}
-
-			// Check if the URL is allowed
-			if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
-				return
-			}
+			// Bundles are fetched only as a source to mine for endpoints; the
+			// bundle URL itself is never recorded as a route. Fetching is gated
+			// by MaxBundles (checked above) and is intentionally exempt from
+			// static-asset and cross-domain policy so that CDN-hosted bundles are
+			// still scanned. Endpoints discovered inside the bundle remain scoped
+			// to the target domain by extractScriptContentRoutes.
 
 			// Fetch the JavaScript content via utils/request so the surrounding
 			// DiscoverRouteConfig (TLS, UA, timeout) is honored.
@@ -827,9 +827,12 @@ func ExtractBundleURLRoutes(ctx context.Context, bundleURLs []string, baseURL st
 		// Resolve relative bundle URLs
 		fullURL := discoverroutehelpers.ResolveURL(baseURL, bundleURL)
 
-		if !discoverroutehelpers.IsURLAllowed(baseURL, fullURL, routeCaptureConfig.IgnoreCrossDomain, routeCaptureConfig.CollectStaticAssets) {
-			continue
-		}
+		// These bundle URLs are explicitly supplied by the operator and are
+		// fetched only to mine for endpoints; the bundle URL itself is never
+		// recorded as a route. Fetching is intentionally exempt from cross-domain
+		// policy so CDN-hosted bundles are honored. Endpoints discovered inside
+		// the bundle remain scoped to the target domain by
+		// extractScriptContentRoutes.
 
 		// Fetch the JS bundle via utils/request so the surrounding
 		// DiscoverRouteConfig (TLS, UA, timeout) is honored.

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -301,8 +301,17 @@ func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 	return strings.TrimRight(baseURL, "/"), parsedURL.EscapedPath(), nil
 }
 
-// IsURLAllowed checks if a target URL is allowed based on base URL and domain matching.
-func IsURLAllowed(baseURL string, targetURL string, ignoreCrossDomain bool, _ bool) bool {
+// IsURLAllowed checks if a target URL is allowed based on base URL, domain
+// matching, and static-asset policy. When captureStaticAssets is false, static
+// asset URLs (e.g. PDFs, images, archives, and JS bundles) are rejected so they
+// are not recorded as routes or queued for spidering. JS bundle fetching for
+// route discovery is gated separately by MaxBundles in the bundle extractors and
+// intentionally bypasses this allowlist; endpoints discovered inside a bundle
+// are still filtered through IsURLAllowed against the target domain.
+func IsURLAllowed(baseURL string, targetURL string, ignoreCrossDomain bool, captureStaticAssets bool) bool {
+	if !captureStaticAssets && utils.IsStaticAsset(targetURL) {
+		return false
+	}
 	if ignoreCrossDomain {
 		return IsSubdomain(baseURL, targetURL)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core URL allowlisting for discovery and deliberately bypasses domain/static checks for bundle fetches, which could affect crawl scope if misconfigured.
> 
> **Overview**
> Fixes route discovery treating static asset URLs (including **`.js` bundles**) as scannable endpoints when **`CollectStaticAssets`** is off.
> 
> **`IsURLAllowed`** now honors **`captureStaticAssets`**: if collection is disabled, **`utils.IsStaticAsset`** URLs are rejected so they are not recorded as routes or queued for spidering. Endpoints extracted from JS still pass through this allowlist.
> 
> **Bundle and source-map fetching** no longer gates on cross-domain or **`IsURLAllowed`**. Those fetches are only for mining; the bundle/map URL is not emitted as a route. **`MaxBundles`** still limits fetches, and **`extractScriptContentRoutes`** keeps in-scope domain filtering for discovered API paths. Comments document this split so CDN-hosted bundles/maps remain scannable without widening the route surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b16ea45b0062e5371b4979492a0e7d15568cb352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->