### PR TITLE
Keep discover application Nuclei redirect filtering after redirect revert

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -99,6 +99,11 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			ignoreCrossDomainRedirects, err := cmd.Flags().GetBool("ignore-cross-domain-redirects")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			templatePaths, err := cmd.Flags().GetStringSlice("template-paths")
 			if err != nil {
@@ -127,7 +132,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, webServerIpAddress, webServerPort, webServerApplicationProtocol)
+			config, err := getDiscoverApplicationConfig(targets, resourceType, templatePaths, timeout, threads, proxy, verboseLogs, globalRateLimit, globalTimeout, userAgentPreset, ignoreCrossDomainRedirects, webServerIpAddress, webServerPort, webServerApplicationProtocol)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -1541,7 +1546,7 @@ func parseDiscoverRequestFiles(pairs []string) ([]*discover.RequestFile, error) 
 }
 
 // getDiscoverApplicationConfig builds the config for application fingerprinting discovery.
-func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, webServerIPAddress string, webServerPort int, webServerApplicationProtocol string) (*discover.DiscoverApplicationConfig, error) {
+func getDiscoverApplicationConfig(targets []string, resource string, templatePaths []string, timeout int, threads int, proxy string, verboseLogs bool, globalRateLimit int, globalTimeout int, userAgent common.UserAgentPreset, ignoreCrossDomainRedirects bool, webServerIPAddress string, webServerPort int, webServerApplicationProtocol string) (*discover.DiscoverApplicationConfig, error) {
 	resourceEnum, err := getDiscoverApplicationResourceConfigTypeFromString(resource)
 	if err != nil {
 		return nil, fmt.Errorf("invalid resource type: %s", resource)
@@ -1555,16 +1560,17 @@ func getDiscoverApplicationConfig(targets []string, resource string, templatePat
 	}
 
 	config := &discover.DiscoverApplicationConfig{
-		Targets:         targets,
-		ResourceType:    &resourceEnum,
-		TemplatePaths:   templatePaths,
-		Timeout:         timeout,
-		Threads:         threads,
-		Proxy:           &proxy,
-		VerboseLogs:     verboseLogs,
-		GlobalRateLimit: max(0, globalRateLimit),
-		GlobalTimeout:   max(0, globalTimeout),
-		UserAgent:       userAgent,
+		Targets:                    targets,
+		ResourceType:               &resourceEnum,
+		TemplatePaths:              templatePaths,
+		Timeout:                    timeout,
+		Threads:                    threads,
+		Proxy:                      &proxy,
+		VerboseLogs:                verboseLogs,
+		GlobalRateLimit:            max(0, globalRateLimit),
+		GlobalTimeout:              max(0, globalTimeout),
+		UserAgent:                  userAgent,
+		IgnoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 	if webServerIPAddress != "" {
 		config.WebServerIpAddress = &webServerIPAddress

--- a/fern/definition/common/nuclei/config.yml
+++ b/fern/definition/common/nuclei/config.yml
@@ -26,4 +26,4 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
-
+      ignoreCrossDomainRedirects: boolean

--- a/fern/definition/discover/application.yml
+++ b/fern/definition/discover/application.yml
@@ -61,6 +61,7 @@ types:
       globalRateLimit: integer
       globalTimeout: integer
       userAgent: method.UserAgentPreset
+      ignoreCrossDomainRedirects: boolean
       webServerIpAddress: optional<string>
       webServerPort: optional<integer>
       webServerApplicationProtocol: optional<http.WebProtocol>

--- a/internal/discover/application/engine.go
+++ b/internal/discover/application/engine.go
@@ -98,16 +98,17 @@ func createDiscoverApplicationNucleiConfig(ctx context.Context, config *discover
 		svc1log.SafeParam("threads", config.Threads))
 
 	return nuclei.NucleiConfig{
-		Targets:         config.Targets,
-		TemplatePaths:   templatePaths,
-		RunMode:         nuclei.NucleiRunModeScan,
-		Timeout:         config.Timeout,
-		Threads:         config.Threads,
-		Proxy:           config.Proxy,
-		VerboseLogs:     config.VerboseLogs,
-		GlobalRateLimit: config.GlobalRateLimit,
-		GlobalTimeout:   config.GlobalTimeout,
-		UserAgent:       config.UserAgent,
+		Targets:                    config.Targets,
+		TemplatePaths:              templatePaths,
+		RunMode:                    nuclei.NucleiRunModeScan,
+		Timeout:                    config.Timeout,
+		Threads:                    config.Threads,
+		Proxy:                      config.Proxy,
+		VerboseLogs:                config.VerboseLogs,
+		GlobalRateLimit:            config.GlobalRateLimit,
+		GlobalTimeout:              config.GlobalTimeout,
+		UserAgent:                  config.UserAgent,
+		IgnoreCrossDomainRedirects: config.IgnoreCrossDomainRedirects,
 	}, nil
 }
 

--- a/utils/nuclei/engine.go
+++ b/utils/nuclei/engine.go
@@ -67,7 +67,7 @@ func RunNucleiEngine(ctx context.Context, config nuclei.NucleiConfig) ([]*nuclei
 	}
 
 	// Build the report builder and run the nuclei engine
-	builder := report.NewBuilder()
+	builder := report.NewBuilder(config.Targets, config.IgnoreCrossDomainRedirects)
 	return runner.Run(ctx, runnerConfig, builder)
 }
 

--- a/utils/nuclei/report/builder.go
+++ b/utils/nuclei/report/builder.go
@@ -10,17 +10,21 @@ import (
 // Builder constructs and manages Nuclei scan reports.
 // It maintains indexes for probes and targets to efficiently process scan results.
 type Builder struct {
-	mu        sync.Mutex
-	targets   []*nuclei.NucleiTargetInfo
-	probeIdx  map[string]*nuclei.NucleiProbe      // template-id → Probe
-	targetIdx map[string]*nuclei.NucleiTargetInfo // host/baseURL → TargetInfo
+	mu                         sync.Mutex
+	targets                    []*nuclei.NucleiTargetInfo
+	probeIdx                   map[string]*nuclei.NucleiProbe      // template-id → Probe
+	targetIdx                  map[string]*nuclei.NucleiTargetInfo // host/baseURL → TargetInfo
+	scopeTargets               []string
+	ignoreCrossDomainRedirects bool
 }
 
 // NewBuilder creates and returns a new Builder instance.
-func NewBuilder() *Builder {
+func NewBuilder(scopeTargets []string, ignoreCrossDomainRedirects bool) *Builder {
 	return &Builder{
-		targets:   []*nuclei.NucleiTargetInfo{},
-		probeIdx:  make(map[string]*nuclei.NucleiProbe),
-		targetIdx: make(map[string]*nuclei.NucleiTargetInfo),
+		targets:                    []*nuclei.NucleiTargetInfo{},
+		probeIdx:                   make(map[string]*nuclei.NucleiProbe),
+		targetIdx:                  make(map[string]*nuclei.NucleiTargetInfo),
+		scopeTargets:               scopeTargets,
+		ignoreCrossDomainRedirects: ignoreCrossDomainRedirects,
 	}
 }

--- a/utils/nuclei/report/data.go
+++ b/utils/nuclei/report/data.go
@@ -16,27 +16,26 @@ import (
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
 
-// getTargetURL extracts the target URL from a ResultEvent.
-// excludes query parameters and fragment ie. https://example.com/path?query#fragment -> https://example.com/path
-// Uses the path from the raw HTTP request if available, as ev.URL may not contain the tested path
-func getTargetURL(ev *nout.ResultEvent) string {
+// getRequestURL extracts the original request URL from a ResultEvent.
+// Uses the path from the raw HTTP request if available, as ev.URL may not
+// contain the tested path.
+func getRequestURL(ev *nout.ResultEvent) string {
 	parsedURL, err := url.Parse(ev.URL)
 	if err != nil {
 		return ev.URL
 	}
 
-	// Extract the actual path from the raw HTTP request
-	// This is necessary because ev.URL might not contain the tested path when using path fuzzing
 	if ev.Request != "" {
 		_, requestPath, _, _ := parseRawRequest(ev.Request)
-		// Only use the parsed path if it's non-empty and looks like a valid path (starts with /)
 		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
-			// Strip query string and fragment if present to avoid URL encoding issues
-			if idx := strings.IndexAny(requestPath, "?#"); idx != -1 {
+			if idx := strings.IndexByte(requestPath, '#'); idx != -1 {
 				requestPath = requestPath[:idx]
 			}
-			// Decode the path since it comes URL-encoded from the HTTP request
-			// This prevents double-encoding when parsedURL.String() re-encodes it
+			parsedURL.RawQuery = ""
+			if idx := strings.IndexByte(requestPath, '?'); idx != -1 {
+				parsedURL.RawQuery = requestPath[idx+1:]
+				requestPath = requestPath[:idx]
+			}
 			if decodedPath, err := url.PathUnescape(requestPath); err == nil {
 				parsedURL.Path = decodedPath
 			} else {
@@ -45,10 +44,83 @@ func getTargetURL(ev *nout.ResultEvent) string {
 		}
 	}
 
+	parsedURL.Fragment = ""
+	parsedURL.RawFragment = ""
+	return parsedURL.String()
+}
+
+// getTargetURL extracts the target URL from a ResultEvent for report bucketing.
+// Query parameters and fragments are excluded.
+func getTargetURL(ev *nout.ResultEvent) string {
+	requestURL := getRequestURL(ev)
+	parsedURL, err := url.Parse(requestURL)
+	if err != nil {
+		return requestURL
+	}
 	parsedURL.RawQuery = ""
 	parsedURL.Fragment = ""
 	parsedURL.RawFragment = ""
 	return parsedURL.String()
+}
+
+// getMatchedURL returns the final URL that Nuclei matched after redirects.
+// Nuclei keeps ev.URL anchored on the original input host and stores the final
+// landed URL in ev.Matched for HTTP findings.
+func getMatchedURL(ev *nout.ResultEvent) string {
+	if ev.Matched != "" {
+		parsedURL, err := url.Parse(ev.Matched)
+		if err == nil && parsedURL.Hostname() != "" {
+			parsedURL.Fragment = ""
+			parsedURL.RawFragment = ""
+			return parsedURL.String()
+		}
+	}
+	return getRequestURL(ev)
+}
+
+func getNucleiNormalizedRequestURL(ev *nout.ResultEvent) string {
+	parsedURL, err := url.Parse(ev.URL)
+	if err != nil {
+		return ev.URL
+	}
+
+	if ev.Request != "" {
+		_, requestPath, _, _ := parseRawRequest(ev.Request)
+		if requestPath != "" && strings.HasPrefix(requestPath, "/") {
+			if parsedRequestPath, err := url.Parse(requestPath); err == nil {
+				if decodedPath, err := url.PathUnescape(parsedRequestPath.Path); err == nil {
+					parsedURL.Path = decodedPath
+				} else {
+					parsedURL.Path = parsedRequestPath.Path
+				}
+				parsedURL.RawPath = parsedRequestPath.Path
+				parsedURL.RawQuery = parsedRequestPath.RawQuery
+			}
+		}
+	}
+
+	parsedURL.Fragment = ""
+	parsedURL.RawFragment = ""
+	return parsedURL.String()
+}
+
+func urlsEqual(firstURL, secondURL string) bool {
+	if firstURL == secondURL {
+		return true
+	}
+
+	firstParsed, firstErr := url.Parse(firstURL)
+	secondParsed, secondErr := url.Parse(secondURL)
+	if firstErr != nil || secondErr != nil {
+		return false
+	}
+	if firstParsed.Path == "" {
+		firstParsed.Path = "/"
+	}
+	if secondParsed.Path == "" {
+		secondParsed.Path = "/"
+	}
+	return firstParsed.String() == secondParsed.String()
 }
 
 // parseRawRequest parses a raw HTTP request string into its components.
@@ -127,16 +199,15 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 		ResponseHeaders: map[string][]string{},
 	}
 
-	// Marshal Request Struct
-	// ev.URL contains the final destination URL after all redirects
-	finalURL, err := url.Parse(ev.URL)
+	// Marshal Request Struct from the original input URL.
+	requestURL, err := url.Parse(ev.URL)
 	if err != nil {
 		// If we can't parse the URL, still include what we can
 		request.BaseUrl = ev.URL
 		request.Path = "/"
 	} else {
-		request.BaseUrl = fmt.Sprintf("%s://%s", finalURL.Scheme, finalURL.Host)
-		request.Path = finalURL.Path
+		request.BaseUrl = fmt.Sprintf("%s://%s", requestURL.Scheme, requestURL.Host)
+		request.Path = requestURL.Path
 		if request.Path == "" {
 			request.Path = "/"
 		}
@@ -189,10 +260,10 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 		params.Body = requesthelpers.CreateBodyFromBytes(contentType, []byte(body))
 	}
 
-	// Parse query parameters - prefer raw request query string, fall back to finalURL
+	// Parse query parameters - prefer raw request query string, fall back to the input URL.
 	queryStringToParse := rawRequestQueryString
-	if queryStringToParse == "" && finalURL != nil && finalURL.RawQuery != "" {
-		queryStringToParse = finalURL.RawQuery
+	if queryStringToParse == "" && requestURL != nil && requestURL.RawQuery != "" {
+		queryStringToParse = requestURL.RawQuery
 	}
 
 	if queryStringToParse != "" {
@@ -212,11 +283,15 @@ func getHTTPRequestResponse(ev *nout.ResultEvent) (*common.HttpRequestResponse, 
 		responseBody = ev.Response
 	}
 
-	// Create redirect chain with the final URL if it's different from base
+	// Nuclei does not expose the full redirect hop list, but it does expose the
+	// original target and final landed URL.
 	var redirectChain []string
-	fullURL := request.GetBaseUrl() + request.GetPath()
-	if finalURL != nil {
-		redirectChain = append(redirectChain, fullURL)
+	originalURL := getRequestURL(ev)
+	if originalURL != "" {
+		redirectChain = append(redirectChain, originalURL)
+	}
+	if matchedURL := getMatchedURL(ev); matchedURL != "" && !urlsEqual(matchedURL, originalURL) && !urlsEqual(matchedURL, getNucleiNormalizedRequestURL(ev)) {
+		redirectChain = append(redirectChain, matchedURL)
 	}
 
 	response = requesthelpers.CreateHTTPResponse(statusCode, redirectChain, singleToMulti(responseHeaders), responseBody)

--- a/utils/nuclei/report/report.go
+++ b/utils/nuclei/report/report.go
@@ -8,6 +8,8 @@ import (
 
 	// Generated
 	nuclei "github.com/Method-Security/webscan/generated/go/common/nuclei"
+	// Utils
+	utils "github.com/Method-Security/webscan/utils"
 	// External
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	nout "github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -223,6 +225,11 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	targetURL := getTargetURL(ev)
+	if b.ignoreCrossDomainRedirects && !b.isTargetInScope(getMatchedURL(ev)) {
+		return
+	}
+
 	// Get or create probe
 	probe, ok := b.probeIdx[ev.TemplateID]
 	if !ok {
@@ -231,7 +238,6 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 	}
 
 	// Get or create target
-	targetURL := getTargetURL(ev)
 	targetInfo, ok := b.targetIdx[targetURL]
 	if !ok {
 		targetInfo = &nuclei.NucleiTargetInfo{Target: targetURL}
@@ -347,6 +353,15 @@ func (b *Builder) Consume(ev *nout.ResultEvent) {
 
 	// Always add the attempt to the report, even if there was an error parsing the request/response
 	targetInfo.Attempts = append(targetInfo.Attempts, attemptInfo)
+}
+
+func (b *Builder) isTargetInScope(targetURL string) bool {
+	for _, scopeTarget := range b.scopeTargets {
+		if utils.IsHostInScope(scopeTarget, targetURL) {
+			return true
+		}
+	}
+	return false
 }
 
 // Final returns the fully-populated Fern report.


### PR DESCRIPTION
Stacked on #490. This keeps only the `discover application` Nuclei redirect behavior after the broader redirect-control revert lands.

- reuse the existing discover-level `--ignore-cross-domain-redirects` flag for `discover application`
- pass scope targets into the Nuclei report builder and drop out-of-scope final matches only when that discover application flag is enabled
- report original and final matched URLs in `response.redirectChain` without false entries for query-only or trailing-slash differences

Verification:
- `fern generate --group local --retry-rate-limited`
- `./godelw verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Nuclei hits surface in discover application (default-on persistent flag) and alters redirect metadata in reports; scope logic mistakes could drop valid same-scan findings.
> 
> **Overview**
> **`discover application`** now threads the existing **`--ignore-cross-domain-redirects`** flag through **`DiscoverApplicationConfig`** / **`NucleiConfig`** into the Nuclei report builder. When enabled, Nuclei findings whose **post-redirect matched URL** is outside the scan targets (via **`IsHostInScope`**) are dropped instead of appearing in application fingerprint results.
> 
> The Nuclei report layer also **splits original vs landed URLs**: **`getMatchedURL`** reads **`ev.Matched`**, request/response marshaling uses the **input URL** for the request, and **`response.redirectChain`** records original → final only when they differ in a meaningful way (ignoring query-only / trailing-slash normalization noise).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be885fa075fb22a7831d2a731e203d6c389f2296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->