### PR TITLE
Add Nuceli Logger

### DIFF
--- a/utils/nuclei/runner/runner.go
+++ b/utils/nuclei/runner/runner.go
@@ -20,6 +20,7 @@ import (
 
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/projectdiscovery/gologger"
 	nucleilib "github.com/projectdiscovery/nuclei/v3/lib"
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
 )
@@ -156,6 +157,7 @@ func buildNucleiOptions(cfg Config, templateDir, workflowDir string) []nucleilib
 	}
 
 	opts := []nucleilib.NucleiSDKOptions{
+		nucleilib.WithLogger(gologger.DefaultLogger),
 		nucleilib.WithTemplatesOrWorkflows(templateSources),
 		nucleilib.EnableSelfContainedTemplates(),
 		nucleilib.DisableUpdateCheck(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Logging wiring only; no changes to scan targets, auth, or result handling.
> 
> **Overview**
> **Nuclei runner logging** — When building Nuclei SDK options in `buildNucleiOptions`, the runner now registers ProjectDiscovery's `gologger.DefaultLogger` through `nucleilib.WithLogger`, so Nuclei's internal log output is routed instead of relying on implicit defaults.
> 
> This is a two-line functional change (import + one option in the options slice); scan behavior, templates, concurrency, and reporting are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8576c0336a4dc09a5338d0fa936ef9bfd92b61ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->