### PR TITLE
Fix Cross Domain Bug

### DIFF
--- a/utils/request/headless/headless.go
+++ b/utils/request/headless/headless.go
@@ -575,7 +575,7 @@ func (b *Requester) sendRequestWithArtifactsOnce(ctx context.Context, config com
 	redirectChainMu.Lock()
 	finalRedirectChain := append([]string(nil), redirectChain...)
 	redirectChainMu.Unlock()
-	if finalErr == nil && config.IgnoreCrossDomainRedirects && len(finalRedirectChain) > 1 {
+	if config.IgnoreCrossDomainRedirects && len(finalRedirectChain) > 1 {
 		originalURL := finalRedirectChain[0]
 		finalURL := finalRedirectChain[len(finalRedirectChain)-1]
 		if isCrossDomainRedirect(originalURL, finalURL) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-condition change in redirect policy ordering; behavior is stricter when both navigation errors and cross-domain redirects occur.
> 
> **Overview**
> When **`IgnoreCrossDomainRedirects`** is enabled, headless capture now **always** evaluates the redirect chain for cross-domain hops after navigation finishes, instead of skipping that check whenever a navigation error was already recorded.
> 
> Previously the guard required **`finalErr == nil`**, so a failed navigation could return a generic headless error and **never** surface **`cross-domain redirect blocked`**, even when the chain clearly left the original host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf828cf8fc4f0702ae92459a66579a14f72f4b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->