### PR TITLE
Add WebServer socket field to DiscoverProbeConfig

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -815,8 +815,26 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
+			// WebServer socket flags — optional; when all three are supplied the probe
+			// report carries the (ip, port, protocol) triple downstream for processor linking.
+			webServerIPAddress, err := cmd.Flags().GetString("web-server-ip-address")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			webServerPort, err := cmd.Flags().GetInt("web-server-port")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			webServerApplicationProtocol, err := cmd.Flags().GetString("web-server-application-protocol")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Set Config
-			config := getDiscoverProbeConfig(targets, protocol, maxRedirects, verifyTLS, timeout, sleep, jitter, ignoreCrossDomainRedirects, userAgentPreset, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverProbeConfig(targets, protocol, maxRedirects, verifyTLS, timeout, sleep, jitter, ignoreCrossDomainRedirects, userAgentPreset, requestMethodConfig.RequestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig, webServerIPAddress, webServerPort, webServerApplicationProtocol)
 
 			// Generate report
 			report, err := discoverprobe.PerformWebProbe(cmd.Context(), config, requestMethodConfig.BrowserbaseSecrets)
@@ -846,6 +864,13 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverProbeCmd.Flags().String("browserbase-project", "", "Browserbase project ID")
 	discoverProbeCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")
 	discoverProbeCmd.Flags().StringSlice("browserbase-countries", []string{}, "List of countries to use for Browserbase proxy")
+
+	// WebServer socket — identifies the listener the probe runs against. Carried through
+	// to the report verbatim so downstream processors can link the discovered web
+	// application to the WebServer entity created by an upstream service-fingerprint pass.
+	discoverProbeCmd.Flags().String("web-server-ip-address", "", "IP address of the WebServer listener this probe is running against")
+	discoverProbeCmd.Flags().Int("web-server-port", 0, "Port of the WebServer listener this probe is running against")
+	discoverProbeCmd.Flags().String("web-server-application-protocol", "", "Application protocol of the WebServer listener this probe is running against (HTTP, HTTPS)")
 
 	// Mark Required Flags
 	_ = discoverProbeCmd.MarkFlagRequired("targets")
@@ -1652,7 +1677,7 @@ func getDiscoverPageConfig(target string, sensitiveContentDetection bool, sensit
 }
 
 // getDiscoverProbeConfig builds the config for probe discovery.
-func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int, verifyTLS bool, timeout int, sleep int, jitter int, ignoreCrossDomainRedirects bool, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) *discover.DiscoverProbeConfig {
+func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int, verifyTLS bool, timeout int, sleep int, jitter int, ignoreCrossDomainRedirects bool, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig, webServerIPAddress string, webServerPort int, webServerApplicationProtocol string) *discover.DiscoverProbeConfig {
 	config := &discover.DiscoverProbeConfig{
 		Targets:                    targets,
 		MaxRedirects:               maxRedirects,
@@ -1679,6 +1704,28 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 		default:
 			// Invalid protocol - will be handled by validation in the probe function
 			// For now, leave it unset to maintain existing behavior
+		}
+	}
+
+	// WebServer socket — populated when the caller passes all three components. The CLI
+	// doesn't otherwise consume the socket; it round-trips through the report so the
+	// ontology probe processor can link WebApplication.web_server to the upstream
+	// WebServer entity (created by a prior service-fingerprint pass).
+	if webServerIPAddress != "" && webServerPort > 0 && webServerApplicationProtocol != "" {
+		var wsProtocol common.WebProtocol
+		switch strings.ToUpper(webServerApplicationProtocol) {
+		case "HTTP":
+			wsProtocol = common.WebProtocolHttp
+		case "HTTPS":
+			wsProtocol = common.WebProtocolHttps
+		default:
+			// Unknown protocol → omit the socket rather than half-populating it.
+			return config
+		}
+		config.WebServer = &common.WebServerSocket{
+			IpAddress:           webServerIPAddress,
+			Port:                webServerPort,
+			ApplicationProtocol: wsProtocol,
 		}
 	}
 

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -815,8 +815,6 @@ func (a *WebScan) InitDiscoverCommand() {
 				return
 			}
 
