### PR TITLE
Update Local Def and Default Port for Route

### DIFF
--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -64,7 +64,7 @@ func MergeWebRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
 			normalizedPath = ""
 		}
 
-		key := fmt.Sprintf("%s:%s%s", method, route.BaseUrl, normalizedPath)
+		key := fmt.Sprintf("%s:%s%s", method, NormalizeBaseURLForIdentity(route.BaseUrl), normalizedPath)
 
 		if existingRoute, exists := routeMap[key]; exists {
 			// Merge QueryParams
@@ -312,9 +312,7 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 	return parsedURL.String(), nil
 }
 
-// SplitURLBaseAndPath returns the URL origin and escaped path as separate route
-// fields. HTTP(S) origins always include their effective port so implicit and
-// explicit default-port URLs collapse into the same route/application bucket.
+// SplitURLBaseAndPath returns the URL origin and escaped path as separate route fields.
 func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -323,7 +321,7 @@ func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 
 	baseURL := ""
 	if parsedURL.Scheme != "" && parsedURL.Host != "" {
-		baseURL = fmt.Sprintf("%s://%s", parsedURL.Scheme, hostWithDefaultPort(parsedURL))
+		baseURL = fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
 	} else if parsedURL.Host != "" {
 		baseURL = "//" + parsedURL.Host
 	}
@@ -331,29 +329,52 @@ func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 	return strings.TrimRight(baseURL, "/"), parsedURL.EscapedPath(), nil
 }
 
