### PR TITLE
Update Web Spider Static Asset Parsing

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -1646,6 +1646,15 @@ func getDiscoverWitnessConfig(target string, responseCodes string, takeScreensho
 
 // getDiscoverProbeConfig builds the config for probe discovery.
 func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int, verifyTLS bool, timeout int, sleep int, jitter int, ignoreCrossDomainRedirects bool, userAgent common.UserAgentPreset, requestMethod common.RequestMethod, headlessConfig *common.HeadlessRequestConfig, browserbaseConfig *common.BrowserbaseRequestConfig, webServerIPAddress string, webServerPort int, webServerApplicationProtocol string) (*discover.DiscoverProbeConfig, error) {
+	var protocolEnum common.WebProtocol
+	if protocol != "" {
+		var err error
+		protocolEnum, err = common.NewWebProtocolFromString(strings.ToUpper(protocol))
+		if err != nil {
+			return nil, fmt.Errorf("invalid protocol: %s", protocol)
+		}
+	}
+
 	var webServerApplicationProtocolEnum common.WebProtocol
 	if len(webServerApplicationProtocol) > 0 {
 		var err error
@@ -1667,6 +1676,9 @@ func getDiscoverProbeConfig(targets []string, protocol string, maxRedirects int,
 		RequestMethod:              requestMethod,
 		HeadlessConfig:             headlessConfig,
 		BrowserbaseConfig:          browserbaseConfig,
+	}
+	if protocol != "" {
+		config.Protocol = &protocolEnum
 	}
 	if webServerIPAddress != "" {
 		config.WebServerIpAddress = &webServerIPAddress

--- a/fern/definition/discover/route.yml
+++ b/fern/definition/discover/route.yml
@@ -45,11 +45,19 @@ types:
       bodyParams: optional<list<RouteBodyParam>>
       evidence: optional<string>
       pathTemplate: optional<string>
+  StaticAssetDetails:
+    properties:
+      local: optional<list<string>>
+      remote: optional<list<string>>
+  WebApplicationDetails:
+    properties:
+      baseURL: string
+      routes: optional<list<RouteDetails>>
+      staticAssets: optional<StaticAssetDetails>
   DiscoverRouteResult:
     properties:
       target: string
-      routes: optional<list<RouteDetails>>
-      staticAssets: optional<list<string>>
+      webApplications: optional<list<WebApplicationDetails>>
   DiscoverRouteReport:
     properties:
       config: DiscoverRouteConfig

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/palantir/pkg/safejson v1.2.0
 	github.com/palantir/witchcraft-go-logging v1.70.0
 	github.com/pb33f/libopenapi v0.38.7
+	github.com/projectdiscovery/gologger v1.1.71
 	github.com/projectdiscovery/nuclei/v3 v3.11.0
 	github.com/projectdiscovery/useragent v0.0.108
 	github.com/projectdiscovery/wappalyzergo v0.2.92
@@ -295,7 +296,6 @@ require (
 	github.com/projectdiscovery/goflags v0.1.74 // indirect
 	github.com/projectdiscovery/goja v0.0.0-20260618133720-acb73e419534 // indirect
 	github.com/projectdiscovery/goja_nodejs v0.0.0-20260618132410-8519f75f703d // indirect
-	github.com/projectdiscovery/gologger v1.1.71 // indirect
 	github.com/projectdiscovery/gostruct v0.0.2 // indirect
 	github.com/projectdiscovery/govaluate v0.0.0-20260615100919-5ee2581bbf7e // indirect
 	github.com/projectdiscovery/gozero v0.1.1-0.20260530071156-fa1dad563d76 // indirect

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -345,6 +345,99 @@ func extractRoutes(ctx context.Context, httpRequestResponse *common.HttpRequestR
 	return mergedRoutes, staticAssetsList, errors
 }
 
+func getResponseBaseURL(httpRequestResponse *common.HttpRequestResponse, fallbackURL string) string {
+	rawURL := fallbackURL
+	if httpRequestResponse != nil && httpRequestResponse.Response != nil && len(httpRequestResponse.Response.RedirectChain) > 0 {
+		rawURL = httpRequestResponse.Response.RedirectChain[len(httpRequestResponse.Response.RedirectChain)-1]
+	}
+
+	baseURL, _, err := discoverroutehelpers.SplitURLBaseAndPath(rawURL)
+	if err != nil {
+		return ""
+	}
+	return baseURL
+}
+
+func sortRoutes(routes []*discover.RouteDetails) {
+	sort.SliceStable(routes, func(i, j int) bool {
+		ri := routes[i]
+		rj := routes[j]
+		hasEvi := ri.Evidence != nil
+		hasEvj := rj.Evidence != nil
+		if hasEvi != hasEvj {
+			return hasEvi
+		}
+		return ri.BaseUrl+ri.Path < rj.BaseUrl+rj.Path
+	})
+}
+
+func buildWebApplications(routes []*discover.RouteDetails, staticAssetsByBaseURL map[string][]string) []*discover.WebApplicationDetails {
+	webApplicationsByBaseURL := make(map[string]*discover.WebApplicationDetails)
+	getWebApplication := func(baseURL string) *discover.WebApplicationDetails {
+		if baseURL == "" {
+			return nil
+		}
+		if webApplication, ok := webApplicationsByBaseURL[baseURL]; ok {
+			return webApplication
+		}
+		webApplication := &discover.WebApplicationDetails{BaseUrl: baseURL}
+		webApplicationsByBaseURL[baseURL] = webApplication
+		return webApplication
+	}
+
+	for _, route := range routes {
+		if route == nil {
+			continue
+		}
+		webApplication := getWebApplication(route.BaseUrl)
+		if webApplication == nil {
+			continue
+		}
+		webApplication.Routes = append(webApplication.Routes, route)
+	}
+
+	for baseURL, staticAssets := range staticAssetsByBaseURL {
+		webApplication := getWebApplication(baseURL)
+		if webApplication == nil {
+			continue
+		}
+
+		staticAssetDetails := webApplication.StaticAssets
+		if staticAssetDetails == nil {
+			staticAssetDetails = &discover.StaticAssetDetails{}
+		}
+		for _, staticAsset := range discoverroutehelpers.MergeStaticAssets(staticAssets) {
+			staticAssetBaseURL, _, err := discoverroutehelpers.SplitURLBaseAndPath(staticAsset)
+			if err != nil {
+				continue
+			}
+			if staticAssetBaseURL == baseURL {
+				staticAssetDetails.Local = append(staticAssetDetails.Local, staticAsset)
+			} else {
+				staticAssetDetails.Remote = append(staticAssetDetails.Remote, staticAsset)
+			}
+		}
+		if len(staticAssetDetails.Local) > 0 || len(staticAssetDetails.Remote) > 0 {
+			webApplication.StaticAssets = staticAssetDetails
+		}
+	}
+
+	webApplications := make([]*discover.WebApplicationDetails, 0, len(webApplicationsByBaseURL))
+	for _, webApplication := range webApplicationsByBaseURL {
+		if webApplication.StaticAssets != nil {
+			webApplication.StaticAssets.Local = discoverroutehelpers.MergeStaticAssets(webApplication.StaticAssets.Local)
+			webApplication.StaticAssets.Remote = discoverroutehelpers.MergeStaticAssets(webApplication.StaticAssets.Remote)
+			sort.Strings(webApplication.StaticAssets.Local)
+			sort.Strings(webApplication.StaticAssets.Remote)
+		}
+		webApplications = append(webApplications, webApplication)
+	}
+	sort.SliceStable(webApplications, func(i, j int) bool {
+		return webApplications[i].BaseUrl < webApplications[j].BaseUrl
+	})
+	return webApplications
+}
+
 // PerformRouteCapture performs route discovery and spidering for the given config, returning a DiscoverRouteReport.
 func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) discover.DiscoverRouteReport {
 	// Get the logger from the context
@@ -366,7 +459,7 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 
 	// Keep track of all discovered routes and static assets
 	allRoutes := []*discover.RouteDetails{}
-	allStaticAssets := []string{}
+	allStaticAssetsByBaseURL := make(map[string][]string)
 
 	// Mutex to protect shared data structures
 	var mu sync.Mutex
@@ -479,11 +572,14 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 				}
 
 				routes, staticAssets, newErrors := extractRoutes(ctx, request, requestConfig, config)
+				responseBaseURL := getResponseBaseURL(request, targetURL)
 
 				// Safely append to shared data structures
 				mu.Lock()
 				allRoutes = append(allRoutes, routes...)
-				allStaticAssets = append(allStaticAssets, staticAssets...)
+				if responseBaseURL != "" {
+					allStaticAssetsByBaseURL[responseBaseURL] = append(allStaticAssetsByBaseURL[responseBaseURL], staticAssets...)
+				}
 				errors = append(errors, newErrors...)
 				mu.Unlock()
 
@@ -534,21 +630,9 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 		currentDepth++
 	}
 
-	// Remove duplicate Routes and Static Assets
-	report.Result.Routes = discoverroutehelpers.MergeWebRoutes(allRoutes)
-	sort.SliceStable(report.Result.Routes, func(i, j int) bool {
-		ri := report.Result.Routes[i]
-		rj := report.Result.Routes[j]
-		// Prefer evidence-tagged routes while keeping output deterministic.
-		hasEvi := ri.Evidence != nil
-		hasEvj := rj.Evidence != nil
-		if hasEvi != hasEvj {
-			return hasEvi // true means ri comes first
-		}
-		// Same evidence tier: lexical for determinism
-		return ri.BaseUrl+ri.Path < rj.BaseUrl+rj.Path
-	})
-	report.Result.StaticAssets = discoverroutehelpers.MergeStaticAssets(allStaticAssets)
+	mergedRoutes := discoverroutehelpers.MergeWebRoutes(allRoutes)
+	sortRoutes(mergedRoutes)
+	report.Result.WebApplications = buildWebApplications(mergedRoutes, allStaticAssetsByBaseURL)
 	report.Errors = append(report.Errors, errors...)
 	return report
 }

--- a/internal/discover/witness/witness.go
+++ b/internal/discover/witness/witness.go
@@ -15,7 +15,6 @@ import (
 
 	// Utils
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
-
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )

--- a/internal/pentest/route/staticassettakeover.go
+++ b/internal/pentest/route/staticassettakeover.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Method-Security/webscan/configs"
 	// Generated
 	common "github.com/Method-Security/webscan/generated/go/common"
+	discoverfern "github.com/Method-Security/webscan/generated/go/discover"
 	pentestroutefern "github.com/Method-Security/webscan/generated/go/pentest/route"
 
 	// Internal
@@ -162,6 +163,30 @@ func isStaticAssetTakeOver(ctx context.Context, httpRequestResponse *common.Http
 	return pentestroutefern.StaticAssetTakeoverVulnerableDetails{Vulnerable: false}
 }
 
+func collectStaticAssets(result *discoverfern.DiscoverRouteResult) []string {
+	if result == nil {
+		return nil
+	}
+
+	staticAssets := []string{}
+	seen := make(map[string]struct{})
+	for _, webApplication := range result.WebApplications {
+		if webApplication == nil || webApplication.StaticAssets == nil {
+			continue
+		}
+		for _, staticAssetsForScope := range [][]string{webApplication.StaticAssets.Local, webApplication.StaticAssets.Remote} {
+			for _, staticAsset := range staticAssetsForScope {
+				if _, ok := seen[staticAsset]; ok {
+					continue
+				}
+				seen[staticAsset] = struct{}{}
+				staticAssets = append(staticAssets, staticAsset)
+			}
+		}
+	}
+	return staticAssets
+}
+
 func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.PentestRouteStaticAssetTakeoverConfig, browserbaseSecrets *common.BrowserbaseRequestSecrets) pentestroutefern.PentestRouteStaticAssetTakeoverReport {
 	// Initialize report
 	report := pentestroutefern.PentestRouteStaticAssetTakeoverReport{Config: &config}
@@ -182,7 +207,8 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 	// Perform Route Capture
 	log.Info("Performing route capture", svc1log.SafeParam("target", config.RouteCaptureConfig.Target))
 	captureRouteReport := discoverroute.PerformRouteCapture(ctx, *config.RouteCaptureConfig, browserbaseSecrets)
-	if len(captureRouteReport.Result.StaticAssets) == 0 {
+	staticAssets := collectStaticAssets(captureRouteReport.Result)
+	if len(staticAssets) == 0 {
 		errors = append(errors, "no static assets found")
 		report.Errors = errors
 		report.Result = &result
@@ -220,7 +246,7 @@ func DetectStaticAssetTakeovers(ctx context.Context, config pentestroutefern.Pen
 
 	// Static Asset Take Over Attempts
 	StaticAssetTakeOverAttempts := []*pentestroutefern.StaticAssetTakeoverStaticRequest{}
-	for _, staticAsset := range captureRouteReport.Result.StaticAssets {
+	for _, staticAsset := range staticAssets {
 		if !utils.IsStaticAsset(staticAsset) {
 			continue
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking Fern/API change to `DiscoverRouteResult` affects any consumer expecting flat routes/static assets; grouping logic changes how assets are attributed after redirects.
> 
> **Overview**
> **Route discovery output is restructured** from flat `routes` and `staticAssets` on `DiscoverRouteResult` to **`webApplications`**: each entry has a `baseURL`, nested routes, and optional `staticAssets` with **`local`** vs **`remote`** URL lists (same-origin vs other hosts).
> 
> During spidering, static assets are **bucketed by the final response base URL** (redirect chain end), then merged into that shape via new helpers (`getResponseBaseURL`, `sortRoutes`, `buildWebApplications`). **Static asset takeover** now **flattens** local and remote assets from `webApplications` instead of reading a top-level list.
> 
> **Discover probe** wiring now **validates and sets** the optional CLI `protocol` on `DiscoverProbeConfig`. **`gologger`** is listed as a direct module dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fce8253390884a2118c06cb2f876101c6668e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->