### PR TITLE
go 1.26.5

### DIFF
--- a/.github/workflows/code-gen.yml
+++ b/.github/workflows/code-gen.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Generate Embedded Asset Archives

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   prepare-linux-arm:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install Dependencies

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # Dockerfile used for the compilation of the statically compiled webscan binary
-FROM golang:1.26.4-alpine3.22 AS base
+FROM golang:1.26.5-alpine3.23 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="webscan"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Method-Security/webscan
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Method-Security/pkg v0.1.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level toolchain and base-image updates only; no application logic changes.
> 
> **Overview**
> Bumps the project toolchain from **Go 1.26.4** to **Go 1.26.5** so local builds, CI, and release images stay aligned.
> 
> `go.mod`’s `go` directive is updated, and GitHub Actions workflows (`code-gen`, `verify`, and reusable build via `GO_VERSION`) now install **1.26.5**. The builder image base moves to `golang:1.26.5-alpine3.23` (Alpine **3.22 → 3.23** alongside the Go bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee02cb1620e1bf0686e625bd25bf3fe5200608d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->