### PR TITLE
Capture wordpress versions

### DIFF
--- a/docs/docs/enumerate.md
+++ b/docs/docs/enumerate.md
@@ -100,7 +100,7 @@ Enumerate content management systems.
 
 #### WordPress Plugins
 
-In addition to enumerating installed plugins, this command detects the WordPress core version running on the target, trying (in order of reliability) `/readme.html`, the HTML `<meta name="generator">` tag, and `?ver=` query strings on core `wp-includes`/`wp-admin` asset URLs. The detected version and the method that found it are reported as `version` and `versionSource` on each target.
+In addition to enumerating installed plugins, this command detects the WordPress core version running on the target, trying (in order of reliability) the HTML `<meta name="generator">` tag and `?ver=` query strings on known core-authored `wp-includes`/`wp-admin` asset URLs. The detected version and the method that found it are reported as `version` and `versionSource` on each target.
 
 ```bash
 webscan enumerate cms wordpress plugins --targets https://example.com

--- a/docs/docs/enumerate.md
+++ b/docs/docs/enumerate.md
@@ -99,6 +99,9 @@ Global Flags:
 Enumerate content management systems.
 
 #### WordPress Plugins
+
+In addition to enumerating installed plugins, this command detects the WordPress core version running on the target, trying (in order of reliability) `/readme.html`, the HTML `<meta name="generator">` tag, and `?ver=` query strings on core `wp-includes`/`wp-admin` asset URLs. The detected version and the method that found it are reported as `version` and `versionSource` on each target.
+
 ```bash
 webscan enumerate cms wordpress plugins --targets https://example.com
 ```
@@ -111,19 +114,24 @@ Usage:
   webscan enumerate cms wordpress plugins [flags]
 
 Flags:
-  -h, --help                        help for plugins
-      --plugins strings             Specific WordPress plugins to check for
-      --plugins-file-paths strings  Paths to files containing WordPress plugin lists
-      --plugins-file-size string    Size of the WordPress plugin list to use (default "SMALL")
-      --targets strings             URL targets to perform WordPress plugin enumeration against
-      --threads int                 Number of concurrent threads for scanning (default 50)
-      --timeout int                 Timeout per request in seconds (default 30)
-      --verify-tls                  Verify TLS certificates when making HTTPS requests
+  -h, --help                         help for plugins
+      --jitter int                   Jitter percentage (0-100) to apply random variance to sleep delay
+      --plugins strings              Specific WordPress plugins to check for
+      --plugins-file-paths strings   Paths to files containing WordPress plugin lists
+      --plugins-file-size string     Size of the WordPress plugin list to use (default "SMALL")
+      --sleep int                    Number of seconds to sleep between requests
+      --targets strings              URL targets to perform WordPress plugin enumeration against
+      --threads int                  Number of concurrent threads for scanning (default 50)
+      --timeout int                  Timeout per request in seconds (default 30)
+      --user-agent string            User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE) (default "RANDOM")
+      --verify-tls                   Verify TLS certificates when making HTTPS requests
 
 Global Flags:
+      --http-proxy string    HTTP/HTTPS proxy URL (e.g., http://proxy.example.com:8080)
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
   -f, --output-file string   Path to output file. If blank, will output to STDOUT
   -q, --quiet                Suppress output
+      --socks-proxy string   SOCKS proxy URL (e.g., socks5://proxy.example.com:1080)
   -v, --verbose              Verbose output
 ```
 

--- a/fern/definition/enumerate/cms/wordpress/plugins.yml
+++ b/fern/definition/enumerate/cms/wordpress/plugins.yml
@@ -23,7 +23,6 @@ types:
             - CSS_REFERENCE
             - HTML
             - META_GENERATOR
-            - README_HTML
             - README_TXT
             - REGISTERED_SCRIPT
             - REST_API_DIRECT

