### PR TITLE
Bump Pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Method-Security/webscan
 go 1.26.0
 
 require (
-	github.com/Method-Security/pkg v0.1.0
+	github.com/Method-Security/pkg v0.1.1
 	github.com/PuerkitoBio/goquery v1.10.3
 	github.com/corona10/goimagehash v1.1.0
 	github.com/go-rod/rod v0.116.2

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/Method-Security/pkg v0.1.0 h1:v7GzPNFJZQr2HB+P0ox7SrhYMF0giNu0uzT4EYJzNDg=
-github.com/Method-Security/pkg v0.1.0/go.mod h1:suN5TaS8DJ4VR3uhwpzTZKfNuWylz08Z+a4JUSbv0LY=
+github.com/Method-Security/pkg v0.1.1 h1:Y8Ca5DlihOVBYuysW6Yr+EeNntDTp9n4sHBhN63Xhe8=
+github.com/Method-Security/pkg v0.1.1/go.mod h1:suN5TaS8DJ4VR3uhwpzTZKfNuWylz08Z+a4JUSbv0LY=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/vendor/github.com/Method-Security/pkg/httpclient/client.go
+++ b/vendor/github.com/Method-Security/pkg/httpclient/client.go
@@ -119,6 +119,10 @@ func New(opts ...Option) *Client {
 	}
 
 	transport := &http.Transport{
+		// Force HTTP/2 negotiation over ALPN. Setting a custom TLSClientConfig
+		// otherwise disables Go's automatic HTTP/2 upgrade, so this flag is
+		// required to keep HTTP/2 enabled.
+		ForceAttemptHTTP2: true,
 		TLSClientConfig: &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: !options.VerifyTLS, //nolint:gosec // configurable by caller

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,7 +101,7 @@ github.com/Knetic/govaluate
 # github.com/Masterminds/semver/v3 v3.4.0
 ## explicit; go 1.21
 github.com/Masterminds/semver/v3
-# github.com/Method-Security/pkg v0.1.0
+# github.com/Method-Security/pkg v0.1.1
 ## explicit; go 1.26.0
 github.com/Method-Security/pkg/httpclient
 github.com/Method-Security/pkg/signal


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only bump with a small transport tweak; no auth or data-model changes in webscan itself.
> 
> **Overview**
> Bumps **`github.com/Method-Security/pkg`** from **v0.1.0** to **v0.1.1** and refreshes **`go.sum`** and vendored **`modules.txt`**.
> 
> The meaningful behavior change is in the shared **`httpclient`** transport: it now sets **`ForceAttemptHTTP2: true`** so HTTP/2 over ALPN stays enabled when a custom **`TLSClientConfig`** is used (which otherwise turns off Go’s automatic HTTP/2 upgrade). Scanning traffic that goes through **`utils/request/standard/helpers/send.go`** and this client may negotiate HTTP/2 again on compatible targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c9d78a8879f38eb781f9ee76264969a32a6cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->