### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "4.68.4"
+  "version": "5.65.3"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,7 +3,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.34.8
+        version: 1.46.4
         config:
           importPath: github.com/Method-Security/webscan/generated/go
         output:

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/ysmood/gson v0.7.3
-	golang.org/x/net v0.56.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -350,6 +349,7 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -828,11 +828,11 @@ func convertSecurityDefinitionsV3(securityDefinitions map[string]*v3.SecuritySch
 	return schemes
 }
 
-func convertOAuthFlowV3(flows *v3.OAuthFlows) *enumerateapiapplicationfern.OauthFlow {
+func convertOAuthFlowV3(flows *v3.OAuthFlows) *enumerateapiapplicationfern.OAuthFlow {
 	if flows == nil {
 		return nil
 	}
-	return &enumerateapiapplicationfern.OauthFlow{
+	return &enumerateapiapplicationfern.OAuthFlow{
 		Implicit:          convertOAuthFlowDetailsV3(flows.Implicit),
 		Password:          convertOAuthFlowDetailsV3(flows.Password),
 		ClientCredentials: convertOAuthFlowDetailsV3(flows.ClientCredentials),
@@ -840,11 +840,11 @@ func convertOAuthFlowV3(flows *v3.OAuthFlows) *enumerateapiapplicationfern.Oauth
 	}
 }
 
-func convertOAuthFlowDetailsV3(flow *v3.OAuthFlow) *enumerateapiapplicationfern.OauthFlowDetails {
+func convertOAuthFlowDetailsV3(flow *v3.OAuthFlow) *enumerateapiapplicationfern.OAuthFlowDetails {
 	if flow == nil {
 		return nil
 	}
-	return &enumerateapiapplicationfern.OauthFlowDetails{
+	return &enumerateapiapplicationfern.OAuthFlowDetails{
 		AuthorizationUrl: &flow.AuthorizationUrl,
 		TokenUrl:         &flow.TokenUrl,
 		RefreshUrl:       &flow.RefreshUrl,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tooling and generated-type renames only; behavior change is limited to matching new SDK identifiers in one conversion path.
> 
> **Overview**
> **Upgrades the Fern toolchain** so generated clients stay in sync with current Fern releases: CLI **4.68.4 → 5.65.3** in `fern.config.json` and the local **fernapi/fern-go-sdk** generator **1.34.8 → 1.46.4** in `generators.yml`.
> 
> The newer Go SDK changes export naming for OAuth-related models (`OAuthFlow`, `OAuthFlowDetails` instead of `OauthFlow` / `OauthFlowDetails`). **`internal/enumerate/apiapplication/swagger.go`** is updated so OpenAPI v3 security-scheme conversion still compiles against the regenerated `enumerate/apiapplication` package.
> 
> **`go.mod`** drops a direct `golang.org/x/net` require and records it as an indirect dependency after the dependency graph refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f724239ada14580f274490ee79cf4c72d6d0ee20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->