### PR TITLE
Omit Emit Examples or Empty Quotes

### DIFF
--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -208,8 +208,13 @@ func ParseQueryParams(reqURL *url.URL) []*discover.RouteQueryParam {
 		// Set Max Size and Length of Examples
 		// Max Value Length is 256 characters
 		// Max Example Values is 5 values
+		// Empty values carry no example information, so omit them rather than
+		// recording an empty string.
 		filteredValues := make([]string, 0, len(values))
 		for _, value := range values {
+			if value == "" {
+				continue
+			}
 			if len(value) <= 256 {
 				filteredValues = append(filteredValues, value)
 			}
@@ -261,9 +266,18 @@ func ParseBodyParams(postData string) ([]*discover.RouteBodyParam, error) {
 				if key == "" {
 					continue
 				}
+				// Empty values carry no example information, so omit them rather
+				// than recording an empty string.
+				filteredValues := make([]string, 0, len(values))
+				for _, value := range values {
+					if value == "" {
+						continue
+					}
+					filteredValues = append(filteredValues, value)
+				}
 				bodyParams = append(bodyParams, &discover.RouteBodyParam{
 					Name:          key,
-					ExampleValues: values,
+					ExampleValues: filteredValues,
 				})
 			}
 		} else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small output-shaping change in route discovery helpers with no auth, security, or persistence impact.
> 
> **Overview**
> Route discovery no longer records **empty strings** as `ExampleValues` when parsing URLs and form bodies.
> 
> **`ParseQueryParams`** now skips blank values while building the filtered example list (length and max-count limits are unchanged). **`ParseBodyParams`** applies the same rule for **form-urlencoded** POST data instead of passing through raw `values` from `url.ParseQuery`. JSON body parsing is untouched.
> 
> Params with only empty values can still appear with an empty `ExampleValues` slice; the change only removes misleading `""` examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825f3ab9daf95390eb9588210027a231ad8e2e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->