### PR TITLE
Update Static Asset Extensions List

### DIFF
--- a/utils/general.go
+++ b/utils/general.go
@@ -71,7 +71,7 @@ func ParseResponseCodes(responseCodes string) (map[int]bool, error) {
 // IsStaticAsset returns true if the URL is a static asset, false otherwise
 func IsStaticAsset(url string) bool {
 	staticExts := []string{
-		".7z", ".avif", ".bmp", ".cjs", ".css", ".csv",
+		".7z", ".assetx", ".avif", ".bmp", ".cjs", ".css", ".csv",
 		".doc", ".docx", ".eot", ".gif", ".gz", ".ico",
 		".ini", ".jpg", ".jpeg", ".js", ".jsx", ".json",
 		".less", ".m4a", ".m4v", ".map", ".markdown", ".md",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-extension allowlist update with no logic, auth, or data-handling changes.
> 
> **Overview**
> Adds **`.assetx`** to the static file extensions recognized by `IsStaticAsset`, so URLs with that suffix are treated as static assets during route discovery and related filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d47941162383053175cc040e3e003232ed09a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->