-func hostWithDefaultPort(parsedURL *url.URL) string {
-	if parsedURL == nil {
-		return ""
-	}
-	if parsedURL.Host == "" || parsedURL.Port() != "" {
-		return parsedURL.Host
-	}
-
-	var defaultPort string
-	switch strings.ToLower(parsedURL.Scheme) {
-	case "http":
-		defaultPort = "80"
-	case "https":
-		defaultPort = "443"
-	default:
-		return parsedURL.Host
+// NormalizeBaseURLForIdentity returns a stable origin key for route comparison
+// and result bucketing without changing the URL used for outbound requests.
+// HTTP(S) origins include their effective port so implicit and explicit default
+// ports collapse into the same identity. Userinfo is intentionally excluded.
+func NormalizeBaseURLForIdentity(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return strings.TrimRight(rawURL, "/")
 	}
 
-	host := net.JoinHostPort(parsedURL.Hostname(), defaultPort)
-	if parsedURL.User != nil {
-		host = parsedURL.User.String() + "@" + host
+	scheme := strings.ToLower(parsedURL.Scheme)
+	host := strings.ToLower(parsedURL.Hostname())
+	port := parsedURL.Port()
+	if port == "" {
+		switch scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
 	}
-	return host
+	if port != "" {
+		host = net.JoinHostPort(host, port)
+	}
+
+	return fmt.Sprintf("%s://%s", scheme, host)
+}
+
+// NormalizeURLForIdentity returns a stable request URL key for visited-route
+// deduplication while preserving the original URL for the actual request.
+func NormalizeURLForIdentity(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	baseURL := NormalizeBaseURLForIdentity(rawURL)
+	if baseURL == "" {
+		return rawURL
+	}
+
+	identity := baseURL + parsedURL.EscapedPath()
+	if parsedURL.RawQuery != "" {
+		identity += "?" + parsedURL.RawQuery
+	}
+	return identity
 }
 
 // IsURLAllowed checks if a target URL is allowed based on the scope anchor, host

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -312,7 +312,9 @@ func URLRemoveQueryParams(rawURL string) (string, error) {
 	return parsedURL.String(), nil
 }
 
-// SplitURLBaseAndPath returns the URL origin and escaped path as separate route fields.
+// SplitURLBaseAndPath returns the URL origin and escaped path as separate route
+// fields. HTTP(S) origins always include their effective port so implicit and
+// explicit default-port URLs collapse into the same route/application bucket.
 func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -321,12 +323,37 @@ func SplitURLBaseAndPath(rawURL string) (string, string, error) {
 
 	baseURL := ""
 	if parsedURL.Scheme != "" && parsedURL.Host != "" {
-		baseURL = fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+		baseURL = fmt.Sprintf("%s://%s", parsedURL.Scheme, hostWithDefaultPort(parsedURL))
 	} else if parsedURL.Host != "" {
 		baseURL = "//" + parsedURL.Host
 	}
 
 	return strings.TrimRight(baseURL, "/"), parsedURL.EscapedPath(), nil
+}
+
+func hostWithDefaultPort(parsedURL *url.URL) string {
+	if parsedURL == nil {
+		return ""
+	}
+	if parsedURL.Host == "" || parsedURL.Port() != "" {
+		return parsedURL.Host
+	}
+
+	var defaultPort string
+	switch strings.ToLower(parsedURL.Scheme) {
+	case "http":
+		defaultPort = "80"
+	case "https":
+		defaultPort = "443"
+	default:
+		return parsedURL.Host
+	}
+
+	host := net.JoinHostPort(parsedURL.Hostname(), defaultPort)
+	if parsedURL.User != nil {
+		host = parsedURL.User.String() + "@" + host
+	}
+	return host
 }
 
 // IsURLAllowed checks if a target URL is allowed based on the scope anchor, host

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -407,11 +407,7 @@ func buildWebApplications(routes []*discover.RouteDetails, staticAssetsByBaseURL
 			staticAssetDetails = &discover.StaticAssetDetails{}
 		}
 		for _, staticAsset := range discoverroutehelpers.MergeStaticAssets(staticAssets) {
-			staticAssetBaseURL, _, err := discoverroutehelpers.SplitURLBaseAndPath(staticAsset)
-			if err != nil {
-				continue
-			}
-			if staticAssetBaseURL == baseURL {
+			if utils.IsHostInScope(baseURL, staticAsset) {
 				staticAssetDetails.Local = append(staticAssetDetails.Local, staticAsset)
 			} else {
 				staticAssetDetails.Remote = append(staticAssetDetails.Remote, staticAsset)

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -377,6 +377,7 @@ func buildWebApplications(routes []*discover.RouteDetails, staticAssetsByBaseURL
 		if baseURL == "" {
 			return nil
 		}
+		baseURL = discoverroutehelpers.NormalizeBaseURLForIdentity(baseURL)
 		if webApplication, ok := webApplicationsByBaseURL[baseURL]; ok {
 			return webApplication
 		}
@@ -393,7 +394,9 @@ func buildWebApplications(routes []*discover.RouteDetails, staticAssetsByBaseURL
 		if webApplication == nil {
 			continue
 		}
-		webApplication.Routes = append(webApplication.Routes, route)
+		outputRoute := *route
+		outputRoute.BaseUrl = discoverroutehelpers.NormalizeBaseURLForIdentity(route.BaseUrl)
+		webApplication.Routes = append(webApplication.Routes, &outputRoute)
 	}
 
 	for baseURL, staticAssets := range staticAssetsByBaseURL {
@@ -407,7 +410,7 @@ func buildWebApplications(routes []*discover.RouteDetails, staticAssetsByBaseURL
 			staticAssetDetails = &discover.StaticAssetDetails{}
 		}
 		for _, staticAsset := range discoverroutehelpers.MergeStaticAssets(staticAssets) {
-			if utils.IsHostInScope(baseURL, staticAsset) {
+			if utils.IsHostInScope(webApplication.BaseUrl, staticAsset) {
 				staticAssetDetails.Local = append(staticAssetDetails.Local, staticAsset)
 			} else {
 				staticAssetDetails.Remote = append(staticAssetDetails.Remote, staticAsset)
@@ -504,12 +507,13 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 				defer func() { <-semaphore }() // Release semaphore when done
 
 				// Skip if already visited
+				targetURLIdentity := discoverroutehelpers.NormalizeURLForIdentity(targetURL)
 				mu.Lock()
-				if _, visited := visitedURLs[targetURL]; visited {
+				if _, visited := visitedURLs[targetURLIdentity]; visited {
 					mu.Unlock()
 					return
 				}
-				visitedURLs[targetURL] = struct{}{}
+				visitedURLs[targetURLIdentity] = struct{}{}
 				mu.Unlock()
 
 				// Parse the URL to preserve query parameters
@@ -586,8 +590,9 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 					}
 					// Visit the base route (without parameters)
 					baseRouteURL := route.BaseUrl + route.Path
+					baseRouteURLIdentity := discoverroutehelpers.NormalizeURLForIdentity(baseRouteURL)
 					mu.Lock()
-					if _, visited := visitedURLs[baseRouteURL]; !visited {
+					if _, visited := visitedURLs[baseRouteURLIdentity]; !visited {
 						nextDepthMu.Lock()
 						nextDepthUrls = append(nextDepthUrls, baseRouteURL)
 						nextDepthMu.Unlock()
@@ -600,7 +605,8 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 						allParameterURLs := buildAllParameterURLs(route)
 						mu.Lock()
 						for _, paramURL := range allParameterURLs {
-							if _, visited := visitedURLs[paramURL]; !visited {
+							paramURLIdentity := discoverroutehelpers.NormalizeURLForIdentity(paramURL)
+							if _, visited := visitedURLs[paramURLIdentity]; !visited {
 								nextDepthMu.Lock()
 								nextDepthUrls = append(nextDepthUrls, paramURL)
 								nextDepthMu.Unlock()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how routes are merged, spider queues dedupe, and static assets are bucketed—could alter discovery coverage or output grouping without touching request URLs.
> 
> **Overview**
> Introduces **stable URL identity helpers** so discovery treats equivalent origins and request URLs the same for merging and crawling, without changing the URLs used for actual HTTP requests.
> 
> **`NormalizeBaseURLForIdentity`** lowercases scheme/host, fills implicit HTTP/HTTPS default ports (so `https://host` and `https://host:443` share one key), and drops userinfo. It is used when **merging routes** (`MergeWebRoutes`), **grouping web applications**, and **normalizing `BaseUrl` on output routes**.
> 
> **`NormalizeURLForIdentity`** builds a full-path+query identity from that origin. The **spider** uses it for `visitedURLs` and when enqueueing base routes and parameter URLs, so duplicate visits from spelling/port variants are skipped while requests still use the original strings.
> 
> **Static asset local vs remote** classification no longer compares split base URL strings to the web app bucket key; it uses **`IsHostInScope`** against the normalized web application base URL, aligning “local” with scope rather than exact origin string match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41d891d8867087778cfe517eb9d242c8b39241d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->