### PR TITLE
Add User Agents to Nuclei Commands

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -105,9 +105,14 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -132,8 +137,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverApplicationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	discoverApplicationCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
 	discoverApplicationCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
-	// TODO: Add --user-agent flag here once the nuclei runner supports UserAgentPreset.
-	// Skipped for now because application discovery uses nuclei, not the standard HTTP client.
+	discoverApplicationCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = discoverApplicationCmd.MarkFlagRequired("targets")
@@ -1373,7 +1377,7 @@ func parseDiscoverRequestFiles(pairs []string) ([]*discover.RequestFile, error) 
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -1389,6 +1393,7 @@ func getDiscoverApplicationConfig(targets []string, resource string, templatePat
 		VerboseLogs:     verboseLogs,
 		GlobalRateLimit: max(0, globalRateLimit),
 		GlobalTimeout:   max(0, globalTimeout),
+		UserAgent:       userAgent,
 	}
 	return config, nil
 }

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -50,9 +50,6 @@ func (a *WebScan) InitPentestCommand() {
 	}
 
 	// Dast Command
-	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
-	// which manages its own HTTP client and does not honor the UserAgentPreset.
-	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationDastCmd := &cobra.Command{
 		Use:   "dast",
 		Short: "Dast targets to discover previously unknown vulnerabilities",
@@ -156,9 +153,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, workflowPaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, workflowPaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -184,6 +186,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
 	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestApplicationDastCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = pentestApplicationDastCmd.MarkFlagRequired("targets")
@@ -201,9 +204,6 @@ func (a *WebScan) InitPentestCommand() {
 	}
 
 	// CVE Scan Command
-	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
-	// which manages its own HTTP client and does not honor the UserAgentPreset.
-	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationCveCmd := &cobra.Command{
 		Use:   "cve",
 		Short: "Scan targets for CVEs",
@@ -265,9 +265,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationCveConfig(targets, years, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationCveConfig(targets, years, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationCveScan(cmd.Context(), config)
@@ -289,6 +294,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationCveCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
 	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestApplicationCveCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = pentestApplicationCveCmd.MarkFlagRequired("targets")
@@ -297,9 +303,6 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationScanCmd.AddCommand(pentestApplicationCveCmd)
 
 	// Misconfiguration Scan Command
-	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
-	// which manages its own HTTP client and does not honor the UserAgentPreset.
-	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationMisconfigurationCmd := &cobra.Command{
 		Use:   "misconfiguration",
 		Short: "Scan targets for security misconfigurations",
@@ -367,9 +370,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationMisconfigurationScan(cmd.Context(), config)
@@ -392,6 +400,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 25, "Global rate limit in requests per second")
 	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 650, "Maximum total scan time in seconds")
+	pentestApplicationMisconfigurationCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = pentestApplicationMisconfigurationCmd.MarkFlagRequired("targets")
@@ -400,9 +409,6 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationScanCmd.AddCommand(pentestApplicationMisconfigurationCmd)
 
 	// Technologies Scan Command
-	// TODO: --user-agent flag is not supported here because this command runs via nuclei,
-	// which manages its own HTTP client and does not honor the UserAgentPreset.
-	// When nuclei adds user-agent override support, wire config.UserAgent here.
 	pentestApplicationTechnologyCmd := &cobra.Command{
 		Use:   "technology",
 		Short: "Scan targets for technology-specific vulnerabilities",
@@ -469,9 +475,14 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Set config
-			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationTechnologyScan(cmd.Context(), config)
@@ -494,6 +505,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit in requests per second")
 	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestApplicationTechnologyCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
 	_ = pentestApplicationTechnologyCmd.MarkFlagRequired("targets")
@@ -1248,7 +1260,7 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, workflowPaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, workflowPaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
 		Targets:           targets,
 		DastCategories:    dastCategories,
@@ -1262,12 +1274,13 @@ func getPentestApplicationDastConfig(targets []string, dastCategories []pentesta
 		VerboseLogs:       verboseLogs,
 		GlobalRateLimit:   max(0, globalRateLimit),
 		GlobalTimeout:     max(0, globalTimeout),
+		UserAgent:         userAgent,
 	}
 	return config
 }
 
 // getPentestApplicationCveConfig builds the config for scan pentest.
-func getPentestApplicationCveConfig(targets []string, years []string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationCveConfig {
+func getPentestApplicationCveConfig(targets []string, years []string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationscanfern.PentestApplicationCveConfig {
 	config := pentestapplicationscanfern.PentestApplicationCveConfig{
 		Targets:         targets,
 		Years:           years,
@@ -1278,12 +1291,13 @@ func getPentestApplicationCveConfig(targets []string, years []string, templatePa
 		VerboseLogs:     verboseLogs,
 		GlobalRateLimit: max(0, globalRateLimit),
 		GlobalTimeout:   max(0, globalTimeout),
+		UserAgent:       userAgent,
 	}
 	return config
 }
 
 // getPentestApplicationMisconfigurationConfig builds the config for scan pentest.
-func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
+func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
 	config := pentestapplicationscanfern.PentestApplicationMisconfigurationConfig{
 		Targets:                    targets,
 		MisconfigurationCategories: misconfigurationCategories,
@@ -1294,12 +1308,13 @@ func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurat
 		VerboseLogs:                verboseLogs,
 		GlobalRateLimit:            max(0, globalRateLimit),
 		GlobalTimeout:              max(0, globalTimeout),
+		UserAgent:                  userAgent,
 	}
 	return config
 }
 
 // getPentestApplicationTechnologiesConfig builds the config for scan pentest.
-func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
+func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
 	config := pentestapplicationscanfern.PentestApplicationTechnologyConfig{
 		Targets:         targets,
 		TechnologyTypes: technologyTypes,
@@ -1310,6 +1325,7 @@ func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []p
 		VerboseLogs:     verboseLogs,
 		GlobalRateLimit: max(0, globalRateLimit),
 		GlobalTimeout:   max(0, globalTimeout),
+		UserAgent:       userAgent,
 	}
 	return config
 }

--- a/fern/definition/common/nuclei/config.yml
+++ b/fern/definition/common/nuclei/config.yml
@@ -1,5 +1,6 @@
 imports:
   http: ../../common/http.yml
+  method: ../../common/method.yml
   parameter: ./parameter.yml
 types:
   # Nuclei Enum and Structs
@@ -24,4 +25,5 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      userAgent: method.UserAgentPreset
 

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -1,5 +1,6 @@
 imports:
   http: ../common/http.yml
+  method: ../common/method.yml
 types:
   # Application Enums
   ApplicationResourceTypeAll:
@@ -59,6 +60,7 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      userAgent: method.UserAgentPreset
   # Application Fingerprint Attempt Struct
   ApplicationFingerprintAttempt:
     properties:

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -2,6 +2,7 @@ imports:
   nuclei: ../../common/nuclei/report.yml
   parameter: ../../common/nuclei/parameter.yml
   http: ../../common/http.yml
+  method: ../../common/method.yml
 types:
   PentestApplicationDastCategory:
     enum:
@@ -29,6 +30,7 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      userAgent: method.UserAgentPreset
   PentestApplicationDastResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/cve.yml
+++ b/fern/definition/pentest/application/scan/cve.yml
@@ -1,5 +1,6 @@
 imports:
   nuclei: ../../../common/nuclei/report.yml
+  method: ../../../common/method.yml
 types:
   # Config Struct
   PentestApplicationCveConfig:
@@ -13,6 +14,7 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      userAgent: method.UserAgentPreset
   PentestApplicationCveResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/misconfiguration.yml
+++ b/fern/definition/pentest/application/scan/misconfiguration.yml
@@ -1,5 +1,6 @@
 imports:
   nuclei: ../../../common/nuclei/report.yml
+  method: ../../../common/method.yml
 types:
   # Enums
   MisconfigurationCategory:
@@ -17,6 +18,7 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      userAgent: method.UserAgentPreset
   PentestApplicationMisconfigurationResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/technology.yml
+++ b/fern/definition/pentest/application/scan/technology.yml
@@ -1,5 +1,6 @@
 imports:
   nuclei: ../../../common/nuclei/report.yml
+  method: ../../../common/method.yml
 types:
   # Currently supported technologies
   TechnologyType:
@@ -19,6 +20,7 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      userAgent: method.UserAgentPreset
   PentestApplicationTechnologyResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -107,6 +107,7 @@ func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
 		GlobalTimeout:   config.GlobalTimeout,
+		UserAgent:       config.UserAgent,
 	}, nil
 }
 

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -68,6 +68,7 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
 		GlobalTimeout:   config.GlobalTimeout,
+		UserAgent:       config.UserAgent,
 	}
 }
 

--- a/internal/pentest/application/scan/cve.go
+++ b/internal/pentest/application/scan/cve.go
@@ -38,6 +38,7 @@ func createCveScanNucleiConfig(config pentestapplicationscanfern.PentestApplicat
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
 		GlobalTimeout:   config.GlobalTimeout,
+		UserAgent:       config.UserAgent,
 	}
 }
 

