### PR TITLE
Have CI install the latest Go 1.26.x patch instead of a pinned patch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26"
 
 jobs:
   prepare-linux-arm:
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
       - name: Generate Embedded Asset Archives
         run: go generate ./configs
@@ -85,6 +86,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
       - name: Generate Embedded Asset Archives
         run: go generate ./configs
@@ -150,6 +152,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
       - name: Generate Embedded Asset Archives
         run: go generate ./configs
@@ -218,6 +221,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
       - name: Generate Embedded Asset Archives
         run: go generate ./configs

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -90,8 +90,14 @@ jobs:
           cache: true
       - name: Generate Embedded Asset Archives
         run: go generate ./configs
+      - name: Resolve Go patch version for builder image
+        id: go-patch
+        run: echo "version=$(go env GOVERSION | sed 's/^go//')" >> "$GITHUB_OUTPUT"
       - name: Build AMD64 Builder Image
-        run: docker buildx build . --platform linux/amd64 --load --tag amdbuilder -f Dockerfile.builder
+        run: >
+          docker buildx build . --platform linux/amd64 --pull --load --tag amdbuilder
+          -f Dockerfile.builder
+          --build-arg GO_VERSION=${{ steps.go-patch.outputs.version }}
       - name: Build AMD64 Image
         run: |
           docker run -v $PWD:/app/webscan \

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26"
+          check-latest: true
           cache: true
 
       - name: Install Dependencies

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,8 @@
-# Dockerfile used for the compilation of the statically compiled webscan binary
-FROM golang:1.26.5-alpine3.23 AS base
+# Dockerfile used for the compilation of the statically compiled webscan binary.
+# GO_VERSION defaults to the minor line so local builds float with the latest
+# 1.26.x image; CI passes the exact patch resolved by actions/setup-go.
+ARG GO_VERSION=1.26
+FROM golang:${GO_VERSION}-alpine3.23 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="webscan"
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Use a fuzzy `go-version` (`1.26`) with `check-latest: true` in `reusable-build.yml` and `verify.yml` so CI always installs the newest available 1.26 patch release instead of a version pinned to a specific patch.
- `go.mod` is left unchanged, keeping its exact minimum version pin.

## Test plan
- [ ] CI (verify/reusable-build workflows) runs green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI Go version selection and builder image tagging; application code and go.mod minimum version are untouched.
> 
> **Overview**
> CI no longer pins Go **1.26.5**; **`reusable-build.yml`** and **`verify.yml`** now use **`go-version: "1.26"`** with **`check-latest: true`** so each run installs the newest **1.26.x** patch. **`go.mod`** is unchanged.
> 
> The **linux/amd64** Docker builder path is aligned with that choice: a step reads the resolved patch from **`go env GOVERSION`**, passes it as **`GO_VERSION`** to **`Dockerfile.builder`**, and the **`docker buildx`** step adds **`--pull`**. **`Dockerfile.builder`** drops the fixed **`golang:1.26.5`** tag in favor of a **`GO_VERSION`** build arg (default **`1.26`** for local builds; CI supplies the exact patch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e67d9daad01a6be0e1ec62f12de1d310d6cf1de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->