### PR TITLE
Fix Final URL Internal Redirect Bug

### DIFF
--- a/fern/definition/common/http.yml
+++ b/fern/definition/common/http.yml
@@ -79,7 +79,6 @@ types:
   HttpResponse:
     properties:
       redirectChain: optional<list<string>>
-      finalUrl: optional<string>
       statusCode: optional<integer>
       responseHeaders: optional<map<string, list<string>>>
       responseBody: optional<Body>

--- a/internal/discover/page/page.go
+++ b/internal/discover/page/page.go
@@ -116,8 +116,8 @@ func PerformPageCapture(
 		// Use the final navigated URL plus rendered HTML to resolve a favicon URL.
 		if response.Response != nil {
 			var finalURLStr string
-			if response.Response.FinalUrl != nil && *response.Response.FinalUrl != "" {
-				finalURLStr = *response.Response.FinalUrl
+			if len(response.Response.RedirectChain) > 0 {
+				finalURLStr = response.Response.RedirectChain[len(response.Response.RedirectChain)-1]
 			} else {
 				finalURLStr = config.Target
 			}

--- a/internal/discover/witness/witness.go
+++ b/internal/discover/witness/witness.go
@@ -284,9 +284,9 @@ func processTarget(
 		tlsTarget := target
 		if pageReport.Result != nil && pageReport.Result.Request != nil &&
 			pageReport.Result.Request.Response != nil &&
-			pageReport.Result.Request.Response.FinalUrl != nil &&
-			*pageReport.Result.Request.Response.FinalUrl != "" {
-			tlsTarget = *pageReport.Result.Request.Response.FinalUrl
+			len(pageReport.Result.Request.Response.RedirectChain) > 0 {
+			redirectChain := pageReport.Result.Request.Response.RedirectChain
+			tlsTarget = redirectChain[len(redirectChain)-1]
 		}
 		tlsCerts := extractTLSFromTarget(ctx, tlsTarget, config)
 		if len(tlsCerts) > 0 {

--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -15,7 +15,6 @@ import (
 	standardhelpers "github.com/Method-Security/webscan/utils/request/standard/helpers"
 
 	// Utils
-	utils "github.com/Method-Security/webscan/utils"
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	useragent "github.com/Method-Security/webscan/utils/useragent"
 
@@ -416,8 +415,15 @@ func (b *Requester) sendRequestWithArtifactsOnce(ctx context.Context, config com
 			}
 		}
 
-		// Redirect Chain
-		if finalURL != "" && !utils.IsStaticAsset(finalURL) {
+		// Redirect Chain: fold the post-render location (window.location.href)
+		// into the chain as the terminal entry. handleNavigation only records
+		// HTTP 3xx redirects, so this is what captures client-side/JS/meta-refresh
+		// redirects — i.e. where the browser actually ended up, including when it
+		// lands on a static asset (e.g. a redirect to a PDF) or bounces back to an
+		// earlier URL (A->B->A). Guard against internal browser URLs (about:blank,
+		// chrome-error://, ...) so they never become the terminal entry consumers
+		// read as the final URL.
+		if finalURL != "" && !isInternalBrowserURL(finalURL) {
 			redirectChainMu.Lock()
 			added, redirectErr := appendRedirectURLLocked(&redirectChain, finalURL, config.MaxRedirects)
 			if redirectErr != nil {
@@ -442,7 +448,6 @@ func (b *Requester) sendRequestWithArtifactsOnce(ctx context.Context, config com
 		log.Info("Final URL", svc1log.SafeParam("url", finalURL))
 
 		// Capture htmlTitle for outer scope (returned to caller via PageMetadata).
-		// finalURL is plumbed onto response.FinalUrl below; no outer-scope copy needed.
 		capturedHtmlTitle = htmlTitle
 
 		// Check if Chrome error page using batch result
@@ -517,13 +522,6 @@ func (b *Requester) sendRequestWithArtifactsOnce(ctx context.Context, config com
 			responseHeaders,
 			responseBody,
 		)
-
-		// Surface the final navigated URL on HttpResponse so downstream consumers
-		// don't have to reconstruct it from redirectChain[-1]. gowitness parity.
-		if finalURL != "" {
-			finalURLCopy := finalURL
-			response.FinalUrl = &finalURLCopy
-		}
 
 		// Attach captured console logs and page cookies when requested.
 		if console != nil {

--- a/utils/request/headless/helpers.go
+++ b/utils/request/headless/helpers.go
@@ -322,13 +322,18 @@ func signalRedirectError(err error, redirectError chan error, requestComplete ch
 	})
 }
 
+// appendRedirectURLLocked records redirectURL as the new terminal entry of the
+// chain. It intentionally does NOT dedup against the whole chain: a bounce flow
+// (A->B->A) must end at A even though A already appears earlier, otherwise
+// redirectChain[-1] would report B while the browser is at A and downstream
+// consumers (favicon, TLS extraction, cross-domain checks) would use the wrong
+// host.
 func appendRedirectURLLocked(redirectChain *[]string, redirectURL string, maxRedirects int) (bool, error) {
-	if chainContainsURL(*redirectChain, redirectURL) {
-		return false, nil
-	}
-
 	if len(*redirectChain) > 0 {
 		lastURL := (*redirectChain)[len(*redirectChain)-1]
+		if lastURL == redirectURL {
+			return false, nil
+		}
 		if utils.IsTrailingSlashRedirect(lastURL, redirectURL) {
 			(*redirectChain)[len(*redirectChain)-1] = redirectURL
 			return false, nil
@@ -372,35 +377,6 @@ func firstRedirectURL(redirectChain *[]string, redirectChainMu *sync.Mutex) stri
 		return ""
 	}
 	return (*redirectChain)[0]
-}
-
-func chainContainsURL(chain []string, candidate string) bool {
-	normalizedCandidate := normalizeDefaultPort(candidate)
-	for _, existing := range chain {
-		if normalizeDefaultPort(existing) == normalizedCandidate {
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeDefaultPort(raw string) string {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return raw
-	}
-	if port := parsed.Port(); port != "" && isDefaultPort(strings.ToLower(parsed.Scheme), port) {
-		hostname := parsed.Hostname()
-		if strings.Contains(hostname, ":") {
-			hostname = "[" + hostname + "]"
-		}
-		parsed.Host = hostname
-	}
-	return parsed.String()
-}
-
-func isDefaultPort(scheme, port string) bool {
-	return (scheme == "http" && port == "80") || (scheme == "https" && port == "443")
 }
 
 func headlessCaptureAttempts(method common.HttpMethod) int {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how final URLs are computed for headless scans and removes a response field, which can affect downstream consumers and TLS/favicon behavior on redirect-heavy targets.
> 
> **Overview**
> Removes **`HttpResponse.finalUrl`** from the API and treats **`redirectChain[-1]`** as the post-navigation URL everywhere (discover page favicon resolution, witness TLS extraction).
> 
> Headless capture now **appends `window.location.href`** to the redirect chain after DOM stabilization so client-side/JS/meta redirects and landings on static assets are reflected in the chain, while **blocking internal browser URLs** (`about:blank`, `chrome-error://`, etc.) from becoming the terminal entry. The old behavior skipped appending the final URL when it looked like a static asset.
> 
> **Redirect chain bookkeeping** no longer deduplicates URLs anywhere in the chain (so **A→B→A** ends at A); it only skips when the new URL equals the current last hop, with trailing-slash normalization unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a934912c53a69efbf88f582fa2dc4d3a5de24d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->