### PR TITLE
Upgrade Go

### DIFF
--- a/.github/workflows/code-gen.yml
+++ b/.github/workflows/code-gen.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
 
       - name: Generate Embedded Asset Archives

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
 
 jobs:
   prepare-linux-arm:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
 
       - name: Install Dependencies

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # Dockerfile used for the compilation of the statically compiled webscan binary
-FROM golang:1.26.3-alpine3.22 AS base
+FROM golang:1.26.4-alpine3.22 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="webscan"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Method-Security/webscan
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Method-Security/pkg v0.1.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level toolchain bump only; no application or dependency logic changes in the diff.
> 
> **Overview**
> Bumps the project’s Go toolchain from **1.26.3** to **1.26.4** so local builds, CI, and container builds stay aligned.
> 
> The `go` directive in `go.mod` is updated, and the same version is applied in **GitHub Actions** (`code-gen`, `verify`, and the shared `GO_VERSION` in `reusable-build`) plus the **`Dockerfile.builder`** base image (`golang:1.26.4-alpine3.22`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b60188e4f2a38cb4701ad1cb2f8280de4bb0fe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->