### PR TITLE
Update Favicon Cross Domain Logic

### DIFF
--- a/internal/discover/witness/witness.go
+++ b/internal/discover/witness/witness.go
@@ -14,6 +14,7 @@ import (
 	witnesshelpers "github.com/Method-Security/webscan/internal/discover/witness/helpers"
 
 	// Utils
+	utils "github.com/Method-Security/webscan/utils"
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -87,7 +88,7 @@ func processTarget(
 		finalURL = resp.RedirectChain[len(resp.RedirectChain)-1]
 	}
 	faviconURL := witnesshelpers.ExtractFaviconURL(string(bodyBytes), finalURL)
-	if faviconURL != "" {
+	if faviconURL != "" && (!config.IgnoreCrossDomainRedirects || utils.IsHostInScope(target, faviconURL)) {
 		if faviconBytes, faviconHash, faviconErr := witnesshelpers.FetchFavicon(ctx, faviconURL, config); faviconErr == nil && len(faviconBytes) > 0 {
 			result.Favicon = &discover.DiscoverWitnessFavicon{
 				Url:    faviconURL,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow behavioral change to optional favicon fetching in witness scans; uses the existing shared host-scoping helper with no auth or data-model impact.
> 
> **Overview**
> Witness favicon collection now honors **`IgnoreCrossDomainRedirects`** the same way other discovery paths do.
> 
> Previously, any non-empty favicon URL from the page HTML triggered a fetch. When cross-domain redirects are ignored, favicons are only fetched if the favicon URL is **in scope** relative to the scan target (via `utils.IsHostInScope`). With the flag off, behavior is unchanged—favicons are still fetched whenever a URL is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42435077dab262de985c3d2f984c64ce75312af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->