--- a/internal/pentest/application/scan/misconfiguration.go
+++ b/internal/pentest/application/scan/misconfiguration.go
@@ -41,6 +41,7 @@ func createMisconfigurationScanNucleiConfig(config pentestapplicationscanfern.Pe
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
 		GlobalTimeout:   config.GlobalTimeout,
+		UserAgent:       config.UserAgent,
 	}
 }
 

--- a/internal/pentest/application/scan/technology.go
+++ b/internal/pentest/application/scan/technology.go
@@ -42,6 +42,7 @@ func createTechnologyScanNucleiConfig(config pentestapplicationscanfern.PentestA
 		VerboseLogs:     config.VerboseLogs,
 		GlobalRateLimit: config.GlobalRateLimit,
 		GlobalTimeout:   config.GlobalTimeout,
+		UserAgent:       config.UserAgent,
 	}
 }
 

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -11,14 +11,15 @@ import (
 	"time"
 
 	// Generated
+	common "github.com/Method-Security/webscan/generated/go/common"
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
 	// Utils
 	report "github.com/Method-Security/webscan/utils/nuclei/report"
+	useragent "github.com/Method-Security/webscan/utils/useragent"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
-	useragent "github.com/projectdiscovery/useragent"
 )
 
 type Config struct {
@@ -34,6 +35,7 @@ type Config struct {
 	Timeout         int
 	GlobalRateLimit int
 	GlobalTimeout   int
+	UserAgent       common.UserAgentPreset
 }
 
 func validateConfig(cfg *Config) error {
@@ -222,9 +224,10 @@ func buildNucleiOptions(cfg Config, templateDir, workflowDir string) []nucleilib
 		opts = append(opts, nucleilib.WithVerbosity(nucleilib.VerbosityOptions{Silent: false, Debug: true, Verbose: true}))
 	}
 
-	// Add random user agent
-	randomUserAgent := useragent.PickRandom()
-	opts = append(opts, nucleilib.WithHeaders([]string{fmt.Sprintf("User-Agent:%s", randomUserAgent.Raw)}))
+	// Resolve the User-Agent from the configured preset. An empty/RANDOM preset
+	// resolves to a random browser UA, preserving prior default behavior.
+	resolvedUserAgent := useragent.Resolve(cfg.UserAgent)
+	opts = append(opts, nucleilib.WithHeaders([]string{fmt.Sprintf("User-Agent:%s", resolvedUserAgent)}))
 
 	if cfg.RunMode == nuclei.NucleiRunModeDast {
 		opts = append(opts, nucleilib.DASTMode())
@@ -291,6 +294,7 @@ func GetRunnerConfig(templateFileSystems, workflowFileSystems []fs.FS, config nu
 		Timeout:         config.Timeout,
 		GlobalRateLimit: config.GlobalRateLimit,
 		GlobalTimeout:   config.GlobalTimeout,
+		UserAgent:       config.UserAgent,
 	}
 	return rconfig
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly flag and config plumbing; default RANDOM preserves prior scan behavior, with only request fingerprinting changing when callers choose a specific preset.
> 
> **Overview**
> Adds configurable **User-Agent presets** (`RANDOM`, `CHROME`, `FIREFOX`, `SAFARI`, `EDGE`) to nuclei-backed flows that previously hard-coded a random UA and documented the gap with TODOs.
> 
> **CLI:** `discover application` and `pentest application` subcommands (`dast`, `scan cve`, `misconfiguration`, `technology`) now expose `--user-agent` (default `RANDOM`), parsed via `requesthelpers.GetUserAgentFlag` and passed into config builders.
> 
> **Schema & wiring:** Fern configs (`NucleiConfig`, `DiscoverApplicationConfig`, pentest DAST/CVE/misconfiguration/technology configs) gain `userAgent: method.UserAgentPreset`; internal engines copy that into `nuclei.NucleiConfig`.
> 
> **Nuclei runner:** Replaces `projectdiscovery/useragent` random pick with `utils/useragent.Resolve(cfg.UserAgent)` and sets the `User-Agent` header on nuclei requests; `RANDOM`/empty still behaves like the old default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415ab024ef901b11f1ccc92d8ab1f5c93259cac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->