### PR TITLE
Add Ignore Redirect Logic to all Tools and Remove Hardcoded Redirect …

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -99,6 +99,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
 			if err != nil {
@@ -127,7 +132,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, webServerIpAddress, webServerPort, webServerApplicationProtocol)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, ignoreCrossDomainRedirects, webServerIpAddress, webServerPort, webServerApplicationProtocol)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -254,6 +259,16 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, err := cmd.Flags().GetInt("max-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			maxRedirectsBaselineRequest, err := cmd.Flags().GetInt("max-redirects-baseline-request")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -292,12 +307,6 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(fmt.Errorf("jitter must be between 0 and 100"))
 				return
 			}
-			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
 			// Get User Agent flag
 			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
 			if err != nil {
@@ -306,7 +315,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set config
-			config := getDiscoverDirectoryConfig(targets, paths, wordlistType, wordlistSize, httpMethods, responseCodes, enableCommonResponseFilters, verifyTLS, threshold, timeout, ignoreCrossDomainRedirects, maxRedirectsBaselineRequest, threads, maxRuntime, retries, sleep, jitter, userAgentPreset)
+			config := getDiscoverDirectoryConfig(targets, paths, wordlistType, wordlistSize, httpMethods, responseCodes, enableCommonResponseFilters, verifyTLS, threshold, timeout, ignoreCrossDomainRedirects, maxRedirects, maxRedirectsBaselineRequest, threads, maxRuntime, retries, sleep, jitter, userAgentPreset)
 
 			// Generate a report
 			rep, err := discoverdirectory.RunDirectoryDiscovery(cmd.Context(), config)
@@ -330,6 +339,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverDirectoryCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverDirectoryCmd.Flags().Float64("threshold", 0.25, "Threshold for successful results")
 	discoverDirectoryCmd.Flags().Int("timeout", 20, "Timeout per request in seconds")
+	discoverDirectoryCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
 	discoverDirectoryCmd.Flags().Int("max-redirects-baseline-request", 10, "Maximum number of redirects to follow for the baseline request")
 	discoverDirectoryCmd.Flags().Int("max-runtime", 650, "Maximum time to run the engagement in seconds")
 	discoverDirectoryCmd.Flags().Int("threads", 25, "Number of threads to use")
@@ -374,18 +384,17 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
 			timeout, err := cmd.Flags().GetInt("timeout")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -640,6 +649,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -650,12 +664,6 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
 			// Get User Agent flag
 			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
 			if err != nil {
@@ -745,6 +753,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -772,11 +785,6 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 			if jitter < 0 || jitter > 100 {
 				a.OutputSignal.AddError(fmt.Errorf("jitter must be between 0 and 100"))
-				return
-			}
-			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
-			if err != nil {
-				a.OutputSignal.AddError(err)
 				return
 			}
 
@@ -1137,6 +1145,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -1198,7 +1211,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Get the config
-			config := getDiscoverSaasConfig(orgs, saasCompanies, ssoCompanies, maxRedirects, verifyTLS, timeout, sleep, jitter, threads, userAgentPreset, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
+			config := getDiscoverSaasConfig(orgs, saasCompanies, ssoCompanies, maxRedirects, ignoreCrossDomainRedirects, verifyTLS, timeout, sleep, jitter, threads, userAgentPreset, requestMethodEnum, requestMethodConfig.HeadlessConfig, requestMethodConfig.BrowserbaseConfig)
 
 			// Generate the report
 			report, err := discoversaas.LaunchDiscoverSaas(cmd.Context(), config, *filteredSaasFingerprints, *filteredSsoFingerprints, requestMethodConfig.BrowserbaseSecrets)
@@ -1283,6 +1296,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, err := cmd.Flags().GetInt("max-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			verifyTLS, err := cmd.Flags().GetBool("verify-tls")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -1325,7 +1343,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set Config
-			config := getDiscoverWordlistConfig(target, minWordLength, spiderDepth, includeMetadata, includeComments, includeAltText, ignoreCrossDomain, verifyTLS, timeout, threads, sleep, jitter, userAgentPreset)
+			config := getDiscoverWordlistConfig(target, minWordLength, spiderDepth, includeMetadata, includeComments, includeAltText, ignoreCrossDomain, maxRedirects, verifyTLS, timeout, threads, sleep, jitter, userAgentPreset)
 
 			// Generate a report
 			report := discoverwordlist.PerformWordlistCapture(cmd.Context(), config)
@@ -1341,6 +1359,7 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverWordlistCmd.Flags().Bool("include-comments", false, "Include words from HTML comments")
 	discoverWordlistCmd.Flags().Bool("include-alt-text", false, "Include words from image alt attributes")
 	discoverWordlistCmd.Flags().Bool("ignore-cross-domain", true, "Ignore links that lead to a different domain")
+	discoverWordlistCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
 	discoverWordlistCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverWordlistCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverWordlistCmd.Flags().Int("threads", 5, "Number of concurrent threads for crawling")
@@ -1541,7 +1560,7 @@ func parseDiscoverRequestFiles(pairs []string) ([]*discover.RequestFile, error) 
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, webServerIPAddress string, webServerPort int, webServerApplicationProtocol string) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, ignoreCrossDomainRedirects bool, webServerIPAddress string, webServerPort int, webServerApplicationProtocol string) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -1555,16 +1574,17 @@ func getDiscoverApplicationConfig(targets []string, resource string, templatePat
 	}
 
 	config := &discover.DiscoverApplicationConfig{
-		Targets:         targets,
-		ResourceType:    &resourceEnum,
-		TemplatePaths:   templatePaths,
-		Timeout:         timeout,
-		Threads:         threads,
-		Proxy:           &proxy,
-		VerboseLogs:     verboseLogs,
-		GlobalRateLimit: max(0, globalRateLimit),
-		GlobalTimeout:   max(0, globalTimeout),
-		UserAgent:       userAgent,
+		Targets:                    targets,
+		ResourceType:               &resourceEnum,
+		TemplatePaths:              templatePaths,
+		Timeout:                    timeout,
+		Threads:                    threads,
+		Proxy:                      &proxy,
+		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
+		UserAgent:                  userAgent,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	if webServerIPAddress != "" {
 		config.WebServerIpAddress = &webServerIPAddress
@@ -1699,27 +1719,28 @@ func getDiscoverRouteConfig(target string, ignoreCrossDomainRoutes bool, ignoreC
 }
 
 // getDiscoverSaasConfig builds the config for SaaS active discovery.
-func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies []string, maxRedirects int, verifyTLS bool, timeout int, sleep int, jitter int, threads int, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverSaasConfig {
+func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies []string, maxRedirects int, ignoreCrossDomainRedirects bool, verifyTLS bool, timeout int, sleep int, jitter int, threads int, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig) discover.DiscoverSaasConfig {
 	config := discover.DiscoverSaasConfig{
-		Orgs:              orgs,
-		SaasCompanies:     saasCompanies,
-		SsoCompanies:      ssoCompanies,
-		MaxRedirects:      maxRedirects,
-		VerifyTls:         verifyTLS,
-		Timeout:           max(timeout, 0),
-		Sleep:             max(sleep, 0),
-		Jitter:            max(jitter, 0),
-		Threads:           max(threads, 0),
-		UserAgent:         userAgent,
-		RequestMethod:     requestMethod,
-		HeadlessConfig:    headlessConfig,
-		BrowserbaseConfig: browserbaseConfig,
+		Orgs:                       orgs,
+		SaasCompanies:              saasCompanies,
+		SsoCompanies:               ssoCompanies,
+		MaxRedirects:               maxRedirects,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		Sleep:                      max(sleep, 0),
+		Jitter:                     max(jitter, 0),
+		Threads:                    max(threads, 0),
+		UserAgent:                  userAgent,
+		RequestMethod:              requestMethod,
+		HeadlessConfig:             headlessConfig,
+		BrowserbaseConfig:          browserbaseConfig,
 	}
 	return config
 }
 
 // getDiscoverDirectoryConfig builds the config for directory discovery.
-func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType string, wordlistSize string, httpMethods []common.HttpMethod, responseCodes string, enableCommonResponseFilters bool, verifyTLS bool, threshold float64, timeout int, ignoreCrossDomainRedirects bool, maxRedirectsBaselineRequest int, threads int, maxRuntime int, retries int, sleep int, jitter int, userAgent common.UserAgentPreset) discover.DiscoverDirectoryConfig {
+func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType string, wordlistSize string, httpMethods []common.HttpMethod, responseCodes string, enableCommonResponseFilters bool, verifyTLS bool, threshold float64, timeout int, ignoreCrossDomainRedirects bool, maxRedirects int, maxRedirectsBaselineRequest int, threads int, maxRuntime int, retries int, sleep int, jitter int, userAgent common.UserAgentPreset) discover.DiscoverDirectoryConfig {
 	config := discover.DiscoverDirectoryConfig{
 		Targets:                     targets,
 		Paths:                       paths,
@@ -1730,6 +1751,7 @@ func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType s
 		Threshold:                   threshold,
 		Timeout:                     timeout,
 		IgnoreCrossDomainRedirects:  ignoreCrossDomainRedirects,
+		MaxRedirects:                maxRedirects,
 		MaxRedirectsBaselineRequest: maxRedirectsBaselineRequest,
 		Threads:                     threads,
 		MaxRuntime:                  maxRuntime,
@@ -1763,7 +1785,7 @@ func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType s
 }
 
 // getDiscoverWordlistConfig builds the config for wordlist generation.
-func getDiscoverWordlistConfig(target string, minWordLength int, spiderDepth int, includeMetadata bool, includeComments bool, includeAltText bool, ignoreCrossDomain bool, verifyTLS bool, timeout int, threads int, sleep int, jitter int, userAgent common.UserAgentPreset) discover.DiscoverWordlistConfig {
+func getDiscoverWordlistConfig(target string, minWordLength int, spiderDepth int, includeMetadata bool, includeComments bool, includeAltText bool, ignoreCrossDomain bool, maxRedirects int, verifyTLS bool, timeout int, threads int, sleep int, jitter int, userAgent common.UserAgentPreset) discover.DiscoverWordlistConfig {
 	return discover.DiscoverWordlistConfig{
 		Target:            target,
 		MinWordLength:     max(minWordLength, 1),
@@ -1772,6 +1794,7 @@ func getDiscoverWordlistConfig(target string, minWordLength int, spiderDepth int
 		IncludeComments:   includeComments,
 		IncludeAltText:    includeAltText,
 		IgnoreCrossDomain: ignoreCrossDomain,
+		MaxRedirects:      maxRedirects,
 		VerifyTls:         verifyTLS,
 		Timeout:           max(timeout, 0),
 		Threads:           max(threads, 0),

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -118,13 +118,20 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			config := enumerateapiapplicationfern.EnumerateGraphqlConfig{
-				Target:    target,
-				Headers:   headers,
-				Cookies:   cookies,
-				Timeout:   &timeout,
-				VerifyTls: verifyTLS,
+				Target:                     target,
+				Headers:                    headers,
+				Cookies:                    cookies,
+				Timeout:                    &timeout,
+				VerifyTls:                  verifyTLS,
+				MaxRedirects:               maxRedirects,
+				IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 			}
 			if query != "" {
 				config.Query = &query
@@ -152,6 +159,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateAPIApplicationGraphqlCmd.Flags().String("variables", "", "JSON-encoded variables for the ad-hoc --query")
 	enumerateAPIApplicationGraphqlCmd.Flags().Bool("allow-mutations", false, "Permit mutation and subscription operations (default rejects them at the AST level)")
 	enumerateAPIApplicationGraphqlCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
+	enumerateAPIApplicationGraphqlCmd.Flags().Int("max-redirects", 10, "Maximum number of redirects to follow")
+	enumerateAPIApplicationGraphqlCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 
 	// Mark required flags
 	_ = enumerateAPIApplicationGraphqlCmd.MarkFlagRequired("target")
@@ -238,15 +247,22 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			config := enumerateapiapplicationfern.EnumerateSwaggerConfig{
-				Target:         target,
-				Timeout:        timeout,
-				UserAgent:      userAgentPreset,
-				Headers:        headers,
-				Cookies:        cookies,
-				CandidatePaths: candidatePaths,
-				VerifyTls:      verifyTLS,
+				Target:                     target,
+				Timeout:                    timeout,
+				UserAgent:                  userAgentPreset,
+				Headers:                    headers,
+				Cookies:                    cookies,
+				CandidatePaths:             candidatePaths,
+				VerifyTls:                  verifyTLS,
+				MaxRedirects:               maxRedirects,
+				IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 			}
 			if specUrl != "" {
 				config.SpecUrl = &specUrl
@@ -267,6 +283,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateAPIApplicationSwaggerCmd.Flags().StringSlice("candidate-paths", []string{}, "Additional spec paths to probe before built-in paths (comma-separated)")
 	enumerateAPIApplicationSwaggerCmd.Flags().String("spec-url", "", "Direct URL to OpenAPI/Swagger spec; skips all probing when set")
 	enumerateAPIApplicationSwaggerCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
+	enumerateAPIApplicationSwaggerCmd.Flags().Int("max-redirects", 1, "Maximum number of redirects to follow")
+	enumerateAPIApplicationSwaggerCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	// User Agent Flag
 	enumerateAPIApplicationSwaggerCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
@@ -304,6 +322,11 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			sleep, err := cmd.Flags().GetInt("sleep")
 			if err != nil {
@@ -332,7 +355,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Set Config
-			config := getEnumerateKubeConfig(target, verifyTLS, timeout, sleep, jitter, userAgentPreset)
+			config := getEnumerateKubeConfig(target, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, sleep, jitter, userAgentPreset)
 
 			// Generate report
 			report := enumeratekube.PerformAppEnumerateKube(cmd.Context(), &config)
@@ -344,6 +367,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateKubeCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateKubeCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	enumerateKubeCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	enumerateKubeCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	enumerateKubeCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	enumerateKubeCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to apply random variance to sleep delay")
 	// User Agent Flag
@@ -443,6 +468,11 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			threads, err := cmd.Flags().GetInt("threads")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -476,7 +506,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateWordpressPluginsConfig(targets, plugins, PluginsFileSizeEnum, verifyTLS, timeout, sleep, jitter, threads, userAgentPreset)
+			config := getEnumerateWordpressPluginsConfig(targets, plugins, PluginsFileSizeEnum, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, sleep, jitter, threads, userAgentPreset)
 
 			// Generate report
 			report := enumeratecms.PerformAppEnumerateCMSWordpressPlugins(cmd.Context(), config)
@@ -491,6 +521,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateCMSWordpressPluginsCmd.Flags().String("plugins-file-size", "SMALL", "Size of the WordPress plugin list to use")
 	enumerateCMSWordpressPluginsCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	enumerateCMSWordpressPluginsCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	enumerateCMSWordpressPluginsCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to apply random variance to sleep delay")
 	enumerateCMSWordpressPluginsCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
@@ -586,6 +618,11 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			threads, err := cmd.Flags().GetInt("threads")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -619,7 +656,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateDrupalModulesConfig(targets, modules, modulesFileSizeEnum, verifyTLS, timeout, sleep, jitter, threads, userAgentPreset)
+			config := getEnumerateDrupalModulesConfig(targets, modules, modulesFileSizeEnum, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, sleep, jitter, threads, userAgentPreset)
 
 			// Generate report
 			report := enumeratecms.PerformAppEnumerateCMSDrupalModules(cmd.Context(), config)
@@ -634,6 +671,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateCMSDrupalModulesCmd.Flags().String("modules-file-size", string(enumeratecmsdrupalfern.ModulesFileSizeSmall), "Size of the Drupal module list to use")
 	enumerateCMSDrupalModulesCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateCMSDrupalModulesCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	enumerateCMSDrupalModulesCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	enumerateCMSDrupalModulesCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	enumerateCMSDrupalModulesCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	enumerateCMSDrupalModulesCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to apply random variance to sleep delay")
 	enumerateCMSDrupalModulesCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
@@ -696,6 +735,11 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			threads, err := cmd.Flags().GetInt("threads")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -724,7 +768,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, sleep, jitter, verifyTLS, timeout, threads, userAgentPreset)
+			config := getEnumerateGeneralRateLimitConfig(targets, maxRequests, sleep, jitter, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, threads, userAgentPreset)
 
 			// Generate report
 			report := enumerategeneral.PerformGeneralRatelimit(cmd.Context(), &config)
@@ -739,6 +783,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	enumerateGeneralRatelimitCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to apply random variance to sleep delay")
 	enumerateGeneralRatelimitCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateGeneralRatelimitCmd.Flags().Int("timeout", 5, "Timeout per request in seconds")
+	enumerateGeneralRatelimitCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	enumerateGeneralRatelimitCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	enumerateGeneralRatelimitCmd.Flags().Int("threads", 100, "Number of concurrent threads for scanning")
 	// User Agent Flag
 	enumerateGeneralRatelimitCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
@@ -786,6 +832,11 @@ func (a *WebScan) InitEnumerateCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getEnumerateRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			threads, err := cmd.Flags().GetInt("threads")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -819,7 +870,7 @@ func (a *WebScan) InitEnumerateCommand() {
 			}
 
 			// Generate config
-			config := getEnumerateDockerConfig(targets, verifyTLS, timeout, sleep, jitter, threads, userAgentPreset)
+			config := getEnumerateDockerConfig(targets, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, sleep, jitter, threads, userAgentPreset)
 
 			// Generate report
 			report := enumeratedocker.PerformAppEnumerateContainerRegistryDocker(cmd.Context(), &config)
@@ -831,6 +882,8 @@ func (a *WebScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateContainerRegistryDockerCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	enumerateContainerRegistryDockerCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	enumerateContainerRegistryDockerCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	enumerateContainerRegistryDockerCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	enumerateContainerRegistryDockerCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	enumerateContainerRegistryDockerCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to apply random variance to sleep delay")
 	enumerateContainerRegistryDockerCmd.Flags().Int("threads", 50, "Number of concurrent manifest requests per repository")
@@ -851,75 +904,97 @@ func (a *WebScan) InitEnumerateCommand() {
 }
 
 // getEnumerateWordpressPluginsConfig builds the config for WordPress plugin enumeration.
-func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, PluginsFileSizeEnum enumeratecmswordpressfern.PluginsFileSize, verifyTLS bool, timeout int, sleep int, jitter int, threads int, userAgent common.UserAgentPreset) enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
+func getEnumerateRedirectFlags(cmd *cobra.Command) (int, bool, error) {
+	maxRedirects, err := cmd.Flags().GetInt("max-redirects")
+	if err != nil {
+		return 0, false, err
+	}
+	ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+	if err != nil {
+		return 0, false, err
+	}
+	return maxRedirects, ignoreCrossDomainRedirects, nil
+}
+
+func getEnumerateWordpressPluginsConfig(targets []string, plugins []string, PluginsFileSizeEnum enumeratecmswordpressfern.PluginsFileSize, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, sleep int, jitter int, threads int, userAgent common.UserAgentPreset) enumeratecmswordpressfern.EnumerateWordpressPluginsConfig {
 	config := enumeratecmswordpressfern.EnumerateWordpressPluginsConfig{
-		Targets:         targets,
-		Plugins:         plugins,
-		PluginsFileSize: &PluginsFileSizeEnum,
-		VerifyTls:       verifyTLS,
-		Timeout:         max(timeout, 0),
-		Sleep:           max(sleep, 0),
-		Jitter:          max(jitter, 0),
-		Threads:         max(threads, 0),
-		UserAgent:       userAgent,
+		Targets:                    targets,
+		Plugins:                    plugins,
+		PluginsFileSize:            &PluginsFileSizeEnum,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Sleep:                      max(sleep, 0),
+		Jitter:                     max(jitter, 0),
+		Threads:                    max(threads, 0),
+		UserAgent:                  userAgent,
 	}
 	return config
 }
 
 // getEnumerateKubeConfig builds the config for Kubernetes enumeration.
-func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int, sleep int, jitter int, userAgent common.UserAgentPreset) enumeratekubefern.EnumerateKubeConfig {
+func getEnumerateKubeConfig(target string, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, sleep int, jitter int, userAgent common.UserAgentPreset) enumeratekubefern.EnumerateKubeConfig {
 	config := enumeratekubefern.EnumerateKubeConfig{
-		Target:    target,
-		VerifyTls: verifyTLS,
-		Timeout:   max(timeout, 0),
-		Sleep:     max(sleep, 0),
-		Jitter:    max(jitter, 0),
-		UserAgent: userAgent,
+		Target:                     target,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Sleep:                      max(sleep, 0),
+		Jitter:                     max(jitter, 0),
+		UserAgent:                  userAgent,
 	}
 	return config
 }
 
 // getEnumerateGeneralRateLimitConfig builds the config for general rate limit enumeration.
-func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, sleep int, jitter int, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) enumerategeneralfern.EnumerateRateLimitConfig {
+func getEnumerateGeneralRateLimitConfig(targets []string, maxRequests int, sleep int, jitter int, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, threads int, userAgent common.UserAgentPreset) enumerategeneralfern.EnumerateRateLimitConfig {
 	config := enumerategeneralfern.EnumerateRateLimitConfig{
-		Targets:     targets,
-		MaxRequests: maxRequests,
-		Sleep:       max(sleep, 0),
-		Jitter:      max(jitter, 0),
-		VerifyTls:   verifyTLS,
-		Timeout:     max(timeout, 0),
-		Threads:     max(threads, 0),
-		UserAgent:   userAgent,
+		Targets:                    targets,
+		MaxRequests:                maxRequests,
+		Sleep:                      max(sleep, 0),
+		Jitter:                     max(jitter, 0),
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Threads:                    max(threads, 0),
+		UserAgent:                  userAgent,
 	}
 	return config
 }
 
 // getEnumerateDockerConfig builds the config for Docker registry enumeration.
-func getEnumerateDockerConfig(targets []string, verifyTLS bool, timeout int, sleep int, jitter int, threads int, userAgent common.UserAgentPreset) enumeratedockerfern.EnumerateDockerConfig {
+func getEnumerateDockerConfig(targets []string, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, sleep int, jitter int, threads int, userAgent common.UserAgentPreset) enumeratedockerfern.EnumerateDockerConfig {
 	config := enumeratedockerfern.EnumerateDockerConfig{
-		Targets:   targets,
-		VerifyTls: verifyTLS,
-		Timeout:   max(timeout, 0),
-		Sleep:     max(sleep, 0),
-		Jitter:    max(jitter, 0),
-		Threads:   max(threads, 1),
-		UserAgent: userAgent,
+		Targets:                    targets,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Sleep:                      max(sleep, 0),
+		Jitter:                     max(jitter, 0),
+		Threads:                    max(threads, 1),
+		UserAgent:                  userAgent,
 	}
 	return config
 }
 
 // getEnumerateDrupalModulesConfig builds the config for Drupal module enumeration.
-func getEnumerateDrupalModulesConfig(targets []string, modules []string, modulesFileSizeEnum enumeratecmsdrupalfern.ModulesFileSize, verifyTLS bool, timeout int, sleep int, jitter int, threads int, userAgent common.UserAgentPreset) enumeratecmsdrupalfern.EnumerateDrupalModulesConfig {
+func getEnumerateDrupalModulesConfig(targets []string, modules []string, modulesFileSizeEnum enumeratecmsdrupalfern.ModulesFileSize, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, sleep int, jitter int, threads int, userAgent common.UserAgentPreset) enumeratecmsdrupalfern.EnumerateDrupalModulesConfig {
 	config := enumeratecmsdrupalfern.EnumerateDrupalModulesConfig{
-		Targets:         targets,
-		Modules:         modules,
-		ModulesFileSize: &modulesFileSizeEnum,
-		VerifyTls:       verifyTLS,
-		Timeout:         max(timeout, 0),
-		Sleep:           max(sleep, 0),
-		Jitter:          max(jitter, 0),
-		Threads:         max(threads, 0),
-		UserAgent:       userAgent,
+		Targets:                    targets,
+		Modules:                    modules,
+		ModulesFileSize:            &modulesFileSizeEnum,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    max(timeout, 0),
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Sleep:                      max(sleep, 0),
+		Jitter:                     max(jitter, 0),
+		Threads:                    max(threads, 0),
+		UserAgent:                  userAgent,
 	}
 	return config
 }

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -142,6 +142,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
 			if err != nil {
@@ -160,7 +165,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, workflowPaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
+			config := getPentestApplicationDastConfig(targets, dastCategories, httpMethods, dastRequestParams, templatePaths, workflowPaths, timeout, threads, &proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, ignoreCrossDomainRedirects)
 
 			// Generate a report
 			rep, err := pentestapplication.RunPentestApplicationDast(cmd.Context(), config)
@@ -186,6 +191,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationDastCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationDastCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
 	pentestApplicationDastCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestApplicationDastCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, exclude results that redirect to a different domain")
 	pentestApplicationDastCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
@@ -265,6 +271,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			userAgentPreset, err := requesthelpers.GetUserAgentFlag(cmd)
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -272,7 +283,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestApplicationCveConfig(targets, years, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
+			config := getPentestApplicationCveConfig(targets, years, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, ignoreCrossDomainRedirects)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationCveScan(cmd.Context(), config)
@@ -294,6 +305,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationCveCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationCveCmd.Flags().Int("global-rate-limit", 10, "Global rate limit in requests per second")
 	pentestApplicationCveCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestApplicationCveCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, exclude results that redirect to a different domain")
 	pentestApplicationCveCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
@@ -364,6 +376,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
 			if err != nil {
@@ -377,7 +394,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
+			config := getPentestApplicationMisconfigurationConfig(targets, misconfigurationCategoriesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, ignoreCrossDomainRedirects)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationMisconfigurationScan(cmd.Context(), config)
@@ -400,6 +417,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationMisconfigurationCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationMisconfigurationCmd.Flags().Int("global-rate-limit", 25, "Global rate limit in requests per second")
 	pentestApplicationMisconfigurationCmd.Flags().Int("global-timeout", 650, "Maximum total scan time in seconds")
+	pentestApplicationMisconfigurationCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, exclude results that redirect to a different domain")
 	pentestApplicationMisconfigurationCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
@@ -469,6 +487,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
 			if err != nil {
@@ -482,7 +505,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset)
+			config := getPentestApplicationTechnologyConfig(targets, technologyTypesEnumList, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, ignoreCrossDomainRedirects)
 
 			// Generate a report
 			rep, err := pentestapplicationscan.RunPentestApplicationTechnologyScan(cmd.Context(), config)
@@ -505,6 +528,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestApplicationTechnologyCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestApplicationTechnologyCmd.Flags().Int("global-rate-limit", 0, "Global rate limit in requests per second")
 	pentestApplicationTechnologyCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestApplicationTechnologyCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, exclude results that redirect to a different domain")
 	pentestApplicationTechnologyCmd.Flags().String("user-agent", "RANDOM", "User-Agent preset (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
 
 	// Mark Required Flags
@@ -563,6 +587,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getPentestRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			retries, err := cmd.Flags().GetInt("retries")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -606,7 +635,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Load configuration
-			config := getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets, successfulOnly, verifyTLS, timeout, retries, sleep, jitter, userAgent, functionName, xmlRpcArgs)
+			config := getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets, successfulOnly, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, retries, sleep, jitter, userAgent, functionName, xmlRpcArgs)
 
 			// Generate report
 			report := pentestcmswordpress.PerformWordpressXMLRPCFunctionsExposed(cmd.Context(), config)
@@ -622,6 +651,8 @@ func (a *WebScan) InitPentestCommand() {
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	pentestCmsWordpressXmlrpcFunctionsExposedCmd.Flags().Int("jitter", 0, "Jitter percentage (0-100) to apply random variance to sleep delay")
@@ -683,6 +714,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getPentestRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			retries, err := cmd.Flags().GetInt("retries")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -700,7 +736,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Load configuration
-			config := getPentestCmsWordpressXmlrpcBruteforceConfig(targets, usernames, passwords, useMulticall, successfulOnly, verifyTLS, timeout, retries, sleep, userAgent)
+			config := getPentestCmsWordpressXmlrpcBruteforceConfig(targets, usernames, passwords, useMulticall, successfulOnly, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, retries, sleep, userAgent)
 
 			// Generate report
 			report := pentestcmswordpress.PerformWordpressXMLRPCBruteforce(cmd.Context(), config)
@@ -720,6 +756,8 @@ func (a *WebScan) InitPentestCommand() {
 	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
 	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	pentestCmsWordpressXmlrpcBruteforceCmd.Flags().String("user-agent", "RANDOM", "User agent preset to use (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
@@ -780,6 +818,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getPentestRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			retries, err := cmd.Flags().GetInt("retries")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -797,7 +840,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Load configuration
-			config := getPentestCmsWordpressWpLoginBruteforceConfig(targets, usernames, passwords, loginPath, successfulOnly, verifyTLS, timeout, retries, sleep, userAgent)
+			config := getPentestCmsWordpressWpLoginBruteforceConfig(targets, usernames, passwords, loginPath, successfulOnly, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, retries, sleep, userAgent)
 
 			// Generate report
 			report := pentestcmswordpress.PerformWordpressWpLoginBruteforce(cmd.Context(), config)
@@ -817,6 +860,8 @@ func (a *WebScan) InitPentestCommand() {
 	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
 	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	pentestCmsWordpressWpLoginBruteforceCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
 	pentestCmsWordpressWpLoginBruteforceCmd.Flags().String("user-agent", "RANDOM", "User agent preset to use (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
@@ -927,6 +972,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			maxRedirects, ignoreCrossDomainRedirects, err := getPentestRedirectFlags(cmd)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			retries, err := cmd.Flags().GetInt("retries")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -959,7 +1009,7 @@ func (a *WebScan) InitPentestCommand() {
 			config := getPentestCmsWordpressPluginDeployConfig(
 				targets, usernames, passwords, execCommand, loginPath, uploadMethod, pluginSlug,
 				cleanup, verifyCallback, callbackURL, callbackToken, callbackTimeout,
-				stopOnFirstSuccess, successfulOnly, verifyTLS, timeout, retries, sleep, userAgent,
+				stopOnFirstSuccess, successfulOnly, verifyTLS, timeout, maxRedirects, ignoreCrossDomainRedirects, retries, sleep, userAgent,
 			)
 
 			// Generate report
@@ -990,6 +1040,8 @@ func (a *WebScan) InitPentestCommand() {
 	pentestCmsWordpressPluginDeployCmd.Flags().Bool("successful-only", false, "Only include successful results in the report")
 	pentestCmsWordpressPluginDeployCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	pentestCmsWordpressPluginDeployCmd.Flags().Int("timeout", 30, "Timeout per HTTP request in seconds")
+	pentestCmsWordpressPluginDeployCmd.Flags().Int("max-redirects", 0, "Maximum number of redirects to follow")
+	pentestCmsWordpressPluginDeployCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, do not follow redirects to a different domain and treat them as errors")
 	pentestCmsWordpressPluginDeployCmd.Flags().Int("retries", 0, "Number of times to retry a failing request")
 	pentestCmsWordpressPluginDeployCmd.Flags().Int("sleep", 0, "Seconds to sleep between credential attempts")
 	pentestCmsWordpressPluginDeployCmd.Flags().String("user-agent", "RANDOM", "User agent preset to use (RANDOM, CHROME, FIREFOX, SAFARI, EDGE)")
@@ -1209,6 +1261,11 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
 			if err != nil {
@@ -1217,7 +1274,7 @@ func (a *WebScan) InitPentestCommand() {
 			}
 
 			// Set config
-			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout)
+			config := getPentestWafDetectConfig(targets, routeRequestParams, httpMethods, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, ignoreCrossDomainRedirects)
 
 			// Generate a report
 			rep, err := pentestwafdetect.RunPentestWafDetect(cmd.Context(), config)
@@ -1241,6 +1298,7 @@ func (a *WebScan) InitPentestCommand() {
 	pentestWafDetectCmd.Flags().Bool("verbose-logs", false, "Verbose logs")
 	pentestWafDetectCmd.Flags().Int("global-rate-limit", 0, "Global rate limit in requests per second")
 	pentestWafDetectCmd.Flags().Int("global-timeout", 0, "Maximum total scan time in seconds")
+	pentestWafDetectCmd.Flags().Bool("ignore-cross-domain-redirects", true, "If true, exclude results that redirect to a different domain")
 
 	// Mark Required Flags
 	_ = pentestWafDetectCmd.MarkFlagRequired("targets")
@@ -1260,44 +1318,58 @@ func (a *WebScan) InitPentestCommand() {
 }
 
 // getPentestApplicationDastConfig builds the config for dast pentest.
-func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, workflowPaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationfern.PentestApplicationDastConfig {
+func getPentestRedirectFlags(cmd *cobra.Command) (int, bool, error) {
+	maxRedirects, err := cmd.Flags().GetInt("max-redirects")
+	if err != nil {
+		return 0, false, err
+	}
+	ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+	if err != nil {
+		return 0, false, err
+	}
+	return maxRedirects, ignoreCrossDomainRedirects, nil
+}
+
+func getPentestApplicationDastConfig(targets []string, dastCategories []pentestapplicationfern.PentestApplicationDastCategory, httpMethods []common.HttpMethod, dastRequestParams []*nuclei.RequestParameter, templatePaths []string, workflowPaths []string, timeout int, threads int, proxy *string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, ignoreCrossDomainRedirects bool) pentestapplicationfern.PentestApplicationDastConfig {
 	config := pentestapplicationfern.PentestApplicationDastConfig{
-		Targets:           targets,
-		DastCategories:    dastCategories,
-		DastRequestParams: dastRequestParams,
-		HttpMethods:       httpMethods,
-		TemplatePaths:     templatePaths,
-		WorkflowPaths:     workflowPaths,
-		Timeout:           timeout,
-		Threads:           threads,
-		Proxy:             proxy,
-		VerboseLogs:       verboseLogs,
-		GlobalRateLimit:   max(0, globalRateLimit),
-		GlobalTimeout:     max(0, globalTimeout),
-		UserAgent:         userAgent,
+		Targets:                    targets,
+		DastCategories:             dastCategories,
+		DastRequestParams:          dastRequestParams,
+		HttpMethods:                httpMethods,
+		TemplatePaths:              templatePaths,
+		WorkflowPaths:              workflowPaths,
+		Timeout:                    timeout,
+		Threads:                    threads,
+		Proxy:                      proxy,
+		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
+		UserAgent:                  userAgent,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	return config
 }
 
 // getPentestApplicationCveConfig builds the config for scan pentest.
-func getPentestApplicationCveConfig(targets []string, years []string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationscanfern.PentestApplicationCveConfig {
+func getPentestApplicationCveConfig(targets []string, years []string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, ignoreCrossDomainRedirects bool) pentestapplicationscanfern.PentestApplicationCveConfig {
 	config := pentestapplicationscanfern.PentestApplicationCveConfig{
-		Targets:         targets,
-		Years:           years,
-		TemplatePaths:   templatePaths,
-		Timeout:         timeout,
-		Threads:         threads,
-		Proxy:           &proxy,
-		VerboseLogs:     verboseLogs,
-		GlobalRateLimit: max(0, globalRateLimit),
-		GlobalTimeout:   max(0, globalTimeout),
-		UserAgent:       userAgent,
+		Targets:                    targets,
+		Years:                      years,
+		TemplatePaths:              templatePaths,
+		Timeout:                    timeout,
+		Threads:                    threads,
+		Proxy:                      &proxy,
+		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
+		UserAgent:                  userAgent,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	return config
 }
 
 // getPentestApplicationMisconfigurationConfig builds the config for scan pentest.
-func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
+func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurationCategories []pentestapplicationscanfern.MisconfigurationCategory, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, ignoreCrossDomainRedirects bool) pentestapplicationscanfern.PentestApplicationMisconfigurationConfig {
 	config := pentestapplicationscanfern.PentestApplicationMisconfigurationConfig{
 		Targets:                    targets,
 		MisconfigurationCategories: misconfigurationCategories,
@@ -1309,38 +1381,42 @@ func getPentestApplicationMisconfigurationConfig(targets []string, misconfigurat
 		GlobalRateLimit:            max(0, globalRateLimit),
 		GlobalTimeout:              max(0, globalTimeout),
 		UserAgent:                  userAgent,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	return config
 }
 
 // getPentestApplicationTechnologiesConfig builds the config for scan pentest.
-func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
+func getPentestApplicationTechnologyConfig(targets []string, technologyTypes []pentestapplicationscanfern.TechnologyType, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, ignoreCrossDomainRedirects bool) pentestapplicationscanfern.PentestApplicationTechnologyConfig {
 	config := pentestapplicationscanfern.PentestApplicationTechnologyConfig{
-		Targets:         targets,
-		TechnologyTypes: technologyTypes,
-		TemplatePaths:   templatePaths,
-		Timeout:         timeout,
-		Threads:         threads,
-		Proxy:           &proxy,
-		VerboseLogs:     verboseLogs,
-		GlobalRateLimit: max(0, globalRateLimit),
-		GlobalTimeout:   max(0, globalTimeout),
-		UserAgent:       userAgent,
+		Targets:                    targets,
+		TechnologyTypes:            technologyTypes,
+		TemplatePaths:              templatePaths,
+		Timeout:                    timeout,
+		Threads:                    threads,
+		Proxy:                      &proxy,
+		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
+		UserAgent:                  userAgent,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	return config
 }
 
 // getPentestCmsWordpressXmlrpcFunctionsExposedConfig builds the config for wordpress xmlrpc function auth pentest.
-func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int, jitter int, userAgent common.UserAgentPreset, functionName string, xmlRpcArgs []string) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig {
+func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, successfulOnly bool, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, retries int, sleep int, jitter int, userAgent common.UserAgentPreset, functionName string, xmlRpcArgs []string) pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig {
 	config := pentestcmswordpressfern.PentestCmsWordpressXmlrpcFunctionsExposedConfig{
-		Targets:        targets,
-		SuccessfulOnly: successfulOnly,
-		VerifyTls:      verifyTLS,
-		Timeout:        timeout,
-		Retries:        retries,
-		Sleep:          sleep,
-		Jitter:         jitter,
-		UserAgent:      userAgent,
+		Targets:                    targets,
+		SuccessfulOnly:             successfulOnly,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    timeout,
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Retries:                    retries,
+		Sleep:                      sleep,
+		Jitter:                     jitter,
+		UserAgent:                  userAgent,
 	}
 	if functionName != "" {
 		config.FunctionName = &functionName
@@ -1352,35 +1428,39 @@ func getPentestCmsWordpressXmlrpcFunctionsExposedConfig(targets []string, succes
 }
 
 // getPentestCmsWordpressXmlrpcBruteforceConfig builds the config for wordpress xmlrpc brute-force pentest.
-func getPentestCmsWordpressXmlrpcBruteforceConfig(targets []string, usernames []string, passwords []string, useMulticall bool, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int, userAgent common.UserAgentPreset) pentestcmswordpressfern.PentestCmsWordpressXmlrpcBruteforceConfig {
+func getPentestCmsWordpressXmlrpcBruteforceConfig(targets []string, usernames []string, passwords []string, useMulticall bool, successfulOnly bool, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, retries int, sleep int, userAgent common.UserAgentPreset) pentestcmswordpressfern.PentestCmsWordpressXmlrpcBruteforceConfig {
 	config := pentestcmswordpressfern.PentestCmsWordpressXmlrpcBruteforceConfig{
-		Targets:        targets,
-		Usernames:      usernames,
-		Passwords:      passwords,
-		UseMulticall:   useMulticall,
-		SuccessfulOnly: successfulOnly,
-		VerifyTls:      verifyTLS,
-		Timeout:        timeout,
-		Retries:        retries,
-		Sleep:          sleep,
-		UserAgent:      userAgent,
+		Targets:                    targets,
+		Usernames:                  usernames,
+		Passwords:                  passwords,
+		UseMulticall:               useMulticall,
+		SuccessfulOnly:             successfulOnly,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    timeout,
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Retries:                    retries,
+		Sleep:                      sleep,
+		UserAgent:                  userAgent,
 	}
 	return config
 }
 
 // getPentestCmsWordpressWpLoginBruteforceConfig builds the config for wordpress wp-login brute-force pentest.
-func getPentestCmsWordpressWpLoginBruteforceConfig(targets []string, usernames []string, passwords []string, loginPath string, successfulOnly bool, verifyTLS bool, timeout int, retries int, sleep int, userAgent common.UserAgentPreset) pentestcmswordpressfern.PentestCmsWordpressWpLoginBruteforceConfig {
+func getPentestCmsWordpressWpLoginBruteforceConfig(targets []string, usernames []string, passwords []string, loginPath string, successfulOnly bool, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, retries int, sleep int, userAgent common.UserAgentPreset) pentestcmswordpressfern.PentestCmsWordpressWpLoginBruteforceConfig {
 	config := pentestcmswordpressfern.PentestCmsWordpressWpLoginBruteforceConfig{
-		Targets:        targets,
-		Usernames:      usernames,
-		Passwords:      passwords,
-		LoginPath:      &loginPath,
-		SuccessfulOnly: successfulOnly,
-		VerifyTls:      verifyTLS,
-		Timeout:        timeout,
-		Retries:        retries,
-		Sleep:          sleep,
-		UserAgent:      userAgent,
+		Targets:                    targets,
+		Usernames:                  usernames,
+		Passwords:                  passwords,
+		LoginPath:                  &loginPath,
+		SuccessfulOnly:             successfulOnly,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    timeout,
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Retries:                    retries,
+		Sleep:                      sleep,
+		UserAgent:                  userAgent,
 	}
 	return config
 }
@@ -1403,27 +1483,31 @@ func getPentestCmsWordpressPluginDeployConfig(
 	successfulOnly bool,
 	verifyTLS bool,
 	timeout int,
+	maxRedirects int,
+	ignoreCrossDomainRedirects bool,
 	retries int,
 	sleep int,
 	userAgent common.UserAgentPreset,
 ) pentestcmswordpressfern.PentestCmsWordpressPluginDeployConfig {
 	config := pentestcmswordpressfern.PentestCmsWordpressPluginDeployConfig{
-		Targets:            targets,
-		Usernames:          usernames,
-		Passwords:          passwords,
-		ExecCommand:        execCommand,
-		LoginPath:          &loginPath,
-		UploadMethod:       &uploadMethod,
-		Cleanup:            cleanup,
-		VerifyCallback:     verifyCallback,
-		CallbackTimeout:    callbackTimeout,
-		StopOnFirstSuccess: stopOnFirstSuccess,
-		SuccessfulOnly:     successfulOnly,
-		VerifyTls:          verifyTLS,
-		Timeout:            timeout,
-		Retries:            retries,
-		Sleep:              sleep,
-		UserAgent:          userAgent,
+		Targets:                    targets,
+		Usernames:                  usernames,
+		Passwords:                  passwords,
+		ExecCommand:                execCommand,
+		LoginPath:                  &loginPath,
+		UploadMethod:               &uploadMethod,
+		Cleanup:                    cleanup,
+		VerifyCallback:             verifyCallback,
+		CallbackTimeout:            callbackTimeout,
+		StopOnFirstSuccess:         stopOnFirstSuccess,
+		SuccessfulOnly:             successfulOnly,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    timeout,
+		MaxRedirects:               max(maxRedirects, 0),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		Retries:                    retries,
+		Sleep:                      sleep,
+		UserAgent:                  userAgent,
 	}
 	if pluginSlug != "" {
 		config.PluginSlug = &pluginSlug
@@ -1469,18 +1553,19 @@ func getPentestRouteStaticAssetTakeoverConfig(target string, fingerprintFilePath
 }
 
 // getPentestWafDetectConfig builds the config for waf detect pentest.
-func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int) waf.PentestWafDetectConfig {
+func getPentestWafDetectConfig(targets []string, routeRequestParams []*nuclei.RequestParameter, httpMethods []common.HttpMethod, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, ignoreCrossDomainRedirects bool) waf.PentestWafDetectConfig {
 	config := waf.PentestWafDetectConfig{
-		Targets:                targets,
-		RouteRequestParameters: routeRequestParams,
-		HttpMethods:            httpMethods,
-		TemplatePaths:          templatePaths,
-		Timeout:                timeout,
-		Threads:                threads,
-		Proxy:                  &proxy,
-		VerboseLogs:            verboseLogs,
-		GlobalRateLimit:        max(0, globalRateLimit),
-		GlobalTimeout:          max(0, globalTimeout),
+		Targets:                    targets,
+		RouteRequestParameters:     routeRequestParams,
+		HttpMethods:                httpMethods,
+		TemplatePaths:              templatePaths,
+		Timeout:                    timeout,
+		Threads:                    threads,
+		Proxy:                      &proxy,
+		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	return config
 }

--- a/fern/definition/common/nuclei/config.yml
+++ b/fern/definition/common/nuclei/config.yml
@@ -26,4 +26,4 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
-
+      ignoreCrossDomainRedirects: boolean

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -61,6 +61,7 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
+      ignoreCrossDomainRedirects: boolean
       webServerIpAddress: optional<string>
       webServerPort: optional<integer>
       webServerApplicationProtocol: optional<http.WebProtocol>

--- a/fern/definition/discover/directory.yml
+++ b/fern/definition/discover/directory.yml
@@ -27,6 +27,7 @@ types:
       threshold: float
       timeout: integer
       ignoreCrossDomainRedirects: boolean
+      maxRedirects: integer
       maxRedirectsBaselineRequest: integer
       maxRuntime: integer
       retries: integer

--- a/fern/definition/discover/saas.yml
+++ b/fern/definition/discover/saas.yml
@@ -22,6 +22,7 @@ types:
       saasCompanies: optional<list<string>>
       ssoCompanies: optional<list<string>>
       maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       verifyTls: boolean
       timeout: integer
       sleep: integer

--- a/fern/definition/discover/wordlist.yml
+++ b/fern/definition/discover/wordlist.yml
@@ -10,6 +10,7 @@ types:
       includeComments: boolean
       includeAltText: boolean
       ignoreCrossDomain: boolean
+      maxRedirects: integer
       verifyTls: boolean
       timeout: integer
       threads: integer

--- a/fern/definition/enumerate/apiapplication/graphql.yml
+++ b/fern/definition/enumerate/apiapplication/graphql.yml
@@ -70,6 +70,8 @@ types:
       variables: optional<string>
       allowMutations: optional<boolean>
       verifyTls: boolean
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
   EnumerateGraphqlData:
     properties:
       apiType: common.ApiType

--- a/fern/definition/enumerate/apiapplication/swagger.yml
+++ b/fern/definition/enumerate/apiapplication/swagger.yml
@@ -12,6 +12,8 @@ types:
       specUrl: optional<string>
       candidatePaths: optional<list<string>>
       verifyTls: boolean
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
   EnumerateSwaggerResult:
     properties:
       apiType: common.ApiType

--- a/fern/definition/enumerate/cms/drupal/modules.yml
+++ b/fern/definition/enumerate/cms/drupal/modules.yml
@@ -35,6 +35,8 @@ types:
             modulesFileSize: optional<ModulesFileSize>
             verifyTls: boolean
             timeout: integer
+            maxRedirects: integer
+            ignoreCrossDomainRedirects: boolean
             sleep: integer
             jitter: integer
             threads: integer

--- a/fern/definition/enumerate/cms/wordpress/plugins.yml
+++ b/fern/definition/enumerate/cms/wordpress/plugins.yml
@@ -13,6 +13,8 @@ types:
             pluginsFileSize: optional<PluginsFileSize>
             verifyTls: boolean
             timeout: integer
+            maxRedirects: integer
+            ignoreCrossDomainRedirects: boolean
             sleep: integer
             jitter: integer
             threads: integer

--- a/fern/definition/enumerate/containerregistry/docker.yml
+++ b/fern/definition/enumerate/containerregistry/docker.yml
@@ -8,6 +8,8 @@ types:
       targets: list<string>
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       sleep: integer
       jitter: integer
       threads: integer

--- a/fern/definition/enumerate/general/ratelimit.yml
+++ b/fern/definition/enumerate/general/ratelimit.yml
@@ -12,6 +12,8 @@ types:
       jitter: integer
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       threads: integer
       userAgent: method.UserAgentPreset
   # Report Struct

--- a/fern/definition/enumerate/kube/kube.yml
+++ b/fern/definition/enumerate/kube/kube.yml
@@ -8,6 +8,8 @@ types:
       target: string
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       sleep: integer
       jitter: integer
       userAgent: method.UserAgentPreset

--- a/fern/definition/pentest/application/dast.yml
+++ b/fern/definition/pentest/application/dast.yml
@@ -31,6 +31,7 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
+      ignoreCrossDomainRedirects: boolean
   PentestApplicationDastResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/cve.yml
+++ b/fern/definition/pentest/application/scan/cve.yml
@@ -15,6 +15,7 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
+      ignoreCrossDomainRedirects: boolean
   PentestApplicationCveResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/misconfiguration.yml
+++ b/fern/definition/pentest/application/scan/misconfiguration.yml
@@ -19,6 +19,7 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
+      ignoreCrossDomainRedirects: boolean
   PentestApplicationMisconfigurationResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/application/scan/technology.yml
+++ b/fern/definition/pentest/application/scan/technology.yml
@@ -21,6 +21,7 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
+      ignoreCrossDomainRedirects: boolean
   PentestApplicationTechnologyResult:
     properties:
       report: optional<list<nuclei.NucleiTargetInfo>>

--- a/fern/definition/pentest/cms/wordpress/plugindeploy.yml
+++ b/fern/definition/pentest/cms/wordpress/plugindeploy.yml
@@ -61,6 +61,8 @@ types:
       successfulOnly: boolean
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       retries: integer
       sleep: integer
       userAgent: method.UserAgentPreset

--- a/fern/definition/pentest/cms/wordpress/wploginbruteforce.yml
+++ b/fern/definition/pentest/cms/wordpress/wploginbruteforce.yml
@@ -12,6 +12,8 @@ types:
       successfulOnly: boolean
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       retries: integer
       sleep: integer
       userAgent: method.UserAgentPreset

--- a/fern/definition/pentest/cms/wordpress/xmlrpcbruteforce.yml
+++ b/fern/definition/pentest/cms/wordpress/xmlrpcbruteforce.yml
@@ -12,6 +12,8 @@ types:
       successfulOnly: boolean
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       retries: integer
       sleep: integer
       userAgent: method.UserAgentPreset

--- a/fern/definition/pentest/cms/wordpress/xmlrpcfunctionsexposed.yml
+++ b/fern/definition/pentest/cms/wordpress/xmlrpcfunctionsexposed.yml
@@ -9,6 +9,8 @@ types:
       successfulOnly: boolean
       verifyTls: boolean
       timeout: integer
+      maxRedirects: integer
+      ignoreCrossDomainRedirects: boolean
       retries: integer
       sleep: integer
       jitter: integer

--- a/fern/definition/pentest/waf/detect.yml
+++ b/fern/definition/pentest/waf/detect.yml
@@ -40,6 +40,7 @@ types:
       verboseLogs: boolean
       globalRateLimit: integer
       globalTimeout: integer
+      ignoreCrossDomainRedirects: boolean
   # Detection Results
   WafRuleCategoryEnum:
     enum:

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -98,16 +98,17 @@ func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover
 		svc1log.SafeParam("threads", config.Threads))
 
 	return nuclei.NucleiConfig{
-		Targets:         config.Targets,
-		TemplatePaths:   templatePaths,
-		RunMode:         nuclei.NucleiRunModeScan,
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
-		UserAgent:       config.UserAgent,
+		Targets:                    config.Targets,
+		TemplatePaths:              templatePaths,
+		RunMode:                    nuclei.NucleiRunModeScan,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		UserAgent:                  config.UserAgent,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}, nil
 }
 

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -223,7 +223,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 						defer func() { <-semaphore }()
 
 						// Send request
-						requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, fullPath, method, common.HttpRequestParams{}, 0, &config)
+						requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, fullPath, method, common.HttpRequestParams{}, config.MaxRedirects, &config)
 						httpRequest, err := request.SendRequest(ctx, requestConfig)
 						if err != nil {
 							// Don't add errors if context was cancelled

--- a/internal/discover/directory/helpers.go
+++ b/internal/discover/directory/helpers.go
@@ -235,7 +235,7 @@ func calibrateCommonResponses(ctx context.Context, baseURL, parsedTargetPath str
 
 	for _, method := range config.HttpMethods {
 		for _, probePath := range commonResponseCalibrationPaths(parsedTargetPath) {
-			requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, probePath, method, common.HttpRequestParams{}, 0, config)
+			requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, probePath, method, common.HttpRequestParams{}, config.MaxRedirects, config)
 			httpRequest, err := request.SendRequest(ctx, requestConfig)
 			if err != nil {
 				failureCount++

--- a/internal/discover/saas/active/active.go
+++ b/internal/discover/saas/active/active.go
@@ -38,15 +38,16 @@ func createSendHTTPRequestConfig(baseURL, path string, config discover.DiscoverS
 	}
 
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       config.MaxRedirects,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		RequestMethod:      config.RequestMethod,
-		HeadlessConfig:     config.HeadlessConfig,
-		BrowserbaseConfig:  config.BrowserbaseConfig,
-		BrowserbaseSecrets: browserbaseSecrets,
-		UserAgent:          config.UserAgent,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		RequestMethod:              config.RequestMethod,
+		HeadlessConfig:             config.HeadlessConfig,
+		BrowserbaseConfig:          config.BrowserbaseConfig,
+		BrowserbaseSecrets:         browserbaseSecrets,
+		UserAgent:                  config.UserAgent,
 	}
 }
 

--- a/internal/discover/wordlist/wordlist.go
+++ b/internal/discover/wordlist/wordlist.go
@@ -59,7 +59,7 @@ func createRequestConfig(rawURL string, config discover.DiscoverWordlistConfig) 
 	// redirect resolution, at the link-enqueueing stage via utils.IsHostInScope.
 	return common.SendHttpRequestConfig{
 		Request:                    httpReq,
-		MaxRedirects:               10,
+		MaxRedirects:               config.MaxRedirects,
 		VerifyTls:                  config.VerifyTls,
 		Timeout:                    config.Timeout,
 		IgnoreCrossDomainRedirects: false,

--- a/internal/enumerate/apiapplication/graphql.go
+++ b/internal/enumerate/apiapplication/graphql.go
@@ -15,6 +15,8 @@ import (
 
 	// Generated
 	enumerateapiapplicationfern "github.com/Method-Security/webscan/generated/go/enumerate/apiapplication"
+	// Utils
+	utils "github.com/Method-Security/webscan/utils"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -147,7 +149,7 @@ func PerformAppEnumerateGraphQL(ctx context.Context, config enumerateapiapplicat
 		return report
 	}
 
-	body, err := fetchGraphQL(ctx, config.Target, requestBody, config.Headers, config.Cookies, config.Timeout, config.VerifyTls)
+	body, err := fetchGraphQL(ctx, config.Target, requestBody, config.Headers, config.Cookies, config.Timeout, config.VerifyTls, config.MaxRedirects, config.IgnoreCrossDomainRedirects)
 	if err != nil {
 		report.Errors = append(report.Errors, err.Error())
 		return report
@@ -209,7 +211,7 @@ func buildGraphQLRequestBody(config enumerateapiapplicationfern.EnumerateGraphql
 	return json.Marshal(payload)
 }
 
-func fetchGraphQL(ctx context.Context, target string, requestBody []byte, headers map[string]string, cookies map[string]string, timeout *int, verifyTls bool) ([]byte, error) {
+func fetchGraphQL(ctx context.Context, target string, requestBody []byte, headers map[string]string, cookies map[string]string, timeout *int, verifyTls bool, maxRedirects int, ignoreCrossDomainRedirects bool) ([]byte, error) {
 	log := svc1log.FromContext(ctx)
 
 	effectiveTimeout := defaultGraphQLTimeout
@@ -234,6 +236,12 @@ func fetchGraphQL(ctx context.Context, target string, requestBody []byte, header
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !verifyTls},
 		},
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) > maxRedirects {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -245,6 +253,9 @@ func fetchGraphQL(ctx context.Context, target string, requestBody []byte, header
 			log.Error("Error closing response body", svc1log.SafeParam("error", err))
 		}
 	}()
+	if ignoreCrossDomainRedirects && !utils.IsHostInScope(target, resp.Request.URL.String()) {
+		return nil, fmt.Errorf("cross-domain redirect blocked: %s -> %s", target, resp.Request.URL.String())
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -109,7 +109,7 @@ func generateSpecPaths() []string {
 	return paths
 }
 
-func createSendHTTPRequestConfig(baseURL, path string, timeout int, verifyTls bool, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, headers map[string][]string) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, timeout int, verifyTls bool, maxRedirects int, ignoreCrossDomainRedirects bool, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, headers map[string][]string) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -117,15 +117,16 @@ func createSendHTTPRequestConfig(baseURL, path string, timeout int, verifyTls bo
 		Params:  &common.HttpRequestParams{Headers: headers},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       1,
-		VerifyTls:          verifyTls,
-		Timeout:            timeout,
-		UserAgent:          userAgent,
-		RequestMethod:      requestMethod,
-		HeadlessConfig:     headlessConfig,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               maxRedirects,
+		VerifyTls:                  verifyTls,
+		Timeout:                    timeout,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		UserAgent:                  userAgent,
+		RequestMethod:              requestMethod,
+		HeadlessConfig:             headlessConfig,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 
@@ -210,7 +211,7 @@ func isLikelySpecURL(url string) bool {
 // findOpenAPISpec attempts to locate a valid OpenAPI/Swagger specification
 // First checks if target is a Swagger UI page, then uses headless if needed,
 // otherwise falls back to trying common endpoint paths.
-func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls bool, headlessPath string, userAgent common.UserAgentPreset, headers map[string][]string, candidatePaths []string) (string, []byte, map[string]interface{}, error) {
+func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls bool, maxRedirects int, ignoreCrossDomainRedirects bool, headlessPath string, userAgent common.UserAgentPreset, headers map[string][]string, candidatePaths []string) (string, []byte, map[string]interface{}, error) {
 	baseURL, parsedTargetPath, _, err := requesthelpers.SplitTargetURL(target)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to split target URL: %w", err)
@@ -224,7 +225,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls 
 	}
 
 	// STEP 1: Make a standard request to check if target is a Swagger UI page
-	requestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, verifyTls, userAgent, common.RequestMethodStandard, nil, headers)
+	requestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, verifyTls, maxRedirects, ignoreCrossDomainRedirects, userAgent, common.RequestMethodStandard, nil, headers)
 	response, err := request.SendRequest(ctx, requestConfig)
 
 	if err == nil && response.Response != nil && response.Response.StatusCode != nil &&
@@ -240,7 +241,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls 
 					MinDomStabalizeTime: 5,
 				}
 
-				headlessRequestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, verifyTls, userAgent, common.RequestMethodHeadless, headlessConfig, headers)
+				headlessRequestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, timeout, verifyTls, maxRedirects, ignoreCrossDomainRedirects, userAgent, common.RequestMethodHeadless, headlessConfig, headers)
 				headlessResponse, err := request.SendRequest(ctx, headlessRequestConfig)
 
 				if err == nil && headlessResponse.Response != nil && headlessResponse.Response.StatusCode != nil &&
@@ -265,7 +266,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls 
 							}
 
 							// Make request to the extracted spec URL
-							specRequestConfig := createSendHTTPRequestConfig(baseURL, specPath, timeout, verifyTls, userAgent, common.RequestMethodStandard, nil, headers)
+							specRequestConfig := createSendHTTPRequestConfig(baseURL, specPath, timeout, verifyTls, maxRedirects, ignoreCrossDomainRedirects, userAgent, common.RequestMethodStandard, nil, headers)
 							specResponse, err := request.SendRequest(ctx, specRequestConfig)
 							if err != nil {
 								continue
@@ -290,7 +291,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls 
 
 						// If no extracted URLs worked, try common paths as fallback
 						for _, path := range specPaths {
-							specRequestConfig := createSendHTTPRequestConfig(baseURL, path, timeout, verifyTls, userAgent, common.RequestMethodStandard, nil, headers)
+							specRequestConfig := createSendHTTPRequestConfig(baseURL, path, timeout, verifyTls, maxRedirects, ignoreCrossDomainRedirects, userAgent, common.RequestMethodStandard, nil, headers)
 							specResponse, err := request.SendRequest(ctx, specRequestConfig)
 							if err != nil {
 								continue
@@ -326,7 +327,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls 
 		}
 
 		// Create a request config for the Swagger/OpenAPI spec and send the request
-		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), timeout, verifyTls, userAgent, common.RequestMethodStandard, nil, headers)
+		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), timeout, verifyTls, maxRedirects, ignoreCrossDomainRedirects, userAgent, common.RequestMethodStandard, nil, headers)
 		request, err := request.SendRequest(ctx, requestConfig)
 		if err != nil {
 			continue // Try next path on request failure
@@ -400,7 +401,7 @@ func PerformAppEnumerateSwagger(ctx context.Context, config enumerateapiapplicat
 			report.Errors = append(report.Errors, fmt.Sprintf("invalid specUrl: %v", err))
 			return report
 		}
-		requestConfig := createSendHTTPRequestConfig(baseURL, specPath, config.Timeout, config.VerifyTls, config.UserAgent, common.RequestMethodStandard, nil, headers)
+		requestConfig := createSendHTTPRequestConfig(baseURL, specPath, config.Timeout, config.VerifyTls, config.MaxRedirects, config.IgnoreCrossDomainRedirects, config.UserAgent, common.RequestMethodStandard, nil, headers)
 		// Preserve query parameters from specUrl (e.g., ?format=openapi) — SplitTargetURL strips them.
 		if len(queryParams) > 0 {
 			if requestConfig.Request.Params == nil {
@@ -445,7 +446,7 @@ func PerformAppEnumerateSwagger(ctx context.Context, config enumerateapiapplicat
 	}
 
 	// Try to find a valid Swagger/OpenAPI spec
-	swaggerURL, bodyBytes, docType, err := findOpenAPISpec(ctx, target, config.Timeout, config.VerifyTls, headlessPath, config.UserAgent, headers, config.CandidatePaths)
+	swaggerURL, bodyBytes, docType, err := findOpenAPISpec(ctx, target, config.Timeout, config.VerifyTls, config.MaxRedirects, config.IgnoreCrossDomainRedirects, headlessPath, config.UserAgent, headers, config.CandidatePaths)
 	if err != nil {
 		report.Errors = append(report.Errors, err.Error())
 		return report

--- a/internal/enumerate/cms/drupal.go
+++ b/internal/enumerate/cms/drupal.go
@@ -55,15 +55,16 @@ func createDrupalSendHTTPRequestConfig(baseURL, path string, method common.HttpM
 		Params:  &common.HttpRequestParams{},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -39,15 +39,16 @@ func createSendHTTPRequestConfig(baseURL, path string, config *enumeratecmswordp
 		Params:  &common.HttpRequestParams{},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/enumerate/containerregistry/docker.go
+++ b/internal/enumerate/containerregistry/docker.go
@@ -86,7 +86,7 @@ func selectPlatformDigest(manifests []interface{}) string {
 
 // fetchPlatformManifestSize resolves a manifest list entry by fetching the
 // platform-specific v2 manifest and computing total size from config + layers.
-func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platformDigest string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) *int {
+func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platformDigest string, config *enumeratedockerfern.EnumerateDockerConfig) *int {
 	log := svc1log.FromContext(ctx)
 
 	manifestURL := strings.TrimSuffix(targetURL, "/") + "/v2/" + repository + "/manifests/" + platformDigest
@@ -100,7 +100,7 @@ func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platf
 		"application/vnd.docker.distribution.manifest.v2+json",
 		"application/vnd.oci.image.manifest.v1+json",
 	}
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, acceptHeaders)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, config, acceptHeaders)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -122,7 +122,7 @@ func fetchPlatformManifestSize(ctx context.Context, targetURL, repository, platf
 	return nil
 }
 
-func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset, acceptHeaders []string) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]string, config *enumeratedockerfern.EnumerateDockerConfig, acceptHeaders []string) common.SendHttpRequestConfig {
 	// Base Headers
 	headers := map[string][]string{
 		"Accept": {"application/json"},
@@ -142,20 +142,21 @@ func createSendHTTPRequestConfig(baseURL, path string, queryParams map[string]st
 		},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       0,
-		VerifyTls:          verifyTLS,
-		Timeout:            timeout,
-		UserAgent:          userAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 
 // enumerateRepositories gets the list of repositories from the registry
-func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) ([]string, *common.HttpRequestResponse, error) {
+func enumerateRepositories(ctx context.Context, targetURL string, config *enumeratedockerfern.EnumerateDockerConfig) ([]string, *common.HttpRequestResponse, error) {
 	log := svc1log.FromContext(ctx)
 
 	catalogURL := strings.TrimSuffix(targetURL, "/") + "/v2/_catalog"
@@ -166,7 +167,7 @@ func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool
 		return nil, nil, err
 	}
 
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, nil)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, config, nil)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -197,7 +198,7 @@ func enumerateRepositories(ctx context.Context, targetURL string, verifyTLS bool
 }
 
 // getImageTags retrieves tags for a specific image repository
-func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) ([]string, []*common.HttpRequestResponse, error) {
+func getImageTags(ctx context.Context, targetURL, repository string, config *enumeratedockerfern.EnumerateDockerConfig) ([]string, []*common.HttpRequestResponse, error) {
 	log := svc1log.FromContext(ctx)
 	var requests []*common.HttpRequestResponse
 
@@ -209,7 +210,7 @@ func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS b
 		return nil, requests, err
 	}
 
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, nil)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, config, nil)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -240,7 +241,7 @@ func getImageTags(ctx context.Context, targetURL, repository string, verifyTLS b
 }
 
 // getImageManifest retrieves the manifest for a specific image:tag and returns the digest, manifest content, size, and requests.
-func getImageManifest(ctx context.Context, targetURL, repository, tag string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) (string, string, *int, []*common.HttpRequestResponse, error) {
+func getImageManifest(ctx context.Context, targetURL, repository, tag string, config *enumeratedockerfern.EnumerateDockerConfig) (string, string, *int, []*common.HttpRequestResponse, error) {
 	log := svc1log.FromContext(ctx)
 	var requests []*common.HttpRequestResponse
 
@@ -257,7 +258,7 @@ func getImageManifest(ctx context.Context, targetURL, repository, tag string, ve
 		"application/vnd.oci.image.manifest.v1+json",
 		"application/vnd.oci.image.index.v1+json",
 	}
-	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, verifyTLS, timeout, userAgent, acceptHeaders)
+	requestConfig := createSendHTTPRequestConfig(baseURL, path, queryParams, config, acceptHeaders)
 
 	httpReqResp, err := standard.SendStandardRequest(ctx, requestConfig)
 	if err != nil {
@@ -297,7 +298,7 @@ func getImageManifest(ctx context.Context, targetURL, repository, tag string, ve
 								svc1log.SafeParam("repository", repository),
 								svc1log.SafeParam("tag", tag),
 								svc1log.SafeParam("platformDigest", platformDigest))
-							totalSize = fetchPlatformManifestSize(ctx, targetURL, repository, platformDigest, verifyTLS, timeout, userAgent)
+							totalSize = fetchPlatformManifestSize(ctx, targetURL, repository, platformDigest, config)
 						}
 					}
 				}
@@ -309,13 +310,13 @@ func getImageManifest(ctx context.Context, targetURL, repository, tag string, ve
 }
 
 // processRepository handles enumeration for a single repository: fetching tags, manifests, and computing sizes.
-func processRepository(ctx context.Context, targetURL, repoName string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset, wg *sync.WaitGroup, results chan<- *enumeratedockerfern.ContainerRepository, errors chan<- string) {
+func processRepository(ctx context.Context, targetURL, repoName string, config *enumeratedockerfern.EnumerateDockerConfig, wg *sync.WaitGroup, results chan<- *enumeratedockerfern.ContainerRepository, errors chan<- string) {
 	defer wg.Done()
 	log := svc1log.FromContext(ctx)
 	log.Info("Processing repository", svc1log.SafeParam("repository", repoName))
 
 	// Step 2: Retrieve available tags
-	tags, _, err := getImageTags(ctx, targetURL, repoName, verifyTLS, timeout, userAgent)
+	tags, _, err := getImageTags(ctx, targetURL, repoName, config)
 	if err != nil {
 		errors <- fmt.Sprintf("Failed to get tags for repository %s: %v", repoName, err)
 		return
@@ -334,7 +335,7 @@ func processRepository(ctx context.Context, targetURL, repoName string, verifyTL
 
 	// Step 3: For each tag, fetch the manifest and digest
 	for _, tag := range tags {
-		digest, manifestContent, size, _, err := getImageManifest(ctx, targetURL, repoName, tag, verifyTLS, timeout, userAgent)
+		digest, manifestContent, size, _, err := getImageManifest(ctx, targetURL, repoName, tag, config)
 		if err != nil {
 			errors <- fmt.Sprintf("Failed to get manifest for %s:%s: %v", repoName, tag, err)
 			continue
@@ -387,11 +388,11 @@ func processRepository(ctx context.Context, targetURL, repoName string, verifyTL
 // Step 2: For each repository, hit /v2/{repo}/tags/list to retrieve available tags.
 // Step 3: For each tag, hit /v2/{repo}/manifests/{tag} to fetch the manifest and digest.
 // Step 4: Group images by digest so tags pointing to the same image are consolidated.
-func enumerateTarget(ctx context.Context, targetURL string, verifyTLS bool, timeout int, threads int, userAgent common.UserAgentPreset) (*enumeratedockerfern.EnumerateDockerResult, []string) {
+func enumerateTarget(ctx context.Context, targetURL string, config *enumeratedockerfern.EnumerateDockerConfig) (*enumeratedockerfern.EnumerateDockerResult, []string) {
 	log := svc1log.FromContext(ctx)
 
 	// Step 1: Hit /v2/_catalog to list all repositories
-	repositories, catalogRequest, err := enumerateRepositories(ctx, targetURL, verifyTLS, timeout, userAgent)
+	repositories, catalogRequest, err := enumerateRepositories(ctx, targetURL, config)
 	if err != nil {
 		return nil, []string{fmt.Sprintf("Failed to enumerate repositories: %v", err)}
 	}
@@ -419,7 +420,7 @@ func enumerateTarget(ctx context.Context, targetURL string, verifyTLS bool, time
 	errorsChan := make(chan string, len(repositories))
 
 	// Create semaphore to limit concurrent repository processing
-	semaphore := make(chan struct{}, threads)
+	semaphore := make(chan struct{}, config.Threads)
 
 	var wg sync.WaitGroup
 	for _, repoName := range repositories {
@@ -427,7 +428,7 @@ func enumerateTarget(ctx context.Context, targetURL string, verifyTLS bool, time
 		semaphore <- struct{}{}
 		go func(repo string) {
 			defer func() { <-semaphore }()
-			processRepository(ctx, targetURL, repo, verifyTLS, timeout, userAgent, &wg, results, errorsChan)
+			processRepository(ctx, targetURL, repo, config, &wg, results, errorsChan)
 		}(repoName)
 	}
 
@@ -478,7 +479,7 @@ func PerformAppEnumerateContainerRegistryDocker(ctx context.Context, config *enu
 	errors := []string{}
 
 	for i, targetURL := range config.Targets {
-		result, errs := enumerateTarget(ctx, targetURL, config.VerifyTls, config.Timeout, config.Threads, config.UserAgent)
+		result, errs := enumerateTarget(ctx, targetURL, config)
 		if result != nil {
 			targets = append(targets, result)
 		}

--- a/internal/enumerate/general/ratelimit.go
+++ b/internal/enumerate/general/ratelimit.go
@@ -66,15 +66,16 @@ func createRateLimitRequestConfig(baseURL, path string, queryParams map[string]s
 		},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		BrowserbaseSecrets: nil,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		BrowserbaseSecrets:         nil,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
 	}
 }
 

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -34,7 +34,7 @@ var commonKubepaths = []string{
 	"/api/v1/configmaps",
 }
 
-func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int, userAgent common.UserAgentPreset) common.SendHttpRequestConfig {
+func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout int, maxRedirects int, ignoreCrossDomainRedirects bool, userAgent common.UserAgentPreset) common.SendHttpRequestConfig {
 	request := common.HttpRequest{
 		BaseUrl: baseURL,
 		Path:    path,
@@ -42,15 +42,16 @@ func createSendHTTPRequestConfig(baseURL, path string, verifyTLS bool, timeout i
 		Params:  &common.HttpRequestParams{},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       0,
-		VerifyTls:          verifyTLS,
-		Timeout:            timeout,
-		UserAgent:          userAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               maxRedirects,
+		VerifyTls:                  verifyTLS,
+		Timeout:                    timeout,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
+		UserAgent:                  userAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 
@@ -72,7 +73,7 @@ func PerformAppEnumerateKube(ctx context.Context, config *enumeratekubefern.Enum
 	requests := []*common.HttpRequestResponse{}
 	for i, path := range commonKubepaths {
 		// Create Request Config
-		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.VerifyTls, config.Timeout, config.UserAgent)
+		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.VerifyTls, config.Timeout, config.MaxRedirects, config.IgnoreCrossDomainRedirects, config.UserAgent)
 
 		// Send Request
 		request, err := request.SendRequest(ctx, requestConfig)

--- a/internal/pentest/application/dast.go
+++ b/internal/pentest/application/dast.go
@@ -62,13 +62,14 @@ func createDastNucleiConfig(config pentestapplicationfern.PentestApplicationDast
 			HttpMethods:       config.HttpMethods,
 			RequestParameters: config.DastRequestParams,
 		},
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
-		UserAgent:       config.UserAgent,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		UserAgent:                  config.UserAgent,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}
 }
 

--- a/internal/pentest/application/scan/cve.go
+++ b/internal/pentest/application/scan/cve.go
@@ -29,16 +29,17 @@ func createCveScanNucleiConfig(config pentestapplicationscanfern.PentestApplicat
 
 	// Return the nuclei config
 	return nuclei.NucleiConfig{
-		Targets:         config.Targets,
-		RunMode:         nuclei.NucleiRunModeScan,
-		TemplatePaths:   templatePaths,
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
-		UserAgent:       config.UserAgent,
+		Targets:                    config.Targets,
+		RunMode:                    nuclei.NucleiRunModeScan,
+		TemplatePaths:              templatePaths,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		UserAgent:                  config.UserAgent,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}
 }
 

--- a/internal/pentest/application/scan/misconfiguration.go
+++ b/internal/pentest/application/scan/misconfiguration.go
@@ -32,16 +32,17 @@ func createMisconfigurationScanNucleiConfig(config pentestapplicationscanfern.Pe
 
 	// Return the nuclei config
 	return nuclei.NucleiConfig{
-		Targets:         config.Targets,
-		RunMode:         nuclei.NucleiRunModeScan,
-		TemplatePaths:   templatePaths,
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
-		UserAgent:       config.UserAgent,
+		Targets:                    config.Targets,
+		RunMode:                    nuclei.NucleiRunModeScan,
+		TemplatePaths:              templatePaths,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		UserAgent:                  config.UserAgent,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}
 }
 

--- a/internal/pentest/application/scan/technology.go
+++ b/internal/pentest/application/scan/technology.go
@@ -33,16 +33,17 @@ func createTechnologyScanNucleiConfig(config pentestapplicationscanfern.PentestA
 	}
 
 	return nuclei.NucleiConfig{
-		Targets:         config.Targets,
-		RunMode:         nuclei.NucleiRunModeScan,
-		TemplatePaths:   templatePaths,
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
-		UserAgent:       config.UserAgent,
+		Targets:                    config.Targets,
+		RunMode:                    nuclei.NucleiRunModeScan,
+		TemplatePaths:              templatePaths,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		UserAgent:                  config.UserAgent,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}
 }
 

--- a/internal/pentest/cms/wordpress/plugindeploy/plugindeploy.go
+++ b/internal/pentest/cms/wordpress/plugindeploy/plugindeploy.go
@@ -66,15 +66,16 @@ func buildGetConfig(baseURL, path string, cookieHeader string, queryParams map[s
 		Params:  params,
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &req,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &req,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 
@@ -103,15 +104,16 @@ func buildPostFormConfig(baseURL, path, cookieHeader string, formFields map[stri
 		Params:  params,
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &req,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &req,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 
@@ -179,15 +181,16 @@ func buildMultipartUploadConfig(baseURL, path, cookieHeader, nonce, fileName str
 		Params:  params,
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &req,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &req,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/pentest/cms/wordpress/wploginbruteforce.go
+++ b/internal/pentest/cms/wordpress/wploginbruteforce.go
@@ -50,15 +50,16 @@ func buildLoginHTTPGetConfig(baseURL, path string, config *pentestcmswordpressfe
 		Params:  &common.HttpRequestParams{},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &req,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &req,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 
@@ -88,15 +89,16 @@ func buildLoginHTTPPostConfig(baseURL, path, cookieHeader string, formFields map
 		Params:  params,
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &req,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &req,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/pentest/cms/wordpress/xmlrpcbruteforce.go
+++ b/internal/pentest/cms/wordpress/xmlrpcbruteforce.go
@@ -29,15 +29,16 @@ func createBruteforceHTTPRequestConfig(baseURL, path string, body string, config
 		Params:  &common.HttpRequestParams{Body: bodyStruct},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &req,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &req,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -32,15 +32,16 @@ func createSendHTTPRequestConfig(baseURL, path string, body string, config *pent
 		Params:  &common.HttpRequestParams{Body: bodyStruct},
 	}
 	return common.SendHttpRequestConfig{
-		Request:            &request,
-		MaxRedirects:       0,
-		VerifyTls:          config.VerifyTls,
-		Timeout:            config.Timeout,
-		UserAgent:          config.UserAgent,
-		RequestMethod:      common.RequestMethodStandard,
-		HeadlessConfig:     nil,
-		BrowserbaseConfig:  nil,
-		BrowserbaseSecrets: nil,
+		Request:                    &request,
+		MaxRedirects:               config.MaxRedirects,
+		VerifyTls:                  config.VerifyTls,
+		Timeout:                    config.Timeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
+		UserAgent:                  config.UserAgent,
+		RequestMethod:              common.RequestMethodStandard,
+		HeadlessConfig:             nil,
+		BrowserbaseConfig:          nil,
+		BrowserbaseSecrets:         nil,
 	}
 }
 

--- a/internal/pentest/waf/detect/detect.go
+++ b/internal/pentest/waf/detect/detect.go
@@ -28,12 +28,13 @@ func createDastNucleiConfigForWafDetect(config waf.PentestWafDetectConfig) nucle
 			HttpMethods:       config.HttpMethods,
 			RequestParameters: config.RouteRequestParameters,
 		},
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}
 }
 

--- a/utils/nuclei/engine.go
+++ b/utils/nuclei/engine.go
@@ -67,7 +67,7 @@ func RunNucleiEngine(ctx context.Context, config nuclei.NucleiConfig) ([]*nuclei
 	}
 
 	// Build the report builder and run the nuclei engine
-	builder := report.NewBuilder()
+	builder := report.NewBuilder(config.Targets, config.IgnoreCrossDomainRedirects)
 	return runner.Run(ctx, runnerConfig, builder)
 }
 

--- a/utils/nuclei/report/builder.go
+++ b/utils/nuclei/report/builder.go
@@ -10,17 +10,21 @@ import (
 // Builder constructs and manages Nuclei scan reports.
 // It maintains indexes for probes and targets to efficiently process scan results.
 type Builder struct {
-	mu        sync.Mutex
-	targets   []*nuclei.NucleiTargetInfo
-	probeIdx  map[string]*nuclei.NucleiProbe      // template-id → Probe
-	targetIdx map[string]*nuclei.NucleiTargetInfo // host/baseURL → TargetInfo
+	mu                         sync.Mutex
+	targets                    []*nuclei.NucleiTargetInfo
+	probeIdx                   map[string]*nuclei.NucleiProbe      // template-id → Probe
+	targetIdx                  map[string]*nuclei.NucleiTargetInfo // host/baseURL → TargetInfo
+	scopeTargets               []string
+	ignoreCrossDomainRedirects bool
 }
 
 // NewBuilder creates and returns a new Builder instance.
-func NewBuilder() *Builder {
+func NewBuilder(scopeTargets []string, ignoreCrossDomainRedirects bool) *Builder {
 	return &Builder{
-		targets:   []*nuclei.NucleiTargetInfo{},
-		probeIdx:  make(map[string]*nuclei.NucleiProbe),
-		targetIdx: make(map[string]*nuclei.NucleiTargetInfo),
+		targets:                    []*nuclei.NucleiTargetInfo{},
+		probeIdx:                   make(map[string]*nuclei.NucleiProbe),
+		targetIdx:                  make(map[string]*nuclei.NucleiTargetInfo),
+		scopeTargets:               scopeTargets,
+		ignoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 }

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -8,6 +8,8 @@ import (
 
 	// Generated
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
+	// Utils
+	utils "github.com/Method-Security/webscan/utils"
 	// External
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -223,6 +225,11 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	targetURL := getTargetURL(ev)
+	if b.ignoreCrossDomainRedirects && !b.isTargetInScope(targetURL) {
+		return
+	}
+
 	// Get or create probe
 	probe, ok := b.probeIdx[ev.TemplateID]
 	if !ok {
@@ -231,7 +238,6 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	}
 
 	// Get or create target
-	targetURL := getTargetURL(ev)
 	targetInfo, ok := b.targetIdx[targetURL]
 	if !ok {
 		targetInfo = &nuclei.NucleiTargetInfo{Target: targetURL}
@@ -347,6 +353,16 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 
 	// Always add the attempt to the report, even if there was an error parsing the request/response
 	targetInfo.Attempts = append(targetInfo.Attempts, attemptInfo)
+}
+
+func (b *Builder) isTargetInScope(targetURL string) bool {
+	for _, scopeTarget := range b.scopeTargets {
+		scopeTarget = strings.ReplaceAll(scopeTarget, "%s", "scope")
+		if utils.IsHostInScope(scopeTarget, targetURL) {
+			return true
+		}
+	}
+	return false
 }
 
 // Final returns the fully-populated Fern report.


### PR DESCRIPTION
…Count

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default redirect and scope behavior for many scanning commands, which can alter enumeration results and nuclei finding sets; scope checks use host matching that may differ from prior implicit behavior.
> 
> **Overview**
> Standardizes **HTTP redirect behavior** across discover, enumerate, and pentest CLIs by exposing **`--max-redirects`** and **`--ignore-cross-domain-redirects`** (often defaulting to blocking off-scope hosts) instead of hardcoded limits in directory scans, Swagger probing, wordlist crawling, CMS/kube/docker enumeration, and WordPress pentest flows.
> 
> **Fern configs** and internal **`SendHttpRequestConfig`** builders now pass **`MaxRedirects`** and **`IgnoreCrossDomainRedirects`** through consistently; directory discovery uses config-driven redirect counts for probe traffic and calibration.
> 
> **Nuclei-based** application discover, DAST/CVE/misconfiguration/technology scans, and WAF detect gain **`ignoreCrossDomainRedirects`** on scan config; the report **builder drops findings** whose final URL is outside the original target scope when that flag is set. GraphQL enumeration applies the same cross-domain check after the HTTP client follows redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df19594fbf2768b64075a7891066a6646cb8b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->