### PR TITLE
Update Swagger Headless Grab Redirect

### DIFF
--- a/internal/enumerate/apiapplication/swagger.go
+++ b/internal/enumerate/apiapplication/swagger.go
@@ -300,7 +300,7 @@ func findOpenAPISpec(ctx context.Context, target string, timeout int, verifyTls 
 					MinDomStabalizeTime: 5,
 				}
 
-				headlessRequestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, swaggerProbeMaxRedirects, true, timeout, verifyTls, userAgent, common.RequestMethodHeadless, headlessConfig, headers)
+				headlessRequestConfig := createSendHTTPRequestConfig(baseURL, parsedTargetPath, swaggerInitialMaxRedirects, true, timeout, verifyTls, userAgent, common.RequestMethodHeadless, headlessConfig, headers)
 				headlessResponse, err := request.SendRequest(ctx, headlessRequestConfig)
 
 				if err == nil && headlessResponse.Response != nil && headlessResponse.Response.StatusCode != nil &&


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-parameter change in Swagger discovery only; improves UI reachability without altering spec probe redirect behavior.
> 
> **Overview**
> When Swagger UI is detected, the **headless** render step now follows up to **10 redirects** (`swaggerInitialMaxRedirects`), matching the initial standard GET in `findOpenAPISpec`.
> 
> Previously that headless request used `swaggerProbeMaxRedirects` (**0**), so UI pages behind login or path redirects could fail to load while the first probe succeeded. Direct spec path probes are unchanged and still use zero redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c10de0b51085923d22d1bf0866724c10e5330f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->