### PR TITLE
Add Rate-Limit Flag to Web Buster

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -259,12 +259,17 @@ func (a *WebScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			globalRateLimit, err := cmd.Flags().GetInt("global-rate-limit")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			maxRedirectsBaselineRequest, err := cmd.Flags().GetInt("max-redirects-baseline-request")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			maxRuntime, err := cmd.Flags().GetInt("max-runtime")
+			globalTimeout, err := cmd.Flags().GetInt("global-timeout")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -311,7 +316,7 @@ func (a *WebScan) InitDiscoverCommand() {
 			}
 
 			// Set config
-			config := getDiscoverDirectoryConfig(targets, paths, wordlistType, wordlistSize, httpMethods, responseCodes, enableCommonResponseFilters, verifyTLS, threshold, timeout, ignoreCrossDomainRedirects, maxRedirectsBaselineRequest, threads, maxRuntime, retries, sleep, jitter, userAgentPreset)
+			config := getDiscoverDirectoryConfig(targets, paths, wordlistType, wordlistSize, httpMethods, responseCodes, enableCommonResponseFilters, verifyTLS, threshold, timeout, globalRateLimit, ignoreCrossDomainRedirects, maxRedirectsBaselineRequest, threads, globalTimeout, retries, sleep, jitter, userAgentPreset)
 
 			// Generate a report
 			rep, err := discoverdirectory.RunDirectoryDiscovery(cmd.Context(), config)
@@ -335,8 +340,9 @@ func (a *WebScan) InitDiscoverCommand() {
 	discoverDirectoryCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests")
 	discoverDirectoryCmd.Flags().Float64("threshold", 0.25, "Threshold for successful results")
 	discoverDirectoryCmd.Flags().Int("timeout", 20, "Timeout per request in seconds")
+	discoverDirectoryCmd.Flags().Int("global-rate-limit", 25, "Global rate limit in requests per second")
 	discoverDirectoryCmd.Flags().Int("max-redirects-baseline-request", 10, "Maximum number of redirects to follow for the baseline request")
-	discoverDirectoryCmd.Flags().Int("max-runtime", 650, "Maximum time to run the engagement in seconds")
+	discoverDirectoryCmd.Flags().Int("global-timeout", 650, "Maximum total scan time in seconds")
 	discoverDirectoryCmd.Flags().Int("threads", 25, "Number of threads to use")
 	discoverDirectoryCmd.Flags().Int("retries", 0, "Number of times to retry a request if it fails")
 	discoverDirectoryCmd.Flags().Int("sleep", 0, "Number of seconds to sleep between requests")
@@ -1725,7 +1731,7 @@ func getDiscoverSaasConfig(orgs []string, saasCompanies []string, ssoCompanies [
 }
 
 // getDiscoverDirectoryConfig builds the config for directory discovery.
-func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType string, wordlistSize string, httpMethods []common.HttpMethod, responseCodes string, enableCommonResponseFilters bool, verifyTLS bool, threshold float64, timeout int, ignoreCrossDomainRedirects bool, maxRedirectsBaselineRequest int, threads int, maxRuntime int, retries int, sleep int, jitter int, userAgent common.UserAgentPreset) discover.DiscoverDirectoryConfig {
+func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType string, wordlistSize string, httpMethods []common.HttpMethod, responseCodes string, enableCommonResponseFilters bool, verifyTLS bool, threshold float64, timeout int, globalRateLimit int, ignoreCrossDomainRedirects bool, maxRedirectsBaselineRequest int, threads int, globalTimeout int, retries int, sleep int, jitter int, userAgent common.UserAgentPreset) discover.DiscoverDirectoryConfig {
 	config := discover.DiscoverDirectoryConfig{
 		Targets:                     targets,
 		Paths:                       paths,
@@ -1735,10 +1741,11 @@ func getDiscoverDirectoryConfig(targets []string, paths []string, wordlistType s
 		VerifyTls:                   verifyTLS,
 		Threshold:                   threshold,
 		Timeout:                     timeout,
+		GlobalRateLimit:             max(0, globalRateLimit),
 		IgnoreCrossDomainRedirects:  ignoreCrossDomainRedirects,
 		MaxRedirectsBaselineRequest: maxRedirectsBaselineRequest,
 		Threads:                     threads,
-		MaxRuntime:                  maxRuntime,
+		GlobalTimeout:               max(0, globalTimeout),
 		Retries:                     retries,
 		Sleep:                       sleep,
 		Jitter:                      jitter,

--- a/fern/definition/discover/directory.yml
+++ b/fern/definition/discover/directory.yml
@@ -26,9 +26,10 @@ types:
       verifyTls: boolean
       threshold: float
       timeout: integer
+      globalRateLimit: integer
       ignoreCrossDomainRedirects: boolean
       maxRedirectsBaselineRequest: integer
-      maxRuntime: integer
+      globalTimeout: integer
       retries: integer
       sleep: integer
       jitter: integer

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/ysmood/gson v0.7.3
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
+	golang.org/x/time v0.14.0
 )
 
 require (
@@ -403,7 +404,6 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect

--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -26,8 +26,8 @@ import (
 func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirectoryConfig) (*discover.DiscoverDirectoryReport, error) {
 	// Set context
 	var cancel context.CancelFunc
-	if config.MaxRuntime > 0 {
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(config.MaxRuntime)*time.Second)
+	if config.GlobalTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(config.GlobalTimeout)*time.Second)
 		defer cancel()
 	}
 
@@ -39,6 +39,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 	report := discover.DiscoverDirectoryReport{Config: &config}
 	errors := []string{}
 	result := discover.DiscoverDirectoryResult{}
+	limiter := newDirectoryRateLimiter(config.GlobalRateLimit)
 
 	// Gather all paths
 	allPaths, err := gatherPaths(config.Paths, config.WordlistType, config.WordlistSize)
@@ -59,7 +60,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 	// Check for timeout before starting main processing
 	if ctx.Err() != nil {
 		report.Result = &result
-		report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds before processing started", config.MaxRuntime))
+		report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds before processing started", config.GlobalTimeout))
 		return &report, nil
 	}
 
@@ -72,7 +73,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 			// Return partial results collected so far
 			result.Targets = targets
 			report.Result = &result
-			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during target processing", config.MaxRuntime))
+			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during target processing", config.GlobalTimeout))
 			return &report, nil
 		}
 
@@ -94,7 +95,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 		var calibrationFailureSample string
 		if config.EnableCommonResponseFilters {
 			// Follow redirects to get the correct baseline size and word count.
-			baselineRequest, baselineSize, baselineWords, err := baseLine(ctx, baseURL, parsedTargetPath, validCodes, config.MaxRedirectsBaselineRequest, &config)
+			baselineRequest, baselineSize, baselineWords, err := baseLine(ctx, baseURL, parsedTargetPath, validCodes, config.MaxRedirectsBaselineRequest, &config, limiter)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("target %s: failed to get base response profile, skipping enumeration: %v", target, err))
 				report.Errors = errors
@@ -105,7 +106,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 			targetInfo.BaselineAttempts = append(targetInfo.BaselineAttempts, baselineRequest)
 			log.Info("Baseline size", svc1log.SafeParam("size", baselineSizeInt), svc1log.SafeParam("words", baselineWordsInt))
 
-			calibrationAttempts, failureCount, failureSample := calibrateCommonResponses(ctx, baseURL, parsedTargetPath, &config, detector)
+			calibrationAttempts, failureCount, failureSample := calibrateCommonResponses(ctx, baseURL, parsedTargetPath, &config, detector, limiter)
 			targetInfo.BaselineAttempts = append(targetInfo.BaselineAttempts, calibrationAttempts...)
 			calibrationFailureCount = failureCount
 			calibrationFailureSample = failureSample
@@ -119,7 +120,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 			// Return partial results collected so far
 			result.Targets = targets
 			report.Result = &result
-			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during baseline setup", config.MaxRuntime))
+			report.Errors = append(report.Errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during baseline setup", config.GlobalTimeout))
 			return &report, nil
 		}
 
@@ -173,7 +174,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 							targets = append(targets, &targetInfo)
 						}
 						result.Targets = targets
-						errors = append(errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during request processing", config.MaxRuntime))
+						errors = append(errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during request processing", config.GlobalTimeout))
 						report.Result = &result
 						report.Errors = errors
 						return &report, nil
@@ -221,6 +222,18 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 							return
 						}
 						defer func() { <-semaphore }()
+
+						if err := waitForDirectoryRateLimit(ctx, limiter); err != nil {
+							if ctx.Err() == nil {
+								attemptsMutex.Lock()
+								metrics.sendFailureCount++
+								if metrics.sendFailureSample == "" {
+									metrics.sendFailureSample = err.Error()
+								}
+								attemptsMutex.Unlock()
+							}
+							return
+						}
 
 						// Send request
 						requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, fullPath, method, common.HttpRequestParams{}, 0, &config)
@@ -311,7 +324,7 @@ func RunDirectoryDiscovery(ctx context.Context, config discover.DiscoverDirector
 		// Check if context expired during processing - still return partial results
 		if ctx.Err() != nil {
 			result.Targets = targets
-			errors = append(errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during processing, returning partial results", config.MaxRuntime))
+			errors = append(errors, fmt.Sprintf("directory discovery operation timed out after %d seconds during processing, returning partial results", config.GlobalTimeout))
 			report.Result = &result
 			report.Errors = errors
 			return &report, nil

--- a/internal/discover/directory/helpers.go
+++ b/internal/discover/directory/helpers.go
@@ -22,6 +22,7 @@ import (
 	// External
 	uuid "github.com/google/uuid"
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"golang.org/x/time/rate"
 )
 
 // createDirectorySendHTTPRequestConfig builds the config for directory discovery.
@@ -49,6 +50,20 @@ func createDirectorySendHTTPRequestConfig(ctx context.Context, baseURL, path str
 	requesthelpers.ApplyProxySettings(ctx, &sendConfig)
 
 	return sendConfig
+}
+
+func newDirectoryRateLimiter(requestsPerSecond int) *rate.Limiter {
+	if requestsPerSecond <= 0 {
+		return nil
+	}
+	return rate.NewLimiter(rate.Limit(requestsPerSecond), 1)
+}
+
+func waitForDirectoryRateLimit(ctx context.Context, limiter *rate.Limiter) error {
+	if limiter == nil {
+		return nil
+	}
+	return limiter.Wait(ctx)
 }
 
 type directoryScanMetrics struct {
@@ -200,9 +215,13 @@ func logDirectoryFindings(ctx context.Context, attempts []*common.HttpRequestRes
 }
 
 // baseLine gets the baseline size and word count of the target to be used for validation of the response
-func baseLine(ctx context.Context, baseURL string, path string, validCodes map[int]bool, maxRedirects int, config *discover.DiscoverDirectoryConfig) (*common.HttpRequestResponse, *int, *int, error) {
+func baseLine(ctx context.Context, baseURL string, path string, validCodes map[int]bool, maxRedirects int, config *discover.DiscoverDirectoryConfig, limiter *rate.Limiter) (*common.HttpRequestResponse, *int, *int, error) {
 	// set request config
 	requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, path, common.HttpMethodGet, common.HttpRequestParams{}, maxRedirects, config)
+
+	if err := waitForDirectoryRateLimit(ctx, limiter); err != nil {
+		return nil, nil, nil, err
+	}
 
 	// send request
 	request, err := request.SendRequest(ctx, requestConfig)
@@ -228,7 +247,7 @@ func baseLine(ctx context.Context, baseURL string, path string, validCodes map[i
 
 // calibrateCommonResponses sends intentionally invalid paths and seeds the common-response
 // detector with the resulting body profiles.
-func calibrateCommonResponses(ctx context.Context, baseURL, parsedTargetPath string, config *discover.DiscoverDirectoryConfig, detector *commonResponseDetector) ([]*common.HttpRequestResponse, int, string) {
+func calibrateCommonResponses(ctx context.Context, baseURL, parsedTargetPath string, config *discover.DiscoverDirectoryConfig, detector *commonResponseDetector, limiter *rate.Limiter) ([]*common.HttpRequestResponse, int, string) {
 	var attempts []*common.HttpRequestResponse
 	var failureCount int
 	var failureSample string
@@ -236,6 +255,13 @@ func calibrateCommonResponses(ctx context.Context, baseURL, parsedTargetPath str
 	for _, method := range config.HttpMethods {
 		for _, probePath := range commonResponseCalibrationPaths(parsedTargetPath) {
 			requestConfig := createDirectorySendHTTPRequestConfig(ctx, baseURL, probePath, method, common.HttpRequestParams{}, 0, config)
+			if err := waitForDirectoryRateLimit(ctx, limiter); err != nil {
+				failureCount++
+				if failureSample == "" {
+					failureSample = err.Error()
+				}
+				continue
+			}
 			httpRequest, err := request.SendRequest(ctx, requestConfig)
 			if err != nil {
 				failureCount++


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how aggressively directory scans hit targets (new default cap) and renames a CLI flag, which can break existing automation; behavior is localized to directory discovery HTTP pacing.
> 
> **Overview**
> Adds a **`--global-rate-limit`** flag (default **25 req/s**) to `discover directory`, wired through the Fern config as `globalRateLimit` and enforced with a shared `golang.org/x/time/rate` limiter across baseline, common-response calibration, and concurrent wordlist workers.
> 
> Renames **`max-runtime` / `MaxRuntime`** to **`global-timeout` / `GlobalTimeout`** for directory discovery so naming matches application discovery; timeout messages and context cancellation use the new field.
> 
> Promotes **`golang.org/x/time`** to a direct module dependency (was indirect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c909e74a075044b742e8d3d255e1894624743283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->