-			// WebServer socket flags — optional; when all three are supplied the probe
-			// report carries the (ip, port, protocol) triple downstream for processor linking.
 			webServerIPAddress, err := cmd.Flags().GetString("web-server-ip-address")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -865,9 +863,6 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverProbeCmd.Flags().Bool("browserbase-proxy", false, "Use Browserbase proxy for requests")
 	discoverProbeCmd.Flags().StringSlice("browserbase-countries", []string{}, "List of countries to use for Browserbase proxy")
 
-	// WebServer socket — identifies the listener the probe runs against. Carried through
-	// to the report verbatim so downstream processors can link the discovered web
-	// application to the WebServer entity created by an upstream service-fingerprint pass.
 	discoverProbeCmd.Flags().String("web-server-ip-address", "", "IP address of the WebServer listener this probe is running against")
 	discoverProbeCmd.Flags().Int("web-server-port", 0, "Port of the WebServer listener this probe is running against")
 	discoverProbeCmd.Flags().String("web-server-application-protocol", "", "Application protocol of the WebServer listener this probe is running against (HTTP, HTTPS)")
@@ -1707,10 +1702,6 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 		}
 	}
 
-	// WebServer socket — populated when the caller passes all three components. The CLI
-	// doesn't otherwise consume the socket; it round-trips through the report so the
-	// ontology probe processor can link WebApplication.web_server to the upstream
-	// WebServer entity (created by a prior service-fingerprint pass).
 	if webServerIPAddress != "" && webServerPort > 0 && webServerApplicationProtocol != "" {
 		var wsProtocol common.WebProtocol
 		switch strings.ToUpper(webServerApplicationProtocol) {
@@ -1719,7 +1710,6 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 		case "HTTPS":
 			wsProtocol = common.WebProtocolHttps
 		default:
-			// Unknown protocol → omit the socket rather than half-populating it.
 			return config
 		}
 		config.WebServer = &common.WebServerSocket{

--- a/fern/definition/common/http.yml
+++ b/fern/definition/common/http.yml
@@ -6,6 +6,15 @@ types:
     enum:
       - HTTP
       - HTTPS
+  # WebServer socket — the (ip, port, application protocol) triple identifying a
+  # specific HTTP/HTTPS listener. Carried verbatim through the probe report so the
+  # ontology processor can link the discovered WebApplication to the upstream
+  # WebServer entity (typically created by a prior service-fingerprint pass).
+  WebServerSocket:
+    properties:
+      ipAddress: string
+      port: integer
+      applicationProtocol: WebProtocol
   # Http Method Enum
   HttpMethod:
     enum:

--- a/fern/definition/common/http.yml
+++ b/fern/definition/common/http.yml
@@ -6,10 +6,6 @@ types:
     enum:
       - HTTP
       - HTTPS
-  # WebServer socket — the (ip, port, application protocol) triple identifying a
-  # specific HTTP/HTTPS listener. Carried verbatim through the probe report so the
-  # ontology processor can link the discovered WebApplication to the upstream
-  # WebServer entity (typically created by a prior service-fingerprint pass).
   WebServerSocket:
     properties:
       ipAddress: string

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -17,10 +17,6 @@ types:
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>
-      # Identifies the WebServer listener the probe is running against. Carried
-      # through to the report verbatim so the ontology processor can link the
-      # discovered WebApplication.web_server to the matching WebServer entity
-      # (typically created by an upstream service-fingerprint pass).
       webServer: optional<http.WebServerSocket>
   DiscoverProbeResult:
     properties:

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -17,6 +17,11 @@ types:
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>
+      # Identifies the WebServer listener the probe is running against. Carried
+      # through to the report verbatim so the ontology processor can link the
+      # discovered WebApplication.web_server to the matching WebServer entity
+      # (typically created by an upstream service-fingerprint pass).
+      webServer: optional<http.WebServerSocket>
   DiscoverProbeResult:
     properties:
       targets: optional<list<http.HttpRequestResponse>>

--- a/internal/discover/request/request_test.go
+++ b/internal/discover/request/request_test.go
@@ -2,10 +2,10 @@
 // primitive. The tests in this file exist to pin the AITF-138 Part 3 bug
 // class: the user's invocation
 //
-//   webscan discover request --target ... --verify-tls TRUE --user-agent CHROME \
-//     --header "Accept: application/json" \
-//     --header "Accept: text/html;q=0.9" \
-//     --header "Accept: */*;q=0.8"
+//	webscan discover request --target ... --verify-tls TRUE --user-agent CHROME \
+//	  --header "Accept: application/json" \
+//	  --header "Accept: text/html;q=0.9" \
+//	  --header "Accept: */*;q=0.8"
 //
 // was supposed to send three Accept values comma-joined per RFC 7230, but
 // silently dropped headers that did not contain a colon and overwrote

--- a/internal/discover/route/helpers/extractors/htmlExtractors.go
+++ b/internal/discover/route/helpers/extractors/htmlExtractors.go
@@ -11,7 +11,6 @@ import (
 
 	// Internal
 	discoverroutehelpers "github.com/Method-Security/webscan/internal/discover/route/helpers"
-
 	// External
 	goquery "github.com/PuerkitoBio/goquery"
 )

--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -13,9 +13,11 @@ import (
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
+
 	// Utils
 	report "github.com/Method-Security/webscan/utils/nuclei/report"
 	useragent "github.com/Method-Security/webscan/utils/useragent"
+
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"

--- a/utils/nuclei/templates/select.go
+++ b/utils/nuclei/templates/select.go
@@ -146,9 +146,9 @@ type singleFileDirHandle struct {
 	offset int
 }
 
-func (d *singleFileDirHandle) Stat() (fs.FileInfo, error)  { return &dirInfo{name: "."}, nil }
-func (d *singleFileDirHandle) Read([]byte) (int, error)    { return 0, fmt.Errorf("is a directory") }
-func (d *singleFileDirHandle) Close() error                { return nil }
+func (d *singleFileDirHandle) Stat() (fs.FileInfo, error) { return &dirInfo{name: "."}, nil }
+func (d *singleFileDirHandle) Read([]byte) (int, error)   { return 0, fmt.Errorf("is a directory") }
+func (d *singleFileDirHandle) Close() error               { return nil }
 
 func (d *singleFileDirHandle) ReadDir(n int) ([]fs.DirEntry, error) {
 	info, err := os.Stat(d.fsys.path)


### PR DESCRIPTION
## Summary

Adds a `webServer` field to `DiscoverProbeConfig` so the probe report can carry the listener identity (ip, port, application_protocol) downstream. The webscan CLI doesn't consume the value itself — it round-trips through the report.

The motivation is the Web Server Model refactor in `ontology-definition` v0.0.281: `WebServer` is now a first-class `NetworkApplication` subclass for HTTP/HTTPS listeners, and the natural bridge from `WebServer` to `WebApplication` is the discover/probe tool. Today the probe report has no field for the upstream listener, so the ontology processor can't link `WebApplication.web_server` to the `WebServer` entity a prior service-fingerprint pass already created. This PR plumbs that field through.

## Changes

- **`fern/definition/common/http.yml`**: new `WebServerSocket { ipAddress, port, applicationProtocol }` type.
- **`fern/definition/discover/probe.yml`**: new optional `webServer: WebServerSocket` field on `DiscoverProbeConfig`.
- **`cmd/discover.go`**: three new CLI flags on `discover probe` — `--web-server-ip-address`, `--web-server-port`, `--web-server-application-protocol`. All three must be supplied together; otherwise the socket is omitted. CLI does nothing else with the value beyond stuffing it into the config so the report carries it.
- Regenerated Go types via `fern generate --group local`.

## Test plan
- [x] `./godelw verify` — green.
- [ ] CI green.
- [ ] Downstream ontology PR (#1559) bumps to this version and uses the new field in the probe processor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema and CLI fields with no change to probe HTTP behavior; partial or invalid web-server flag combinations are silently omitted rather than failing.
> 
> **Overview**
> Adds optional **WebServer listener identity** to discover probe output so downstream ontology can tie `WebApplication` results to an existing `WebServer` entity.
> 
> Introduces **`WebServerSocket`** (`ipAddress`, `port`, `applicationProtocol`) in the API schema and an optional **`webServer`** field on **`DiscoverProbeConfig`**, echoed in the probe report config. **`discover probe`** gains `--web-server-ip-address`, `--web-server-port`, and `--web-server-application-protocol`; when all three are set with a valid HTTP/HTTPS protocol, the CLI fills `webServer` on the config. The probe path does not use this for requests—it only round-trips through the report.
> 
> Other diff hunks are whitespace/formatting only (tests, nuclei utils, route helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d22652b095ae55dc43bc008d6cb04d83c12fbe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->