--- a/fern/definition/enumerate/cms/wordpress/plugins.yml
+++ b/fern/definition/enumerate/cms/wordpress/plugins.yml
@@ -22,6 +22,8 @@ types:
         enum:
             - CSS_REFERENCE
             - HTML
+            - META_GENERATOR
+            - README_HTML
             - README_TXT
             - REGISTERED_SCRIPT
             - REST_API_DIRECT
@@ -41,6 +43,8 @@ types:
     WordpressPluginsTarget:
         properties:
             target: string
+            version: optional<string>
+            versionSource: optional<DetectionSource>
             plugins: optional<list<WordpressPluginDetails>>
     EnumerateWordpressPluginsResult:
         properties:

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -621,17 +621,32 @@ func checkMetaGeneratorVersion(responseBody string) *string {
 	return nil
 }
 
-// checkCoreAssetVersion extracts the WordPress core version from ?ver= query strings on
-// wp-includes/wp-admin core asset URLs (e.g. wp-emoji-release.min.js?ver=6.4.3).
-func checkCoreAssetVersion(responseBody string) *string {
-	assetRegex := regexp.MustCompile(`/(?:wp-includes|wp-admin)/[^'"]+\?ver=([0-9]+(?:\.[0-9]+)+)`)
-	match := assetRegex.FindStringSubmatch(responseBody)
+// coreOnlyAssetFiles are asset paths shipped and versioned by WordPress core itself, as opposed
+// to third-party libraries bundled under wp-includes/wp-admin (e.g. jQuery, Moment, React) that
+// publish their own independent version in the same ?ver= query string convention. Matching only
+// these avoids reporting a bundled library's version as the WordPress core version.
+var coreOnlyAssetFiles = []string{
+	"wp-includes/js/wp-emoji-release.min.js",
+	"wp-includes/js/wp-embed.min.js",
+	"wp-includes/css/dist/block-library/style.min.css",
+	"wp-admin/css/common.min.css",
+	"wp-admin/load-styles.php",
+	"wp-admin/load-scripts.php",
+}
 
-	// Regex Info:
-	// match[0] = full match
-	// match[1] = version
-	if len(match) > 1 {
-		return &match[1]
+// checkCoreAssetVersion extracts the WordPress core version from the ?ver= query string on a
+// known core-authored asset URL (e.g. wp-emoji-release.min.js?ver=6.4.3).
+func checkCoreAssetVersion(responseBody string) *string {
+	for _, asset := range coreOnlyAssetFiles {
+		assetRegex := regexp.MustCompile(regexp.QuoteMeta(asset) + `\?ver=([0-9]+(?:\.[0-9]+)+)`)
+		match := assetRegex.FindStringSubmatch(responseBody)
+
+		// Regex Info:
+		// match[0] = full match
+		// match[1] = version
+		if len(match) > 1 {
+			return &match[1]
+		}
 	}
 
 	return nil

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -589,12 +589,14 @@ var coreOnlyAssetFiles = []string{
 }
 
 // checkCoreAssetVersion extracts the WordPress core version from the ver query param on a known
-// core-authored asset URL (e.g. wp-emoji-release.min.js?ver=6.4.3). The ver param isn't always
-// the first query param (e.g. wp-admin/load-scripts.php?c=1&load%5B%5D=jquery&ver=6.4.3), and
-// HTML-escaped markup renders the separator as &amp; rather than &, so both are accepted.
+// core-authored asset URL (e.g. wp-emoji-release.min.js?ver=6.4.3). Real WordPress markup escapes
+// these URLs in ways this must tolerate: forward slashes are JSON-escaped as \/ inside inline
+// scripts like _wpemojiSettings, esc_url() renders the query separator as &#038; (or &amp;)
+// rather than a literal &, and the ver param isn't always the first query param.
 func checkCoreAssetVersion(responseBody string) *string {
 	for _, asset := range coreOnlyAssetFiles {
-		assetRegex := regexp.MustCompile(regexp.QuoteMeta(asset) + `[^'"]*?[?&](?:amp;)?ver=([0-9]+(?:\.[0-9]+)+)`)
+		pathPattern := strings.ReplaceAll(regexp.QuoteMeta(asset), "/", `\\?/`)
+		assetRegex := regexp.MustCompile(pathPattern + `[^'"]*?(?:\?|&(?:amp;|#0*38;)?)ver=([0-9]+(?:\.[0-9]+)+)`)
 		match := assetRegex.FindStringSubmatch(responseBody)
 
 		// Regex Info:

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -165,12 +165,11 @@ func scanTarget(ctx context.Context, url string, config *enumeratecmswordpressfe
 	}
 
 	// Core version detection
-	version, versionSource, errs := detectWordPressVersion(ctx, url, config, responseBody)
-	if len(errs) > 0 {
-		errors = append(errors, errs...)
+	if responseBody != nil {
+		version, versionSource := detectWordPressVersion(*responseBody)
+		result.Version = version
+		result.VersionSource = versionSource
 	}
-	result.Version = version
-	result.VersionSource = versionSource
 
 	// Combine results with proper deduplication
 	pluginsMap := make(map[string]*enumeratecmswordpressfern.WordpressPluginDetails)
@@ -541,69 +540,24 @@ func checkCSSReferences(baseResponseBody *string) []*enumeratecmswordpressfern.W
 	return plugins
 }
 
-// detectWordPressVersion attempts to identify the WordPress core version running on the target.
-// It tries detection methods in order of reliability: readme.html, the HTML meta generator tag,
-// and the ?ver= query string on core wp-includes/wp-admin asset URLs.
-func detectWordPressVersion(ctx context.Context, url string, config *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig, responseBody *string) (*string, *enumeratecmswordpressfern.DetectionSource, []string) {
-	version, errors := checkReadmeHTMLVersion(ctx, url, config)
-	if version != nil {
-		source := enumeratecmswordpressfern.DetectionSourceReadmeHtml
-		return version, &source, errors
+// detectWordPressVersion attempts to identify the WordPress core version running on the target
+// from its homepage response body. It tries detection methods in order of reliability: the HTML
+// meta generator tag, then the ?ver= query string on core wp-includes/wp-admin asset URLs.
+// readme.html is deliberately not used as a source: WordPress core does not publish its own
+// release version there, only PHP/MySQL/GPL version numbers that are unrelated to the running
+// core version and would otherwise be misreported as such.
+func detectWordPressVersion(responseBody string) (*string, *enumeratecmswordpressfern.DetectionSource) {
+	if version := checkMetaGeneratorVersion(responseBody); version != nil {
+		source := enumeratecmswordpressfern.DetectionSourceMetaGenerator
+		return version, &source
 	}
 
-	if responseBody != nil {
-		if version := checkMetaGeneratorVersion(*responseBody); version != nil {
-			source := enumeratecmswordpressfern.DetectionSourceMetaGenerator
-			return version, &source, errors
-		}
-
-		if version := checkCoreAssetVersion(*responseBody); version != nil {
-			source := enumeratecmswordpressfern.DetectionSourceHtml
-			return version, &source, errors
-		}
+	if version := checkCoreAssetVersion(responseBody); version != nil {
+		source := enumeratecmswordpressfern.DetectionSourceHtml
+		return version, &source
 	}
 
-	return nil, nil, errors
-}
-
-// checkReadmeHTMLVersion fetches /readme.html and extracts the WordPress core version, if present.
-func checkReadmeHTMLVersion(ctx context.Context, url string, config *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig) (*string, []string) {
-	errors := []string{}
-
-	baseURL, path, _, err := requesthelpers.SplitTargetURL(url)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return nil, errors
-	}
-
-	readmePath := fmt.Sprintf("%s/readme.html", path)
-	requestConfig := createSendHTTPRequestConfig(baseURL, readmePath, config)
-	readmeRequest, err := request.SendRequest(ctx, requestConfig)
-	if err != nil {
-		errors = append(errors, err.Error())
-		return nil, errors
-	}
-
-	if readmeRequest.Response == nil || readmeRequest.Response.StatusCode == nil || *readmeRequest.Response.StatusCode != 200 {
-		return nil, errors
-	}
-
-	readmeBody := requesthelpers.GetResponseBodyStringFromBodyStruct(readmeRequest.Response.ResponseBody)
-	if readmeBody == nil {
-		return nil, errors
-	}
-
-	versionRegex := regexp.MustCompile(`(?i)version\s+([0-9]+(?:\.[0-9]+)+)`)
-	versionMatch := versionRegex.FindStringSubmatch(*readmeBody)
-
-	// Regex Info:
-	// versionMatch[0] = full match
-	// versionMatch[1] = version
-	if len(versionMatch) > 1 {
-		return &versionMatch[1], errors
-	}
-
-	return nil, errors
+	return nil, nil
 }
 
 // checkMetaGeneratorVersion extracts the WordPress core version from the HTML meta generator tag.
@@ -634,11 +588,13 @@ var coreOnlyAssetFiles = []string{
 	"wp-admin/load-scripts.php",
 }
 
-// checkCoreAssetVersion extracts the WordPress core version from the ?ver= query string on a
-// known core-authored asset URL (e.g. wp-emoji-release.min.js?ver=6.4.3).
+// checkCoreAssetVersion extracts the WordPress core version from the ver query param on a known
+// core-authored asset URL (e.g. wp-emoji-release.min.js?ver=6.4.3). The ver param isn't always
+// the first query param (e.g. wp-admin/load-scripts.php?c=1&load%5B%5D=jquery&ver=6.4.3), and
+// HTML-escaped markup renders the separator as &amp; rather than &, so both are accepted.
 func checkCoreAssetVersion(responseBody string) *string {
 	for _, asset := range coreOnlyAssetFiles {
-		assetRegex := regexp.MustCompile(regexp.QuoteMeta(asset) + `\?ver=([0-9]+(?:\.[0-9]+)+)`)
+		assetRegex := regexp.MustCompile(regexp.QuoteMeta(asset) + `[^'"]*?[?&](?:amp;)?ver=([0-9]+(?:\.[0-9]+)+)`)
 		match := assetRegex.FindStringSubmatch(responseBody)
 
 		// Regex Info:

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -164,6 +164,14 @@ func scanTarget(ctx context.Context, url string, config *enumeratecmswordpressfe
 		errors = append(errors, fmt.Sprintf("no response body found for url: %s", url))
 	}
 
+	// Core version detection
+	version, versionSource, errs := detectWordPressVersion(ctx, url, config, responseBody)
+	if len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	result.Version = version
+	result.VersionSource = versionSource
+
 	// Combine results with proper deduplication
 	pluginsMap := make(map[string]*enumeratecmswordpressfern.WordpressPluginDetails)
 
@@ -531,4 +539,100 @@ func checkCSSReferences(baseResponseBody *string) []*enumeratecmswordpressfern.W
 	}
 
 	return plugins
+}
+
+// detectWordPressVersion attempts to identify the WordPress core version running on the target.
+// It tries detection methods in order of reliability: readme.html, the HTML meta generator tag,
+// and the ?ver= query string on core wp-includes/wp-admin asset URLs.
+func detectWordPressVersion(ctx context.Context, url string, config *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig, responseBody *string) (*string, *enumeratecmswordpressfern.DetectionSource, []string) {
+	version, errors := checkReadmeHTMLVersion(ctx, url, config)
+	if version != nil {
+		source := enumeratecmswordpressfern.DetectionSourceReadmeHtml
+		return version, &source, errors
+	}
+
+	if responseBody != nil {
+		if version := checkMetaGeneratorVersion(*responseBody); version != nil {
+			source := enumeratecmswordpressfern.DetectionSourceMetaGenerator
+			return version, &source, errors
+		}
+
+		if version := checkCoreAssetVersion(*responseBody); version != nil {
+			source := enumeratecmswordpressfern.DetectionSourceHtml
+			return version, &source, errors
+		}
+	}
+
+	return nil, nil, errors
+}
+
+// checkReadmeHTMLVersion fetches /readme.html and extracts the WordPress core version, if present.
+func checkReadmeHTMLVersion(ctx context.Context, url string, config *enumeratecmswordpressfern.EnumerateWordpressPluginsConfig) (*string, []string) {
+	errors := []string{}
+
+	baseURL, path, _, err := requesthelpers.SplitTargetURL(url)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return nil, errors
+	}
+
+	readmePath := fmt.Sprintf("%s/readme.html", path)
+	requestConfig := createSendHTTPRequestConfig(baseURL, readmePath, config)
+	readmeRequest, err := request.SendRequest(ctx, requestConfig)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return nil, errors
+	}
+
+	if readmeRequest.Response == nil || readmeRequest.Response.StatusCode == nil || *readmeRequest.Response.StatusCode != 200 {
+		return nil, errors
+	}
+
+	readmeBody := requesthelpers.GetResponseBodyStringFromBodyStruct(readmeRequest.Response.ResponseBody)
+	if readmeBody == nil {
+		return nil, errors
+	}
+
+	versionRegex := regexp.MustCompile(`(?i)version\s+([0-9]+(?:\.[0-9]+)+)`)
+	versionMatch := versionRegex.FindStringSubmatch(*readmeBody)
+
+	// Regex Info:
+	// versionMatch[0] = full match
+	// versionMatch[1] = version
+	if len(versionMatch) > 1 {
+		return &versionMatch[1], errors
+	}
+
+	return nil, errors
+}
+
+// checkMetaGeneratorVersion extracts the WordPress core version from the HTML meta generator tag.
+func checkMetaGeneratorVersion(responseBody string) *string {
+	generatorRegex := regexp.MustCompile(`(?i)<meta\s+name=["']generator["']\s+content=["']WordPress\s+([0-9]+(?:\.[0-9]+)+)`)
+	match := generatorRegex.FindStringSubmatch(responseBody)
+
+	// Regex Info:
+	// match[0] = full match
+	// match[1] = version
+	if len(match) > 1 {
+		return &match[1]
+	}
+
+	return nil
+}
+
+// checkCoreAssetVersion extracts the WordPress core version from ?ver= query strings on
+// wp-includes/wp-admin core asset URLs (e.g. wp-emoji-release.min.js?ver=6.4.3).
+func checkCoreAssetVersion(responseBody string) *string {
+	assetRegex := regexp.MustCompile(`/(?:wp-includes|wp-admin)/[^'"]+\?ver=([0-9]+(?:\.[0-9]+)+)`)
+	match := assetRegex.FindStringSubmatch(responseBody)
+
+	// Regex Info:
+	// match[0] = full match
+	// match[1] = version
+	if len(match) > 1 {
+		return &match[1]
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive parsing on an existing homepage response; no changes to auth, storage, or request behavior beyond populating new optional report fields.
> 
> **Overview**
> **WordPress plugin enumeration** now also reports **WordPress core version** per target, alongside the existing plugin list.
> 
> After the homepage fetch used for HTML/plugin heuristics, the scanner runs `detectWordPressVersion`: first the `<meta name="generator">` tag (`versionSource`: `META_GENERATOR`), then `?ver=` on a fixed list of **core-only** `wp-includes` / `wp-admin` asset URLs (`versionSource`: `HTML`), with regex handling escaped slashes and `&#038;`/`&amp;` query separators. `readme.html` is intentionally excluded to avoid false versions.
> 
> The Fern report shape gains optional `version` and `versionSource` on each `WordpressPluginsTarget`, plus the new `META_GENERATOR` detection source enum value. Docs describe the behavior and refresh the plugins command help flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0060e8c786f0bab6d79ff9eea16f05e45cdea760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->