### PR TITLE
Flatten WebServer socket into DiscoverProbeConfig fields

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -1702,20 +1702,20 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 		}
 	}
 
-	if webServerIPAddress != "" && webServerPort > 0 && webServerApplicationProtocol != "" {
-		var wsProtocol common.WebProtocol
+	if webServerIPAddress != "" {
+		config.WebServerIpAddress = &webServerIPAddress
+	}
+	if webServerPort > 0 {
+		config.WebServerPort = &webServerPort
+	}
+	if webServerApplicationProtocol != "" {
 		switch strings.ToUpper(webServerApplicationProtocol) {
 		case "HTTP":
-			wsProtocol = common.WebProtocolHttp
+			wsProtocol := common.WebProtocolHttp
+			config.WebServerApplicationProtocol = &wsProtocol
 		case "HTTPS":
-			wsProtocol = common.WebProtocolHttps
-		default:
-			return config
-		}
-		config.WebServer = &common.WebServerSocket{
-			IpAddress:           webServerIPAddress,
-			Port:                webServerPort,
-			ApplicationProtocol: wsProtocol,
+			wsProtocol := common.WebProtocolHttps
+			config.WebServerApplicationProtocol = &wsProtocol
 		}
 	}
 

--- a/fern/definition/common/http.yml
+++ b/fern/definition/common/http.yml
@@ -6,11 +6,6 @@ types:
     enum:
       - HTTP
       - HTTPS
-  WebServerSocket:
-    properties:
-      ipAddress: string
-      port: integer
-      applicationProtocol: WebProtocol
   # Http Method Enum
   HttpMethod:
     enum:

--- a/fern/definition/discover/probe.yml
+++ b/fern/definition/discover/probe.yml
@@ -17,7 +17,9 @@ types:
       requestMethod: method.RequestMethod
       headlessConfig: optional<method.HeadlessRequestConfig>
       browserbaseConfig: optional<method.BrowserbaseRequestConfig>
-      webServer: optional<http.WebServerSocket>
+      webServerIpAddress: optional<string>
+      webServerPort: optional<integer>
+      webServerApplicationProtocol: optional<http.WebProtocol>
   DiscoverProbeResult:
     properties:
       targets: optional<list<http.HttpRequestResponse>>


### PR DESCRIPTION
## Summary

Follow-up to #467 based on ontology-side review feedback: the nested `WebServerSocket` struct required the ontology compiler to manually emit flat CLI flags because `CompilerUtils.generate_flags_from_config` strips the parent field name when recursing into nested structs. Flattening into three top-level optional fields on `DiscoverProbeConfig` lets the compiler set them directly on the config and rely on standard serialization.

## Changes
- `fern/definition/common/http.yml`: drop `WebServerSocket` type.
- `fern/definition/discover/probe.yml`: replace `webServer: WebServerSocket` with three optional flat fields: `webServerIpAddress`, `webServerPort`, `webServerApplicationProtocol`.
- `cmd/discover.go`: populate the three fields independently on `DiscoverProbeConfig` from the existing `--web-server-*` CLI flags.

## Test plan
- [x] `./godelw verify` — green.
- [ ] Downstream ontology PR (#1559) bumps to this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema and config-shape change for discover probe metadata; partial web-server fields are now allowed, which may differ from prior all-or-nothing behavior until downstream consumers are updated.
> 
> **Overview**
> **Replaces the nested `webServer` / `WebServerSocket` shape with three optional top-level fields** on `DiscoverProbeConfig` (`webServerIpAddress`, `webServerPort`, `webServerApplicationProtocol`) and removes the `WebServerSocket` Fern type from `http.yml`, so ontology tooling can map CLI flags without nested-struct flag generation.
> 
> `getDiscoverProbeConfig` now sets each web-server field when its CLI value is present, instead of requiring IP, port, and protocol together before populating a single nested object. Invalid `web-server-application-protocol` values no longer short-circuit config building; the protocol field is simply left unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ba2f993ec1f7b20d1a0c9651d59ee44cac2dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->