### PR TITLE
Fix interpolated route prefix, method and parameter naming

### DIFF
--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -261,6 +261,21 @@ var leadingInterpolationPattern = regexp.MustCompile(`^\$\{[^}]*\}`)
 
 var interpolationPattern = regexp.MustCompile(`\$\{([^}]*)\}`)
 
+// enclosingVerbCallPattern matches the HTTP verb of the call the literal sits directly inside.
+var enclosingVerbCallPattern = regexp.MustCompile(`\.(get|post|put|patch|delete|head|options)\s*(?:<[^<>()]*>)?\s*\(\s*$`)
+
+// fetchOptionsMethodPattern matches the method of a fetch-style options object following the URL.
+var fetchOptionsMethodPattern = regexp.MustCompile(`^\s*,\s*\{[^{}]{0,200}?method\s*:\s*['"]([A-Za-z]+)['"]`)
+
+// identifierPattern matches a bare JavaScript identifier.
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_$][\w$]*$`)
+
+// absoluteURLPrefixPattern matches the scheme and host of an absolute URL.
+var absoluteURLPrefixPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.-]*://[^/]*`)
+
+// enclosingVerbLookback bounds how far the verb of the enclosing call may sit from the literal.
+const enclosingVerbLookback = 120
+
 // An interpolation in a URL position is evidence a parameter exists there.
 func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*discover.RouteDetails {
 	origin, _, err := discoverroutehelpers.SplitURLBaseAndPath(sourceURL)
@@ -268,25 +283,44 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 		return nil
 	}
 
-	seen := map[string]struct{}{}
+	type routeIdentity struct {
+		method   common.HttpMethod
+		template string
+	}
+	seen := map[routeIdentity]struct{}{}
 	var routes []*discover.RouteDetails
 
-	for _, match := range templateLiteralPattern.FindAllStringSubmatch(content, -1) {
-		template, params, ok := interpolatedTemplateFrom(match[1])
+	for _, location := range templateLiteralPattern.FindAllStringSubmatchIndex(content, -1) {
+		literal := content[location[2]:location[3]]
+
+		method, methodOK := enclosingRequestMethod(content, location[0], location[1])
+		if !methodOK {
+			continue
+		}
+
+		prefix, prefixOK := resolveInterpolatedBasePrefix(content, literal)
+		if !prefixOK {
+			continue
+		}
+
+		template, params, ok := interpolatedTemplateFrom(literal)
 		if !ok {
 			continue
 		}
-		if _, exists := seen[template]; exists {
+		template = prefix + template
+
+		identity := routeIdentity{method: method, template: template}
+		if _, exists := seen[identity]; exists {
 			continue
 		}
-		seen[template] = struct{}{}
+		seen[identity] = struct{}{}
 
 		evidence := discoverroutehelpers.InterpolatedRouteEvidence
 		templateValue := template
 		routes = append(routes, &discover.RouteDetails{
 			BaseUrl:      origin,
 			Path:         template,
-			Method:       common.HttpMethodGet,
+			Method:       method,
 			PathParams:   params,
 			PathTemplate: &templateValue,
 			Evidence:     &evidence,
@@ -294,6 +328,69 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 	}
 
 	return routes
+}
+
+// enclosingRequestMethod reads the verb of the call the literal sits in; a default would mislabel
+// every POST, PUT and DELETE as a GET.
+func enclosingRequestMethod(content string, literalStart int, literalEnd int) (common.HttpMethod, bool) {
+	windowStart := literalStart - enclosingVerbLookback
+	if windowStart < 0 {
+		windowStart = 0
+	}
+	if match := enclosingVerbCallPattern.FindStringSubmatch(content[windowStart:literalStart]); match != nil {
+		return parseRouteMethod(match[1])
+	}
+
+	windowEnd := literalEnd + enclosingVerbLookback
+	if windowEnd > len(content) {
+		windowEnd = len(content)
+	}
+	if match := fetchOptionsMethodPattern.FindStringSubmatch(content[literalEnd:windowEnd]); match != nil {
+		return parseRouteMethod(match[1])
+	}
+	return "", false
+}
+
+// resolveInterpolatedBasePrefix returns the path an interpolated base contributes. An API base is
+// routinely a variable holding `${host}/api/v2`, so treating it as origin-only drops the prefix and
+// reports an endpoint that does not exist.
+func resolveInterpolatedBasePrefix(content string, literal string) (string, bool) {
+	leading := leadingInterpolationPattern.FindString(literal)
+	if leading == "" {
+		return "", true
+	}
+
+	expression := strings.TrimSuffix(strings.TrimPrefix(leading, "${"), "}")
+	parts := strings.Split(strings.TrimSpace(expression), ".")
+	name := parts[len(parts)-1]
+	if !identifierPattern.MatchString(name) {
+		return "", false
+	}
+
+	assignments := regexp.MustCompile(
+		`(?:^|[^\w$.])`+regexp.QuoteMeta(name)+`\s*[:=]\s*`+"[`\"']([^`\"']*)[`\"']",
+	).FindAllStringSubmatch(content, -1)
+	distinct := map[string]struct{}{}
+	for _, assignment := range assignments {
+		distinct[assignment[1]] = struct{}{}
+	}
+	// Minified bundles reuse short names, so conflicting assignments mean the base is unknown.
+	if len(distinct) != 1 {
+		return "", false
+	}
+
+	value := assignments[0][1]
+	value = leadingInterpolationPattern.ReplaceAllString(value, "")
+	value = absoluteURLPrefixPattern.ReplaceAllString(value, "")
+	value = strings.TrimSuffix(value, "/")
+	if value == "" {
+		return "", true
+	}
+	// A residual interpolation means part of the prefix is still unknown.
+	if strings.Contains(value, "${") || !strings.HasPrefix(value, "/") {
+		return "", false
+	}
+	return value, true
 }
 
 // interpolatedTemplateFrom converts a template literal into a `{name}` path template.
@@ -318,10 +415,6 @@ func interpolatedTemplateFrom(literal string) (string, []*discover.RoutePathPara
 		if !strings.Contains(segment, "${") {
 			continue
 		}
-		previousSegment := ""
-		if i > 0 {
-			previousSegment = segments[i-1]
-		}
 		rewritten := segment
 		for {
 			location := interpolationPattern.FindStringSubmatchIndex(rewritten)
@@ -330,7 +423,7 @@ func interpolatedTemplateFrom(literal string) (string, []*discover.RoutePathPara
 			}
 			expression := rewritten[location[2]:location[3]]
 			name := discoverroutehelpers.UniqueParamName(
-				discoverroutehelpers.InterpolatedParamName(expression, rewritten[:location[0]], previousSegment),
+				discoverroutehelpers.InterpolatedParamName(expression, rewritten[:location[0]], i),
 				taken,
 			)
 			taken[name] = struct{}{}

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -270,6 +270,9 @@ var fetchOptionsMethodPattern = regexp.MustCompile(`^\s*,\s*\{[^{}]{0,200}?metho
 // identifierPattern matches a bare JavaScript identifier.
 var identifierPattern = regexp.MustCompile(`^[A-Za-z_$][\w$]*$`)
 
+// protocolRelativePrefixPattern matches the host of a protocol-relative URL.
+var protocolRelativePrefixPattern = regexp.MustCompile(`^//[^/]*`)
+
 // absoluteURLPrefixPattern matches the scheme and host of an absolute URL.
 var absoluteURLPrefixPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.-]*://[^/]*`)
 
@@ -301,7 +304,7 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 
 		prefix, prefixOK := resolveInterpolatedBasePrefix(content, literal)
 
-		template, params, ok := interpolatedTemplateFrom(literal)
+		template, params, ok := interpolatedTemplateFrom(literal, prefixOK)
 		if !ok {
 			continue
 		}
@@ -309,6 +312,11 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 		evidence := discoverroutehelpers.InterpolatedRouteEvidence
 		if prefixOK {
 			template = prefix + template
+			template, params = discoverroutehelpers.RenumberPositionalParams(template, params)
+			// Without a fixed segment the template matches every path of that length.
+			if !discoverroutehelpers.HasLiteralSegment(strings.Split(template, "/")) {
+				continue
+			}
 		} else {
 			// The base may hold a path, so leave rooting to corroboration against observed routes.
 			evidence = discoverroutehelpers.UnrootedEvidenceFor(interpolatedBaseName(literal))
@@ -426,6 +434,7 @@ func resolveInterpolatedBasePrefix(content string, literal string) (string, bool
 	value := assignments[0][1]
 	value = leadingInterpolationPattern.ReplaceAllString(value, "")
 	value = absoluteURLPrefixPattern.ReplaceAllString(value, "")
+	value = protocolRelativePrefixPattern.ReplaceAllString(value, "")
 	value = strings.TrimSuffix(value, "/")
 	if value == "" {
 		return "", true
@@ -438,7 +447,7 @@ func resolveInterpolatedBasePrefix(content string, literal string) (string, bool
 }
 
 // interpolatedTemplateFrom converts a template literal into a `{name}` path template.
-func interpolatedTemplateFrom(literal string) (string, []*discover.RoutePathParam, bool) {
+func interpolatedTemplateFrom(literal string, prefixKnown bool) (string, []*discover.RoutePathParam, bool) {
 	path := leadingInterpolationPattern.ReplaceAllString(literal, "")
 	path = strings.SplitN(path, "?", 2)[0]
 	path = strings.SplitN(path, "#", 2)[0]
@@ -481,8 +490,8 @@ func interpolatedTemplateFrom(literal string) (string, []*discover.RoutePathPara
 		return "", nil, false
 	}
 
-	// A leading placeholder means the discarded base carried the real prefix.
-	if len(segments) > 1 && strings.HasPrefix(segments[1], "{") {
+	// A leading placeholder is only unusable while the base it followed is still unknown.
+	if !prefixKnown && len(segments) > 1 && strings.HasPrefix(segments[1], "{") {
 		return "", nil, false
 	}
 

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -286,6 +286,7 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 	type routeIdentity struct {
 		method   common.HttpMethod
 		template string
+		base     string
 	}
 	seen := map[routeIdentity]struct{}{}
 	var routes []*discover.RouteDetails
@@ -313,7 +314,8 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 			evidence = discoverroutehelpers.UnrootedEvidenceFor(interpolatedBaseName(literal))
 		}
 
-		identity := routeIdentity{method: method, template: template}
+		// Two bases can share a tail; keeping both lets either one corroborate.
+		identity := routeIdentity{method: method, template: template, base: evidence}
 		if _, exists := seen[identity]; exists {
 			continue
 		}

--- a/internal/discover/route/helpers/extractors/jsExtractors.go
+++ b/internal/discover/route/helpers/extractors/jsExtractors.go
@@ -299,15 +299,19 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 		}
 
 		prefix, prefixOK := resolveInterpolatedBasePrefix(content, literal)
-		if !prefixOK {
-			continue
-		}
 
 		template, params, ok := interpolatedTemplateFrom(literal)
 		if !ok {
 			continue
 		}
-		template = prefix + template
+
+		evidence := discoverroutehelpers.InterpolatedRouteEvidence
+		if prefixOK {
+			template = prefix + template
+		} else {
+			// The base may hold a path, so leave rooting to corroboration against observed routes.
+			evidence = discoverroutehelpers.UnrootedEvidenceFor(interpolatedBaseName(literal))
+		}
 
 		identity := routeIdentity{method: method, template: template}
 		if _, exists := seen[identity]; exists {
@@ -315,7 +319,6 @@ func ExtractInterpolatedRouteTemplates(content string, sourceURL string) []*disc
 		}
 		seen[identity] = struct{}{}
 
-		evidence := discoverroutehelpers.InterpolatedRouteEvidence
 		templateValue := template
 		routes = append(routes, &discover.RouteDetails{
 			BaseUrl:      origin,
@@ -348,7 +351,46 @@ func enclosingRequestMethod(content string, literalStart int, literalEnd int) (c
 	if match := fetchOptionsMethodPattern.FindStringSubmatch(content[literalEnd:windowEnd]); match != nil {
 		return parseRouteMethod(match[1])
 	}
+
+	if navigationSinkPattern.MatchString(content[windowStart:literalStart]) {
+		return common.HttpMethodGet, true
+	}
+	if assigned := assignedVariablePattern.FindStringSubmatch(content[windowStart:literalStart]); assigned != nil {
+		if navigationSinkArgumentPattern(assigned[1]).MatchString(content[literalEnd:windowEnd]) {
+			return common.HttpMethodGet, true
+		}
+	}
 	return "", false
+}
+
+// navigationSinkPattern matches a browser navigation taking the literal directly; navigation is a
+// GET by definition rather than an inferred default.
+var navigationSinkPattern = regexp.MustCompile(`(?:window\.open|location\.(?:href|assign|replace))\s*(?:=\s*|\(\s*)$`)
+
+// assignedVariablePattern captures the variable a literal is assigned to.
+var assignedVariablePattern = regexp.MustCompile(`(?:^|[^\w$])([A-Za-z_$][\w$]*)\s*=\s*$`)
+
+// navigationSinkArgumentPattern matches that variable later reaching a navigation sink.
+func navigationSinkArgumentPattern(name string) *regexp.Regexp {
+	return regexp.MustCompile(
+		`(?:window\.open|location\.(?:href|assign|replace))\s*(?:=\s*|\(\s*)` + regexp.QuoteMeta(name) + `\b`,
+	)
+}
+
+// interpolatedBaseName returns the identifier of the leading interpolation, used to share a
+// corroborated prefix between candidates built from the same base.
+func interpolatedBaseName(literal string) string {
+	leading := leadingInterpolationPattern.FindString(literal)
+	if leading == "" {
+		return ""
+	}
+	expression := strings.TrimSuffix(strings.TrimPrefix(leading, "${"), "}")
+	parts := strings.Split(strings.TrimSpace(expression), ".")
+	name := parts[len(parts)-1]
+	if !identifierPattern.MatchString(name) {
+		return ""
+	}
+	return name
 }
 
 // resolveInterpolatedBasePrefix returns the path an interpolated base contributes. An API base is

--- a/internal/discover/route/helpers/pathparams.go
+++ b/internal/discover/route/helpers/pathparams.go
@@ -312,6 +312,9 @@ func MergePathParams(params1 []*discover.RoutePathParam, params2 []*discover.Rou
 // InterpolatedRouteEvidence marks a route whose parameter is proven but only loosely named.
 const InterpolatedRouteEvidence = "interpolated"
 
+// wrapperCallArgumentPattern unwraps a call with one identifier argument, e.g. encodeURIComponent(id).
+var wrapperCallArgumentPattern = regexp.MustCompile(`^[A-Za-z_$][\w$.]*\(\s*([A-Za-z_$][\w$.]*)\s*\)$`)
+
 var identifierExpressionPattern = regexp.MustCompile(`^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$`)
 
 var trailingWordPattern = regexp.MustCompile(`([A-Za-z][A-Za-z0-9]*)[^A-Za-z0-9]*$`)
@@ -341,7 +344,15 @@ func trailingWord(fragment string) string {
 }
 
 // InterpolatedParamName derives a name; unlike a declaration it is a best effort, not authoritative.
-func InterpolatedParamName(expression string, segmentPrefix string, previousSegment string) string {
+//
+// The preceding path segment is deliberately not used. It is as often a verb or a generic token as
+// a resource, which produced names like lockId and idId, and it varies with the call site so one
+// route family fragments into differently named duplicates. A positional name is stable and does
+// not claim a meaning the bundle never carried.
+func InterpolatedParamName(expression string, segmentPrefix string, segmentIndex int) string {
+	if unwrapped := wrapperCallArgumentPattern.FindStringSubmatch(expression); unwrapped != nil {
+		expression = unwrapped[1]
+	}
 	if identifierExpressionPattern.MatchString(expression) {
 		parts := strings.Split(expression, ".")
 		last := parts[len(parts)-1]
@@ -353,10 +364,7 @@ func InterpolatedParamName(expression string, segmentPrefix string, previousSegm
 	if word := trailingWord(segmentPrefix); word != "" {
 		return singularize(word) + "Id"
 	}
-	if word := trailingWord(previousSegment); word != "" {
-		return singularize(word) + "Id"
-	}
-	return "param"
+	return fmt.Sprintf("param%d", segmentIndex)
 }
 
 // Names must be unique per route: the ontology keys on (parameter_name, parameter_location).

--- a/internal/discover/route/helpers/pathparams.go
+++ b/internal/discover/route/helpers/pathparams.go
@@ -243,10 +243,14 @@ func EvidenceRank(evidence *string) int {
 	if evidence == nil {
 		return 0
 	}
-	switch *evidence {
-	case DeclaredRouteEvidence:
+	switch {
+	case *evidence == DeclaredRouteEvidence:
 		return 3
-	case InterpolatedRouteEvidence:
+	case *evidence == InterpolatedRouteEvidence:
+		return 2
+	// An unrooted candidate is derivation provenance too; losing the tag would skip rooting and let
+	// the unprefixed tail reach the report.
+	case IsUnrootedEvidence(evidence):
 		return 2
 	default:
 		return 1

--- a/internal/discover/route/helpers/pathparams.go
+++ b/internal/discover/route/helpers/pathparams.go
@@ -63,14 +63,14 @@ func NormalizeDeclaredTemplate(path string) (string, []*discover.RoutePathParam,
 		}
 	}
 	// Without a literal segment the template discriminates on segment count alone.
-	if !hasLiteralSegment(segments) {
+	if !HasLiteralSegment(segments) {
 		return path, nil, false
 	}
 	return strings.Join(segments, "/"), params, true
 }
 
-// hasLiteralSegment reports whether any segment is fixed rather than a placeholder.
-func hasLiteralSegment(segments []string) bool {
+// HasLiteralSegment reports whether any segment is fixed rather than a placeholder.
+func HasLiteralSegment(segments []string) bool {
 	for _, segment := range segments {
 		if segment == "" {
 			continue
@@ -364,8 +364,9 @@ func trailingWord(fragment string) string {
 // route family fragments into differently named duplicates. A positional name is stable and does
 // not claim a meaning the bundle never carried.
 func InterpolatedParamName(expression string, segmentPrefix string, segmentIndex int) string {
+	expression = strings.TrimSpace(expression)
 	if unwrapped := wrapperCallArgumentPattern.FindStringSubmatch(expression); unwrapped != nil {
-		expression = unwrapped[1]
+		expression = strings.TrimSpace(unwrapped[1])
 	}
 	if identifierExpressionPattern.MatchString(expression) {
 		parts := strings.Split(expression, ".")
@@ -390,4 +391,37 @@ func UniqueParamName(name string, taken map[string]struct{}) string {
 		}
 		candidate = fmt.Sprintf("%s%d", name, suffix)
 	}
+}
+
+// positionalParamPattern matches a synthesized positional name.
+var positionalParamPattern = regexp.MustCompile(`^param\d+$`)
+
+// RenumberPositionalParams renumbers synthesized names against the final path, so the same endpoint
+// written with and without an interpolated base yields the same names instead of splitting in two.
+func RenumberPositionalParams(template string, params []*discover.RoutePathParam) (string, []*discover.RoutePathParam) {
+	segments := strings.Split(template, "/")
+	renamed := map[string]string{}
+
+	for i, segment := range segments {
+		rewritten := segment
+		for _, location := range embeddedPlaceholderPattern.FindAllStringSubmatchIndex(segment, -1) {
+			name := segment[location[2]:location[3]]
+			if !positionalParamPattern.MatchString(name) {
+				continue
+			}
+			renamed[name] = fmt.Sprintf("param%d", i)
+			rewritten = strings.Replace(rewritten, "{"+name+"}", "{"+renamed[name]+"}", 1)
+		}
+		segments[i] = rewritten
+	}
+	if len(renamed) == 0 {
+		return template, params
+	}
+
+	for _, param := range params {
+		if replacement, ok := renamed[param.Name]; ok {
+			param.Name = replacement
+		}
+	}
+	return strings.Join(segments, "/"), params
 }

--- a/internal/discover/route/helpers/pathparams.go
+++ b/internal/discover/route/helpers/pathparams.go
@@ -158,6 +158,16 @@ func ApplyDeclaredRouteTemplates(routes []*discover.RouteDetails) []*discover.Ro
 		template string
 	}
 
+	// An unrooted candidate carries a path resolution never confirmed, so it must not reach output.
+	rooted := make([]*discover.RouteDetails, 0, len(routes))
+	for _, route := range routes {
+		if IsUnrootedEvidence(route.Evidence) {
+			continue
+		}
+		rooted = append(rooted, route)
+	}
+	routes = rooted
+
 	var templates []templateRoute
 	declaredLiterals := map[string]struct{}{}
 	for _, route := range routes {

--- a/internal/discover/route/helpers/unrooted.go
+++ b/internal/discover/route/helpers/unrooted.go
@@ -1,0 +1,168 @@
+package discoverroute
+
+import (
+	"strings"
+
+	"github.com/Method-Security/webscan/generated/go/discover"
+)
+
+// InterpolatedUnrootedEvidence marks an interpolated route whose base could not be resolved inside
+// the bundle. It is an intermediate state: ResolveUnrootedInterpolatedRoutes either roots the route
+// against corroborating evidence or drops it, so it never reaches the report.
+const InterpolatedUnrootedEvidence = "interpolated-unrooted"
+
+// UnrootedEvidenceFor tags a candidate with the base it was built from, so candidates sharing a base
+// can share whatever prefix corroboration establishes for it.
+func UnrootedEvidenceFor(baseName string) string {
+	if baseName == "" {
+		return InterpolatedUnrootedEvidence
+	}
+	return InterpolatedUnrootedEvidence + ":" + baseName
+}
+
+// IsUnrootedEvidence reports a candidate awaiting rooting.
+func IsUnrootedEvidence(evidence *string) bool {
+	return evidence != nil && strings.HasPrefix(*evidence, InterpolatedUnrootedEvidence)
+}
+
+// unrootedBaseName returns the base recorded on a candidate, or "" when it carried none.
+func unrootedBaseName(evidence *string) string {
+	if !IsUnrootedEvidence(evidence) {
+		return ""
+	}
+	_, name, found := strings.Cut(*evidence, ":")
+	if !found {
+		return ""
+	}
+	return name
+}
+
+// corroboratingEvidence reports whether a route is evidence the server actually serves that path.
+//
+// Only observed routes qualify. A route-table declaration is a client-side route, so an SPA serving
+// /products while its API lives at /api/v2/products would otherwise confirm the wrong prefix — the
+// same failure this resolution exists to prevent. Strings lifted from a bundle are ambiguous for the
+// same reason, and an interpolated route must never corroborate itself or another candidate.
+func corroboratingEvidence(route *discover.RouteDetails) bool {
+	return route.Evidence == nil
+}
+
+// anchorSegment returns the first literal segment of a path, which is what a candidate is matched on.
+func anchorSegment(path string) (string, bool) {
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || strings.Contains(segment, "{") {
+			continue
+		}
+		return segment, true
+	}
+	return "", false
+}
+
+// ResolveUnrootedInterpolatedRoutes roots interpolated candidates whose base was unresolvable, using
+// the paths the application is already known to serve.
+//
+// A candidate carries the path that followed the interpolated base, so `${base}/basket/{id}` arrives
+// as `/basket/{id}`. Whether that is the real path depends entirely on what the base held, which the
+// bundle may never state. Corroborating against observed routes answers it without assuming: if the
+// application serves paths under `/basket` the candidate is already rooted, and if it instead serves
+// `/api/v2/basket` the candidate is missing that prefix.
+func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
+	anchorsAtRoot := map[string]struct{}{}
+	prefixesByAnchor := map[string]map[string]struct{}{}
+
+	for _, route := range routes {
+		if !corroboratingEvidence(route) {
+			continue
+		}
+		segments := strings.Split(route.Path, "/")
+		for i, segment := range segments {
+			if i == 0 || segment == "" || strings.Contains(segment, "{") {
+				continue
+			}
+			if i == 1 {
+				anchorsAtRoot[segment] = struct{}{}
+				continue
+			}
+			if prefixesByAnchor[segment] == nil {
+				prefixesByAnchor[segment] = map[string]struct{}{}
+			}
+			prefixesByAnchor[segment][strings.Join(segments[:i], "/")] = struct{}{}
+		}
+	}
+
+	// First pass: root every candidate its own anchor corroborates, recording what each base implied.
+	prefixByBase := map[string]map[string]struct{}{}
+	prefixes := make(map[*discover.RouteDetails]string, len(routes))
+	for _, route := range routes {
+		if !IsUnrootedEvidence(route.Evidence) {
+			continue
+		}
+		anchor, ok := anchorSegment(route.Path)
+		if !ok {
+			continue
+		}
+		prefix, ok := corroboratedPrefix(anchor, anchorsAtRoot, prefixesByAnchor)
+		if !ok {
+			continue
+		}
+		prefixes[route] = prefix
+		base := unrootedBaseName(route.Evidence)
+		if base == "" {
+			continue
+		}
+		if prefixByBase[base] == nil {
+			prefixByBase[base] = map[string]struct{}{}
+		}
+		prefixByBase[base][prefix] = struct{}{}
+	}
+
+	resolved := make([]*discover.RouteDetails, 0, len(routes))
+	for _, route := range routes {
+		if !IsUnrootedEvidence(route.Evidence) {
+			resolved = append(resolved, route)
+			continue
+		}
+
+		prefix, rooted := prefixes[route]
+		if !rooted {
+			// Second pass: inherit the prefix corroboration established for the same base, but only
+			// when every corroborated candidate for that base agreed on it.
+			agreed, ok := prefixByBase[unrootedBaseName(route.Evidence)]
+			if !ok || len(agreed) != 1 {
+				continue
+			}
+			for only := range agreed {
+				prefix = only
+			}
+		}
+
+		rootedPath := prefix + route.Path
+		evidence := InterpolatedRouteEvidence
+		route.Path = rootedPath
+		route.PathTemplate = &rootedPath
+		route.Evidence = &evidence
+		resolved = append(resolved, route)
+	}
+
+	return resolved
+}
+
+// corroboratedPrefix returns the prefix the application demonstrably serves this anchor under.
+func corroboratedPrefix(
+	anchor string,
+	anchorsAtRoot map[string]struct{},
+	prefixesByAnchor map[string]map[string]struct{},
+) (string, bool) {
+	if _, rooted := anchorsAtRoot[anchor]; rooted {
+		return "", true
+	}
+	candidates := prefixesByAnchor[anchor]
+	// More than one prefix serves this anchor, so which one applies is unknown.
+	if len(candidates) != 1 {
+		return "", false
+	}
+	for candidate := range candidates {
+		return candidate, true
+	}
+	return "", false
+}

--- a/internal/discover/route/helpers/unrooted.go
+++ b/internal/discover/route/helpers/unrooted.go
@@ -67,31 +67,41 @@ func anchorSegment(path string) (string, bool) {
 // application serves paths under `/basket` the candidate is already rooted, and if it instead serves
 // `/api/v2/basket` the candidate is missing that prefix.
 func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*discover.RouteDetails {
-	anchorsAtRoot := map[string]struct{}{}
-	prefixesByAnchor := map[string]map[string]struct{}{}
+	type originAnchor struct {
+		origin string
+		anchor string
+	}
+	anchorsAtRoot := map[originAnchor]struct{}{}
+	prefixesByAnchor := map[originAnchor]map[string]struct{}{}
 
 	for _, route := range routes {
 		if !corroboratingEvidence(route) {
 			continue
 		}
+		origin := NormalizeBaseURLForIdentity(route.BaseUrl)
 		segments := strings.Split(route.Path, "/")
 		for i, segment := range segments {
 			if i == 0 || segment == "" || strings.Contains(segment, "{") {
 				continue
 			}
+			key := originAnchor{origin: origin, anchor: segment}
 			if i == 1 {
-				anchorsAtRoot[segment] = struct{}{}
+				anchorsAtRoot[key] = struct{}{}
 				continue
 			}
-			if prefixesByAnchor[segment] == nil {
-				prefixesByAnchor[segment] = map[string]struct{}{}
+			if prefixesByAnchor[key] == nil {
+				prefixesByAnchor[key] = map[string]struct{}{}
 			}
-			prefixesByAnchor[segment][strings.Join(segments[:i], "/")] = struct{}{}
+			prefixesByAnchor[key][strings.Join(segments[:i], "/")] = struct{}{}
 		}
 	}
 
 	// First pass: root every candidate its own anchor corroborates, recording what each base implied.
-	prefixByBase := map[string]map[string]struct{}{}
+	type originBase struct {
+		origin string
+		base   string
+	}
+	prefixByBase := map[originBase]map[string]struct{}{}
 	prefixes := make(map[*discover.RouteDetails]string, len(routes))
 	for _, route := range routes {
 		if !IsUnrootedEvidence(route.Evidence) {
@@ -101,7 +111,8 @@ func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*disco
 		if !ok {
 			continue
 		}
-		prefix, ok := corroboratedPrefix(anchor, anchorsAtRoot, prefixesByAnchor)
+		key := originAnchor{origin: NormalizeBaseURLForIdentity(route.BaseUrl), anchor: anchor}
+		prefix, ok := corroboratedPrefix(key, anchorsAtRoot, prefixesByAnchor)
 		if !ok {
 			continue
 		}
@@ -110,10 +121,11 @@ func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*disco
 		if base == "" {
 			continue
 		}
-		if prefixByBase[base] == nil {
-			prefixByBase[base] = map[string]struct{}{}
+		baseKey := originBase{origin: key.origin, base: base}
+		if prefixByBase[baseKey] == nil {
+			prefixByBase[baseKey] = map[string]struct{}{}
 		}
-		prefixByBase[base][prefix] = struct{}{}
+		prefixByBase[baseKey][prefix] = struct{}{}
 	}
 
 	resolved := make([]*discover.RouteDetails, 0, len(routes))
@@ -127,7 +139,10 @@ func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*disco
 		if !rooted {
 			// Second pass: inherit the prefix corroboration established for the same base, but only
 			// when every corroborated candidate for that base agreed on it.
-			agreed, ok := prefixByBase[unrootedBaseName(route.Evidence)]
+			agreed, ok := prefixByBase[originBase{
+				origin: NormalizeBaseURLForIdentity(route.BaseUrl),
+				base:   unrootedBaseName(route.Evidence),
+			}]
 			if !ok || len(agreed) != 1 {
 				continue
 			}
@@ -148,15 +163,15 @@ func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*disco
 }
 
 // corroboratedPrefix returns the prefix the application demonstrably serves this anchor under.
-func corroboratedPrefix(
-	anchor string,
-	anchorsAtRoot map[string]struct{},
-	prefixesByAnchor map[string]map[string]struct{},
+func corroboratedPrefix[K comparable](
+	key K,
+	anchorsAtRoot map[K]struct{},
+	prefixesByAnchor map[K]map[string]struct{},
 ) (string, bool) {
-	if _, rooted := anchorsAtRoot[anchor]; rooted {
+	if _, rooted := anchorsAtRoot[key]; rooted {
 		return "", true
 	}
-	candidates := prefixesByAnchor[anchor]
+	candidates := prefixesByAnchor[key]
 	// More than one prefix serves this anchor, so which one applies is unknown.
 	if len(candidates) != 1 {
 		return "", false

--- a/internal/discover/route/helpers/unrooted.go
+++ b/internal/discover/route/helpers/unrooted.go
@@ -151,9 +151,10 @@ func ResolveUnrootedInterpolatedRoutes(routes []*discover.RouteDetails) []*disco
 			}
 		}
 
-		rootedPath := prefix + route.Path
+		rootedPath, params := RenumberPositionalParams(prefix+route.Path, route.PathParams)
 		evidence := InterpolatedRouteEvidence
 		route.Path = rootedPath
+		route.PathParams = params
 		route.PathTemplate = &rootedPath
 		route.Evidence = &evidence
 		resolved = append(resolved, route)

--- a/internal/discover/route/route.go
+++ b/internal/discover/route/route.go
@@ -636,7 +636,9 @@ func PerformRouteCapture(ctx context.Context, config discover.DiscoverRouteConfi
 		currentDepth++
 	}
 
-	mergedRoutes := discoverroutehelpers.MergeWebRoutes(allRoutes)
+	// Root candidates before merging so an unrooted path never merges with a real one.
+	rootedRoutes := discoverroutehelpers.ResolveUnrootedInterpolatedRoutes(allRoutes)
+	mergedRoutes := discoverroutehelpers.MergeWebRoutes(rootedRoutes)
 	mergedRoutes = discoverroutehelpers.ApplyDeclaredRouteTemplates(mergedRoutes)
 	sortRoutes(mergedRoutes)
 	report.Result.WebApplications = buildWebApplications(mergedRoutes, allStaticAssetsByBaseURL)

--- a/tests/discover/route/helpers/extractors/interpolated_routes_test.go
+++ b/tests/discover/route/helpers/extractors/interpolated_routes_test.go
@@ -3,6 +3,7 @@ package extractors_test
 import (
 	"testing"
 
+	common "github.com/Method-Security/webscan/generated/go/common"
 	"github.com/Method-Security/webscan/generated/go/discover"
 	extractors "github.com/Method-Security/webscan/internal/discover/route/helpers/extractors"
 )
@@ -17,90 +18,146 @@ func onlyRoute(t *testing.T, routes []*discover.RouteDetails) *discover.RouteDet
 	if len(routes) != 1 {
 		paths := make([]string, 0, len(routes))
 		for _, route := range routes {
-			paths = append(paths, route.Path)
+			paths = append(paths, string(route.Method)+" "+route.Path)
 		}
 		t.Fatalf("expected exactly one route, got %v", paths)
 	}
 	return routes[0]
 }
 
-func TestExtractInterpolatedRoutesStripsInterpolatedOrigin(t *testing.T) {
-	// The API base is itself interpolated, so a leading-slash rule matches nothing.
-	route := onlyRoute(t, interpolated(t, "const u = `${this.hostServer}/rest/basket/${basketId}`"))
+func TestExtractInterpolatedRoutesKeepsResolvableBasePrefix(t *testing.T) {
+	// An API base routinely holds a path; treating it as origin-only drops the prefix.
+	route := onlyRoute(t, interpolated(t,
+		"const API=`${this.host}/api/v2`;\nthis.http.get(`${API}/reports/${reportId}`);"))
 
-	if route.Path != "/rest/basket/{basketId}" {
-		t.Errorf("path = %q, want /rest/basket/{basketId}", route.Path)
+	if route.Path != "/api/v2/reports/{reportId}" {
+		t.Errorf("path = %q, want the base prefix retained", route.Path)
 	}
 	if route.BaseUrl != "https://example.com" {
 		t.Errorf("BaseUrl = %q, want the bundle origin", route.BaseUrl)
 	}
 }
 
+func TestExtractInterpolatedRoutesKeepsEnclosingVerb(t *testing.T) {
+	for declaration, want := range map[string]common.HttpMethod{
+		"const A=`${h}/api/v2`;\nthis.http.post(`${A}/sessions/${sessionId}/refresh`, b);": common.HttpMethodPost,
+		"const A=`${h}/api/v2`;\nthis.http.put(`${A}/reports/${reportId}`, b);":            common.HttpMethodPut,
+		"const A=`${h}/api/v2`;\nthis.http.delete(`${A}/reports/${reportId}`);":            common.HttpMethodDelete,
+		"const A=`${h}/api/v2`;\nthis.http.patch(`${A}/users/${userId}`, b);":              common.HttpMethodPatch,
+	} {
+		route := onlyRoute(t, interpolated(t, declaration))
+		if route.Method != want {
+			t.Errorf("method = %q, want %q for %q", route.Method, want, declaration)
+		}
+	}
+}
+
+func TestExtractInterpolatedRoutesReadsFetchOptionsMethod(t *testing.T) {
+	route := onlyRoute(t, interpolated(t, "fetch(`/api/v2/user/${userId}`, { method: 'DELETE' })"))
+
+	if route.Method != common.HttpMethodDelete {
+		t.Errorf("method = %q, want DELETE", route.Method)
+	}
+}
+
+func TestExtractInterpolatedRoutesSkipsUndeterminableMethod(t *testing.T) {
+	// Defaulting to GET reported every POST, PUT and DELETE as a GET.
+	routes := interpolated(t, "const url = `/api/v2/user/${userId}`;")
+
+	for _, route := range routes {
+		t.Errorf("expected no route without a determinable method, got %s %s", route.Method, route.Path)
+	}
+}
+
+func TestExtractInterpolatedRoutesSkipsUnresolvableBase(t *testing.T) {
+	// The base may carry a path, so without its value the full path is unknown.
+	routes := interpolated(t, "this.http.get(`${this.hostServer}/rest/basket/${id}`);")
+
+	for _, route := range routes {
+		t.Errorf("expected no route for an unresolvable base, got %q", route.Path)
+	}
+}
+
+func TestExtractInterpolatedRoutesSkipsAmbiguousBase(t *testing.T) {
+	// Minified bundles reuse short names; conflicting assignments mean the base is unknown.
+	routes := interpolated(t,
+		"var A=`${h}/api/v1`;\nvar A=`${h}/api/v2`;\nthis.http.get(`${A}/reports/${id}`);")
+
+	for _, route := range routes {
+		t.Errorf("expected no route for an ambiguous base, got %q", route.Path)
+	}
+}
+
+func TestExtractInterpolatedRoutesAcceptsRootedLiteralWithoutBase(t *testing.T) {
+	route := onlyRoute(t, interpolated(t, "this.http.get(`/api/v2/reports/${reportId}`);"))
+
+	if route.Path != "/api/v2/reports/{reportId}" {
+		t.Errorf("path = %q", route.Path)
+	}
+}
+
 func TestExtractInterpolatedRoutesNamesFromExpressionWhenMeaningful(t *testing.T) {
-	route := onlyRoute(t, interpolated(t, "fetch(`/rest/track/${this.orderId}`)"))
+	route := onlyRoute(t, interpolated(t, "fetch(`/rest/track/${this.orderId}`, {method:'GET'})"))
 
 	if len(route.PathParams) != 1 || route.PathParams[0].Name != "orderId" {
 		t.Fatalf("expected the expression to name the param, got %v", route.PathParams)
 	}
 }
 
-func TestExtractInterpolatedRoutesFallsBackWhenExpressionIsMinified(t *testing.T) {
-	// Minified locals carry no meaning, so the preceding segment is better evidence.
-	route := onlyRoute(t, interpolated(t, "fetch(`/rest/baskets/${e}`)"))
+func TestExtractInterpolatedRoutesUsesPositionalNameWhenMinified(t *testing.T) {
+	// The preceding segment is as often a verb as a resource, and it varied by call site.
+	first := onlyRoute(t, interpolated(t,
+		"const A=`${h}/api/v2`;\nthis.http.put(`${A}/widgets/archive/${e}/id/${i}`, b);"))
+	second := onlyRoute(t, interpolated(t,
+		"const A=`${h}/api/v2`;\nthis.http.put(`${A}/widgets/archive/${t}/id/${n}`, b);"))
 
-	if len(route.PathParams) != 1 || route.PathParams[0].Name != "basketId" {
-		t.Fatalf("expected a name derived from the preceding segment, got %v", route.PathParams)
+	if first.Path != "/api/v2/widgets/archive/{param3}/id/{param5}" {
+		t.Errorf("path = %q, want positional names", first.Path)
+	}
+	if first.Path != second.Path {
+		t.Errorf("names must not vary by call site: %q vs %q", first.Path, second.Path)
 	}
 }
 
-func TestExtractInterpolatedRoutesHandlesMultipleParameters(t *testing.T) {
-	route := onlyRoute(t, interpolated(t, "fetch(`${h}/rest/basket/${e}/coupon/${i}`)"))
-
-	if route.Path != "/rest/basket/{basketId}/coupon/{couponId}" {
-		t.Errorf("path = %q", route.Path)
-	}
-	if len(route.PathParams) != 2 {
-		t.Fatalf("expected two params, got %v", route.PathParams)
-	}
-	if route.PathParams[0].Name == route.PathParams[1].Name {
-		t.Errorf("param names collided: %q", route.PathParams[0].Name)
-	}
-}
-
-func TestExtractInterpolatedRoutesHandlesPartialSegmentInterpolation(t *testing.T) {
-	// ConstructURL substitutes {name} anywhere, so an embedded placeholder is executable.
-	route := onlyRoute(t, interpolated(t, "fetch(`${h}/ftp/order_${e}.pdf`)"))
+func TestExtractInterpolatedRoutesNamesFromAdjacentLiteralText(t *testing.T) {
+	// Literal text inside the same segment is adjacent evidence, unlike the preceding segment.
+	route := onlyRoute(t, interpolated(t, "fetch(`/ftp/order_${e}.pdf`, {method:'GET'})"))
 
 	if route.Path != "/ftp/order_{orderId}.pdf" {
 		t.Errorf("path = %q, want /ftp/order_{orderId}.pdf", route.Path)
 	}
 }
 
+func TestExtractInterpolatedRoutesHandlesMultipleParameters(t *testing.T) {
+	route := onlyRoute(t, interpolated(t,
+		"const A=`${h}/api/v2`;\nthis.http.put(`${A}/basket/${basketId}/coupon/${couponId}`, b);"))
+
+	if route.Path != "/api/v2/basket/{basketId}/coupon/{couponId}" {
+		t.Errorf("path = %q", route.Path)
+	}
+	if len(route.PathParams) != 2 || route.PathParams[0].Name == route.PathParams[1].Name {
+		t.Fatalf("expected two distinctly named params, got %v", route.PathParams)
+	}
+}
+
 func TestExtractInterpolatedRoutesAcceptsWrappedExpressions(t *testing.T) {
-	// Validation runs on the substituted template, not the raw literal.
-	for declaration, want := range map[string]string{
-		"fetch(`/api/user/${encodeURIComponent(id)}`)": "/api/user/{userId}",
-		"fetch(`/api/item/${ id }`)":                   "/api/item/{itemId}",
-	} {
-		route := onlyRoute(t, interpolated(t, declaration))
-		if route.Path != want {
-			t.Errorf("%s: path = %q, want %q", declaration, route.Path, want)
-		}
+	route := onlyRoute(t, interpolated(t, "this.http.get(`/api/user/${encodeURIComponent(accountId)}`)"))
+
+	if route.Path != "/api/user/{accountId}" {
+		t.Errorf("path = %q, want the unwrapped argument as the name", route.Path)
 	}
 }
 
 func TestExtractInterpolatedRoutesRejectsNonPathInterpolations(t *testing.T) {
 	cases := map[string]string{
-		"markup":              "const h = `<code>${e.data[0].orderId}</code>`",
-		"inline style":        "const s = `scaleX(${this.value/100})`",
-		"protocol relative":   "const u = `//${window.location.host}/rest/x`",
-		"query only":          "const u = `${this.hostServer}/rest/languages?v=${e}`",
-		"leading param":       "const u = `${this.host}/${e}/reviews`",
-		"whole path is param": "const u = `${this.host}/${e}`",
-		"no interpolation":    "const u = `/rest/languages`",
-		// A closing tag is slash-prefixed and survives every other check.
-		"closing tag": "const x = `</div>${y}`",
-		"prose":       "const p = `/5 items ${count}`",
+		"markup":              "this.http.get(`<code>${e.data[0].orderId}</code>`)",
+		"inline style":        "this.http.get(`scaleX(${this.value/100})`)",
+		"protocol relative":   "this.http.get(`//${window.location.host}/rest/x`)",
+		"query only":          "const A=`${h}/api`;\nthis.http.get(`${A}/languages?v=${e}`)",
+		"whole path is param": "const A=`${h}/api`;\nthis.http.get(`${A}/${e}`)",
+		"no interpolation":    "this.http.get(`/rest/languages`)",
+		"closing tag":         "this.http.get(`</div>${y}`)",
+		"prose":               "this.http.get(`/5 items ${count}`)",
 	}
 
 	for name, content := range cases {
@@ -112,7 +169,7 @@ func TestExtractInterpolatedRoutesRejectsNonPathInterpolations(t *testing.T) {
 
 func TestExtractInterpolatedRoutesTagsProvenance(t *testing.T) {
 	// Must stay distinguishable from a route-table declaration downstream.
-	route := onlyRoute(t, interpolated(t, "fetch(`${h}/rest/basket/${e}`)"))
+	route := onlyRoute(t, interpolated(t, "this.http.get(`/rest/basket/${basketId}`)"))
 
 	if route.Evidence == nil || *route.Evidence != "interpolated" {
 		t.Errorf("evidence = %v, want interpolated", route.Evidence)

--- a/tests/discover/route/helpers/extractors/interpolated_routes_test.go
+++ b/tests/discover/route/helpers/extractors/interpolated_routes_test.go
@@ -200,3 +200,18 @@ func TestExtractInterpolatedRoutesTagsProvenance(t *testing.T) {
 		t.Errorf("evidence = %v, want interpolated", route.Evidence)
 	}
 }
+
+func TestExtractInterpolatedRoutesKeepsCandidatesFromDistinctBases(t *testing.T) {
+	// Two bases sharing a tail must both survive, or a route recoverable from one is lost when the
+	// other never corroborates.
+	routes := interpolated(t,
+		"this.http.get(`${this.apiA}/reports/${id}`);\nthis.http.get(`${this.apiB}/reports/${id}`);")
+
+	if len(routes) != 2 {
+		paths := make([]string, 0, len(routes))
+		for _, route := range routes {
+			paths = append(paths, *route.Evidence)
+		}
+		t.Fatalf("expected a candidate per base, got %v", paths)
+	}
+}

--- a/tests/discover/route/helpers/extractors/interpolated_routes_test.go
+++ b/tests/discover/route/helpers/extractors/interpolated_routes_test.go
@@ -1,6 +1,7 @@
 package extractors_test
 
 import (
+	"strings"
 	"testing"
 
 	common "github.com/Method-Security/webscan/generated/go/common"
@@ -69,22 +70,46 @@ func TestExtractInterpolatedRoutesSkipsUndeterminableMethod(t *testing.T) {
 	}
 }
 
-func TestExtractInterpolatedRoutesSkipsUnresolvableBase(t *testing.T) {
-	// The base may carry a path, so without its value the full path is unknown.
-	routes := interpolated(t, "this.http.get(`${this.hostServer}/rest/basket/${id}`);")
+func TestExtractInterpolatedRoutesMarksUnresolvableBaseAsUnrooted(t *testing.T) {
+	// The base may carry a path, so rooting is deferred to corroboration rather than guessed.
+	route := onlyRoute(t, interpolated(t, "this.http.get(`${this.hostServer}/rest/basket/${id}`);"))
 
-	for _, route := range routes {
-		t.Errorf("expected no route for an unresolvable base, got %q", route.Path)
+	if route.Evidence == nil || !strings.HasPrefix(*route.Evidence, "interpolated-unrooted") {
+		t.Errorf("evidence = %v, want an unrooted candidate", route.Evidence)
+	}
+	if route.Path != "/rest/basket/{param3}" {
+		t.Errorf("path = %q, want the tail that followed the base", route.Path)
 	}
 }
 
-func TestExtractInterpolatedRoutesSkipsAmbiguousBase(t *testing.T) {
+func TestExtractInterpolatedRoutesMarksAmbiguousBaseAsUnrooted(t *testing.T) {
 	// Minified bundles reuse short names; conflicting assignments mean the base is unknown.
-	routes := interpolated(t,
-		"var A=`${h}/api/v1`;\nvar A=`${h}/api/v2`;\nthis.http.get(`${A}/reports/${id}`);")
+	route := onlyRoute(t, interpolated(t,
+		"var A=`${h}/api/v1`;\nvar A=`${h}/api/v2`;\nthis.http.get(`${A}/reports/${id}`);"))
 
-	for _, route := range routes {
-		t.Errorf("expected no route for an ambiguous base, got %q", route.Path)
+	if route.Evidence == nil || !strings.HasPrefix(*route.Evidence, "interpolated-unrooted") {
+		t.Errorf("evidence = %v, want an unrooted candidate", route.Evidence)
+	}
+	if !strings.HasSuffix(*route.Evidence, ":A") {
+		t.Errorf("evidence = %q, want the base name recorded", *route.Evidence)
+	}
+}
+
+func TestExtractInterpolatedRoutesTreatsNavigationAsGet(t *testing.T) {
+	// window.open is a GET by definition, not an inferred default.
+	route := onlyRoute(t, interpolated(t, "window.open(`/ftp/order_${e}.pdf`)"))
+
+	if route.Method != common.HttpMethodGet {
+		t.Errorf("method = %q, want GET", route.Method)
+	}
+}
+
+func TestExtractInterpolatedRoutesTreatsAssignedNavigationAsGet(t *testing.T) {
+	route := onlyRoute(t, interpolated(t,
+		"openPDF(e){let i=`/ftp/order_${e}.pdf`;window.open(i)}"))
+
+	if route.Method != common.HttpMethodGet {
+		t.Errorf("method = %q, want GET", route.Method)
 	}
 }
 

--- a/tests/discover/route/helpers/extractors/interpolated_routes_test.go
+++ b/tests/discover/route/helpers/extractors/interpolated_routes_test.go
@@ -136,7 +136,7 @@ func TestExtractInterpolatedRoutesUsesPositionalNameWhenMinified(t *testing.T) {
 	second := onlyRoute(t, interpolated(t,
 		"const A=`${h}/api/v2`;\nthis.http.put(`${A}/widgets/archive/${t}/id/${n}`, b);"))
 
-	if first.Path != "/api/v2/widgets/archive/{param3}/id/{param5}" {
+	if first.Path != "/api/v2/widgets/archive/{param5}/id/{param7}" {
 		t.Errorf("path = %q, want positional names", first.Path)
 	}
 	if first.Path != second.Path {
@@ -179,7 +179,7 @@ func TestExtractInterpolatedRoutesRejectsNonPathInterpolations(t *testing.T) {
 		"inline style":        "this.http.get(`scaleX(${this.value/100})`)",
 		"protocol relative":   "this.http.get(`//${window.location.host}/rest/x`)",
 		"query only":          "const A=`${h}/api`;\nthis.http.get(`${A}/languages?v=${e}`)",
-		"whole path is param": "const A=`${h}/api`;\nthis.http.get(`${A}/${e}`)",
+		"whole path is param": "this.http.get(`/${e}`)",
 		"no interpolation":    "this.http.get(`/rest/languages`)",
 		"closing tag":         "this.http.get(`</div>${y}`)",
 		"prose":               "this.http.get(`/5 items ${count}`)",
@@ -188,6 +188,46 @@ func TestExtractInterpolatedRoutesRejectsNonPathInterpolations(t *testing.T) {
 	for name, content := range cases {
 		if routes := interpolated(t, content); len(routes) != 0 {
 			t.Errorf("%s: expected no routes, got %q", name, routes[0].Path)
+		}
+	}
+}
+
+func TestExtractInterpolatedRoutesAllowsParamFirstTailUnderResolvedBase(t *testing.T) {
+	// The base is known, so a parameter immediately after it is a real path rather than a guess.
+	route := onlyRoute(t, interpolated(t, "const A=`${h}/api/v2`;\nthis.http.get(`${A}/${e}`)"))
+
+	if route.Path != "/api/v2/{param3}" {
+		t.Errorf("path = %q, want the resolved base to anchor the template", route.Path)
+	}
+}
+
+func TestExtractInterpolatedRoutesRenumbersNamesAgainstFinalPath(t *testing.T) {
+	// The same endpoint written with and without an interpolated base must yield the same names.
+	viaBase := onlyRoute(t, interpolated(t,
+		"const A=`${h}/api/v2`;\nthis.http.put(`${A}/widgets/lock/${e}`, b);"))
+	rooted := onlyRoute(t, interpolated(t, "this.http.put(`/api/v2/widgets/lock/${e}`, b);"))
+
+	if viaBase.Path != rooted.Path {
+		t.Errorf("names split the same endpoint: %q vs %q", viaBase.Path, rooted.Path)
+	}
+}
+
+func TestExtractInterpolatedRoutesNamesSpacedInterpolations(t *testing.T) {
+	compact := onlyRoute(t, interpolated(t, "this.http.get(`/api/v2/track/${this.orderId}`)"))
+	spaced := onlyRoute(t, interpolated(t, "this.http.get(`/api/v2/track/${ this.orderId }`)"))
+
+	if compact.Path != spaced.Path {
+		t.Errorf("spacing split the same endpoint: %q vs %q", compact.Path, spaced.Path)
+	}
+}
+
+func TestExtractInterpolatedRoutesRejectsProtocolRelativeBase(t *testing.T) {
+	// A protocol-relative base is a host, not a path prefix.
+	routes := interpolated(t, "const A=`//cdn.example.com/api`;\nthis.http.get(`${A}/reports/${id}`)")
+
+	for _, route := range routes {
+		if strings.HasPrefix(route.Path, "//") {
+			t.Errorf("a host was treated as a path prefix: %q", route.Path)
 		}
 	}
 }

--- a/tests/discover/route/helpers/unrooted_test.go
+++ b/tests/discover/route/helpers/unrooted_test.go
@@ -268,3 +268,51 @@ func TestResolveUnrootedDoesNotInheritWithoutRecordedBase(t *testing.T) {
 		}
 	}
 }
+
+func TestUnrootedEvidenceCountsAsDerivationProvenance(t *testing.T) {
+	// Source-map tagging must not strip the marker; losing it skips rooting and lets the
+	// unprefixed tail reach the report.
+	evidence := discoverroute.UnrootedEvidenceFor("hostServer")
+	if discoverroute.EvidenceRank(&evidence) < 2 {
+		t.Errorf("rank = %d, want it protected as derivation provenance", discoverroute.EvidenceRank(&evidence))
+	}
+	if !discoverroute.IsProvenanceEvidence(evidence) {
+		t.Errorf("expected an unrooted candidate to be treated as provenance")
+	}
+}
+
+func TestResolveUnrootedCorroboratesWithinOriginOnly(t *testing.T) {
+	// A path served by another origin says nothing about this one.
+	other := tagged("/rest/products", "")
+	other.BaseUrl = "https://other.example.com"
+
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		other,
+		candidate("/rest/basket/{param2}"),
+	})
+
+	for _, route := range routes {
+		if route.Path == "/rest/basket/{param2}" {
+			t.Errorf("a foreign origin must not corroborate a candidate")
+		}
+	}
+}
+
+func TestResolveUnrootedDoesNotInheritAcrossOrigins(t *testing.T) {
+	foreign := candidateOf("/reports/{param2}", "apiBase")
+	foreign.BaseUrl = "https://other.example.com"
+	foreignObserved := tagged("/api/v2/reports", "")
+	foreignObserved.BaseUrl = "https://other.example.com"
+
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		foreignObserved,
+		foreign,
+		candidateOf("/exports/{param2}", "apiBase"),
+	})
+
+	for _, route := range routes {
+		if route.Path == "/api/v2/exports/{param2}" {
+			t.Errorf("a prefix corroborated on another origin must not be inherited here")
+		}
+	}
+}

--- a/tests/discover/route/helpers/unrooted_test.go
+++ b/tests/discover/route/helpers/unrooted_test.go
@@ -1,6 +1,7 @@
 package helpers_test
 
 import (
+	"regexp"
 	"testing"
 
 	common "github.com/Method-Security/webscan/generated/go/common"
@@ -16,20 +17,23 @@ func tagged(path string, evidence string) *discover.RouteDetails {
 	return route
 }
 
-func candidateOf(path string, base string) *discover.RouteDetails {
-	route := tagged(path, discoverroute.UnrootedEvidenceFor(base))
+var placeholderPattern = regexp.MustCompile(`\{([^{}]+)\}`)
+
+func withCandidateShape(route *discover.RouteDetails, path string) *discover.RouteDetails {
 	template := path
 	route.PathTemplate = &template
-	route.PathParams = []*discover.RoutePathParam{{Name: "param2"}}
+	for _, match := range placeholderPattern.FindAllStringSubmatch(path, -1) {
+		route.PathParams = append(route.PathParams, &discover.RoutePathParam{Name: match[1]})
+	}
 	return route
 }
 
+func candidateOf(path string, base string) *discover.RouteDetails {
+	return withCandidateShape(tagged(path, discoverroute.UnrootedEvidenceFor(base)), path)
+}
+
 func candidate(path string) *discover.RouteDetails {
-	route := tagged(path, discoverroute.InterpolatedUnrootedEvidence)
-	template := path
-	route.PathTemplate = &template
-	route.PathParams = []*discover.RoutePathParam{{Name: "param2"}}
-	return route
+	return withCandidateShape(tagged(path, discoverroute.InterpolatedUnrootedEvidence), path)
 }
 
 func TestResolveUnrootedAcceptsCandidateAlreadyRooted(t *testing.T) {
@@ -37,14 +41,14 @@ func TestResolveUnrootedAcceptsCandidateAlreadyRooted(t *testing.T) {
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 		tagged("/rest/products", ""),
 		tagged("/rest/user", ""),
-		candidate("/rest/basket/{param2}"),
+		candidate("/rest/basket/{param3}"),
 	})
 
-	route := findRoute(t, routes, "/rest/basket/{param2}")
+	route := findRoute(t, routes, "/rest/basket/{param3}")
 	if route.Evidence == nil || *route.Evidence != discoverroute.InterpolatedRouteEvidence {
 		t.Errorf("evidence = %v, want it retagged as resolved", route.Evidence)
 	}
-	if route.PathTemplate == nil || *route.PathTemplate != "/rest/basket/{param2}" {
+	if route.PathTemplate == nil || *route.PathTemplate != "/rest/basket/{param3}" {
 		t.Errorf("PathTemplate = %v, want it to track Path", route.PathTemplate)
 	}
 }
@@ -57,8 +61,8 @@ func TestResolveUnrootedRecoversMissingPrefix(t *testing.T) {
 		candidate("/appmessages/{param2}"),
 	})
 
-	route := findRoute(t, routes, "/api/v2/appmessages/{param2}")
-	if route.PathTemplate == nil || *route.PathTemplate != "/api/v2/appmessages/{param2}" {
+	route := findRoute(t, routes, "/api/v2/appmessages/{param4}")
+	if route.PathTemplate == nil || *route.PathTemplate != "/api/v2/appmessages/{param4}" {
 		t.Errorf("PathTemplate = %v, want the rooted path", route.PathTemplate)
 	}
 }
@@ -107,10 +111,10 @@ func TestResolveUnrootedCorroboratesOnlyOnObservedRoutes(t *testing.T) {
 	for _, evidence := range []string{"CONST:X", "sourcemap:app.ts", discoverroute.DeclaredRouteEvidence} {
 		routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 			tagged("/rest/products", evidence),
-			candidate("/rest/basket/{param2}"),
+			candidate("/rest/basket/{param3}"),
 		})
 		for _, route := range routes {
-			if route.Path == "/rest/basket/{param2}" {
+			if route.Path == "/rest/basket/{param3}" {
 				t.Errorf("%s must not corroborate a candidate", evidence)
 			}
 		}
@@ -118,9 +122,9 @@ func TestResolveUnrootedCorroboratesOnlyOnObservedRoutes(t *testing.T) {
 
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 		tagged("/rest/products", ""),
-		candidate("/rest/basket/{param2}"),
+		candidate("/rest/basket/{param3}"),
 	})
-	findRoute(t, routes, "/rest/basket/{param2}")
+	findRoute(t, routes, "/rest/basket/{param3}")
 }
 
 func TestResolveUnrootedIgnoresClientRouteDeclarations(t *testing.T) {
@@ -132,7 +136,7 @@ func TestResolveUnrootedIgnoresClientRouteDeclarations(t *testing.T) {
 		candidate("/reports/{param2}"),
 	})
 
-	findRoute(t, routes, "/api/v2/reports/{param2}")
+	findRoute(t, routes, "/api/v2/reports/{param4}")
 }
 
 func TestResolveUnrootedAnchorsOnFirstLiteralSegment(t *testing.T) {
@@ -142,7 +146,7 @@ func TestResolveUnrootedAnchorsOnFirstLiteralSegment(t *testing.T) {
 		candidate("/{param1}/basket/{param3}"),
 	})
 
-	findRoute(t, routes, "/api/v2/{param1}/basket/{param3}")
+	findRoute(t, routes, "/api/v2/{param3}/basket/{param5}")
 }
 
 func TestResolveUnrootedDropsCandidateWithNoLiteralSegment(t *testing.T) {
@@ -171,7 +175,7 @@ func TestResolveUnrootedLeavesOtherRoutesUntouched(t *testing.T) {
 }
 
 func TestResolveUnrootedKeepsMethodOfCandidate(t *testing.T) {
-	route := candidate("/rest/basket/{param2}")
+	route := candidate("/rest/basket/{param3}")
 	route.Method = common.HttpMethodPut
 
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
@@ -179,7 +183,7 @@ func TestResolveUnrootedKeepsMethodOfCandidate(t *testing.T) {
 		route,
 	})
 
-	if findRoute(t, routes, "/rest/basket/{param2}").Method != common.HttpMethodPut {
+	if findRoute(t, routes, "/rest/basket/{param3}").Method != common.HttpMethodPut {
 		t.Errorf("method was not preserved through rooting")
 	}
 }
@@ -188,11 +192,11 @@ func TestApplyDeclaredRouteTemplatesDropsUnresolvedCandidate(t *testing.T) {
 	// Defence in depth: a candidate that never went through resolution must not reach the report.
 	routes := discoverroute.ApplyDeclaredRouteTemplates([]*discover.RouteDetails{
 		tagged("/rest/products", ""),
-		candidate("/rest/basket/{param2}"),
+		candidate("/rest/basket/{param3}"),
 	})
 
 	for _, route := range routes {
-		if route.Path == "/rest/basket/{param2}" {
+		if route.Path == "/rest/basket/{param3}" {
 			t.Errorf("an unrooted candidate reached the output")
 		}
 	}
@@ -203,11 +207,11 @@ func TestResolveUnrootedInheritsPrefixFromSameBase(t *testing.T) {
 	// own, but the base has been shown to contribute no prefix.
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 		tagged("/rest/products", ""),
-		candidateOf("/rest/basket/{param2}", "hostServer"),
+		candidateOf("/rest/basket/{param3}", "hostServer"),
 		candidateOf("/ftp/order_{param2}.pdf", "hostServer"),
 	})
 
-	findRoute(t, routes, "/rest/basket/{param2}")
+	findRoute(t, routes, "/rest/basket/{param3}")
 	findRoute(t, routes, "/ftp/order_{param2}.pdf")
 }
 
@@ -218,8 +222,8 @@ func TestResolveUnrootedInheritsNonEmptyPrefixFromSameBase(t *testing.T) {
 		candidateOf("/exports/{param2}", "apiBase"),
 	})
 
-	findRoute(t, routes, "/api/v2/reports/{param2}")
-	findRoute(t, routes, "/api/v2/exports/{param2}")
+	findRoute(t, routes, "/api/v2/reports/{param4}")
+	findRoute(t, routes, "/api/v2/exports/{param4}")
 }
 
 func TestResolveUnrootedDoesNotInheritAcrossDifferentBases(t *testing.T) {
@@ -229,9 +233,9 @@ func TestResolveUnrootedDoesNotInheritAcrossDifferentBases(t *testing.T) {
 		candidateOf("/exports/{param2}", "otherBase"),
 	})
 
-	findRoute(t, routes, "/api/v2/reports/{param2}")
+	findRoute(t, routes, "/api/v2/reports/{param4}")
 	for _, route := range routes {
-		if route.Path == "/api/v2/exports/{param2}" {
+		if route.Path == "/api/v2/exports/{param4}" {
 			t.Errorf("a different base must not inherit the prefix")
 		}
 	}
@@ -242,13 +246,13 @@ func TestResolveUnrootedDoesNotInheritWhenBasePrefixesDisagree(t *testing.T) {
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 		tagged("/rest/products", ""),
 		tagged("/api/v2/reports", ""),
-		candidateOf("/rest/basket/{param2}", "base"),
+		candidateOf("/rest/basket/{param3}", "base"),
 		candidateOf("/reports/{param2}", "base"),
 		candidateOf("/unseen/{param2}", "base"),
 	})
 
 	for _, route := range routes {
-		if route.Path == "/unseen/{param2}" || route.Path == "/api/v2/unseen/{param2}" {
+		if route.Path == "/unseen/{param2}" || route.Path == "/api/v2/unseen/{param4}" {
 			t.Errorf("expected no inheritance from a base with disagreeing prefixes, got %q", route.Path)
 		}
 	}
@@ -257,11 +261,11 @@ func TestResolveUnrootedDoesNotInheritWhenBasePrefixesDisagree(t *testing.T) {
 func TestResolveUnrootedDoesNotInheritWithoutRecordedBase(t *testing.T) {
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 		tagged("/rest/products", ""),
-		candidate("/rest/basket/{param2}"),
+		candidate("/rest/basket/{param3}"),
 		candidate("/ftp/order_{param2}.pdf"),
 	})
 
-	findRoute(t, routes, "/rest/basket/{param2}")
+	findRoute(t, routes, "/rest/basket/{param3}")
 	for _, route := range routes {
 		if route.Path == "/ftp/order_{param2}.pdf" {
 			t.Errorf("a candidate with no recorded base must not inherit")
@@ -288,11 +292,11 @@ func TestResolveUnrootedCorroboratesWithinOriginOnly(t *testing.T) {
 
 	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
 		other,
-		candidate("/rest/basket/{param2}"),
+		candidate("/rest/basket/{param3}"),
 	})
 
 	for _, route := range routes {
-		if route.Path == "/rest/basket/{param2}" {
+		if route.Path == "/rest/basket/{param3}" {
 			t.Errorf("a foreign origin must not corroborate a candidate")
 		}
 	}
@@ -311,7 +315,7 @@ func TestResolveUnrootedDoesNotInheritAcrossOrigins(t *testing.T) {
 	})
 
 	for _, route := range routes {
-		if route.Path == "/api/v2/exports/{param2}" {
+		if route.Path == "/api/v2/exports/{param4}" {
 			t.Errorf("a prefix corroborated on another origin must not be inherited here")
 		}
 	}

--- a/tests/discover/route/helpers/unrooted_test.go
+++ b/tests/discover/route/helpers/unrooted_test.go
@@ -1,0 +1,270 @@
+package helpers_test
+
+import (
+	"testing"
+
+	common "github.com/Method-Security/webscan/generated/go/common"
+	"github.com/Method-Security/webscan/generated/go/discover"
+	discoverroute "github.com/Method-Security/webscan/internal/discover/route/helpers"
+)
+
+func tagged(path string, evidence string) *discover.RouteDetails {
+	route := routeAt(path)
+	if evidence != "" {
+		route.Evidence = &evidence
+	}
+	return route
+}
+
+func candidateOf(path string, base string) *discover.RouteDetails {
+	route := tagged(path, discoverroute.UnrootedEvidenceFor(base))
+	template := path
+	route.PathTemplate = &template
+	route.PathParams = []*discover.RoutePathParam{{Name: "param2"}}
+	return route
+}
+
+func candidate(path string) *discover.RouteDetails {
+	route := tagged(path, discoverroute.InterpolatedUnrootedEvidence)
+	template := path
+	route.PathTemplate = &template
+	route.PathParams = []*discover.RoutePathParam{{Name: "param2"}}
+	return route
+}
+
+func TestResolveUnrootedAcceptsCandidateAlreadyRooted(t *testing.T) {
+	// The application serves paths under /rest, so the candidate needs no prefix.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		tagged("/rest/user", ""),
+		candidate("/rest/basket/{param2}"),
+	})
+
+	route := findRoute(t, routes, "/rest/basket/{param2}")
+	if route.Evidence == nil || *route.Evidence != discoverroute.InterpolatedRouteEvidence {
+		t.Errorf("evidence = %v, want it retagged as resolved", route.Evidence)
+	}
+	if route.PathTemplate == nil || *route.PathTemplate != "/rest/basket/{param2}" {
+		t.Errorf("PathTemplate = %v, want it to track Path", route.PathTemplate)
+	}
+}
+
+func TestResolveUnrootedRecoversMissingPrefix(t *testing.T) {
+	// The application serves the anchor only under /api/v2, so that is the missing prefix.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/api/v2/appmessages", ""),
+		tagged("/api/v2/health", ""),
+		candidate("/appmessages/{param2}"),
+	})
+
+	route := findRoute(t, routes, "/api/v2/appmessages/{param2}")
+	if route.PathTemplate == nil || *route.PathTemplate != "/api/v2/appmessages/{param2}" {
+		t.Errorf("PathTemplate = %v, want the rooted path", route.PathTemplate)
+	}
+}
+
+func TestResolveUnrootedDropsAmbiguousPrefix(t *testing.T) {
+	// Two versions serve the same anchor, so which one the base held is unknown.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/api/v1/reports", ""),
+		tagged("/api/v2/reports", ""),
+		candidate("/reports/{param2}"),
+	})
+
+	if len(routes) != 2 {
+		t.Fatalf("expected the candidate dropped, got %v", pathsOf(routes))
+	}
+}
+
+func TestResolveUnrootedDropsUncorroboratedCandidate(t *testing.T) {
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		candidate("/appmessages/{param2}"),
+	})
+
+	if len(routes) != 1 {
+		t.Fatalf("expected the candidate dropped, got %v", pathsOf(routes))
+	}
+}
+
+func TestResolveUnrootedIgnoresInterpolatedCorroboration(t *testing.T) {
+	// A candidate must not be corroborated by another interpolated route, or a wrong prefix
+	// confirms itself.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/appmessages/1", discoverroute.InterpolatedRouteEvidence),
+		candidate("/appmessages/{param2}"),
+		candidate("/appmessages/{param2}/detail"),
+	})
+
+	if len(routes) != 1 {
+		t.Fatalf("expected both candidates dropped, got %v", pathsOf(routes))
+	}
+}
+
+func TestResolveUnrootedCorroboratesOnlyOnObservedRoutes(t *testing.T) {
+	// A route-table declaration is a client-side route: an SPA serving /products while its API lives
+	// at /api/v2/products would otherwise confirm the wrong prefix.
+	for _, evidence := range []string{"CONST:X", "sourcemap:app.ts", discoverroute.DeclaredRouteEvidence} {
+		routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+			tagged("/rest/products", evidence),
+			candidate("/rest/basket/{param2}"),
+		})
+		for _, route := range routes {
+			if route.Path == "/rest/basket/{param2}" {
+				t.Errorf("%s must not corroborate a candidate", evidence)
+			}
+		}
+	}
+
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		candidate("/rest/basket/{param2}"),
+	})
+	findRoute(t, routes, "/rest/basket/{param2}")
+}
+
+func TestResolveUnrootedIgnoresClientRouteDeclarations(t *testing.T) {
+	// The SPA declares /reports as a client route while the API serves /api/v2/reports; the
+	// candidate must take the observed API prefix, not the client route.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/reports", discoverroute.DeclaredRouteEvidence),
+		tagged("/api/v2/reports", ""),
+		candidate("/reports/{param2}"),
+	})
+
+	findRoute(t, routes, "/api/v2/reports/{param2}")
+}
+
+func TestResolveUnrootedAnchorsOnFirstLiteralSegment(t *testing.T) {
+	// A leading placeholder is not an anchor; the first fixed segment is.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/api/v2/basket/1/items", ""),
+		candidate("/{param1}/basket/{param3}"),
+	})
+
+	findRoute(t, routes, "/api/v2/{param1}/basket/{param3}")
+}
+
+func TestResolveUnrootedDropsCandidateWithNoLiteralSegment(t *testing.T) {
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		candidate("/{param1}"),
+	})
+
+	if len(routes) != 1 {
+		t.Fatalf("expected the candidate dropped, got %v", pathsOf(routes))
+	}
+}
+
+func TestResolveUnrootedLeavesOtherRoutesUntouched(t *testing.T) {
+	observed := tagged("/rest/products", "")
+	declared := tagged("/documents/{id}", discoverroute.DeclaredRouteEvidence)
+
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{observed, declared})
+
+	if len(routes) != 2 {
+		t.Fatalf("expected both routes kept, got %v", pathsOf(routes))
+	}
+	if *declared.Evidence != discoverroute.DeclaredRouteEvidence {
+		t.Errorf("declared evidence was modified: %q", *declared.Evidence)
+	}
+}
+
+func TestResolveUnrootedKeepsMethodOfCandidate(t *testing.T) {
+	route := candidate("/rest/basket/{param2}")
+	route.Method = common.HttpMethodPut
+
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		route,
+	})
+
+	if findRoute(t, routes, "/rest/basket/{param2}").Method != common.HttpMethodPut {
+		t.Errorf("method was not preserved through rooting")
+	}
+}
+
+func TestApplyDeclaredRouteTemplatesDropsUnresolvedCandidate(t *testing.T) {
+	// Defence in depth: a candidate that never went through resolution must not reach the report.
+	routes := discoverroute.ApplyDeclaredRouteTemplates([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		candidate("/rest/basket/{param2}"),
+	})
+
+	for _, route := range routes {
+		if route.Path == "/rest/basket/{param2}" {
+			t.Errorf("an unrooted candidate reached the output")
+		}
+	}
+}
+
+func TestResolveUnrootedInheritsPrefixFromSameBase(t *testing.T) {
+	// One candidate for this base is corroborated directly; the other has no observed anchor of its
+	// own, but the base has been shown to contribute no prefix.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		candidateOf("/rest/basket/{param2}", "hostServer"),
+		candidateOf("/ftp/order_{param2}.pdf", "hostServer"),
+	})
+
+	findRoute(t, routes, "/rest/basket/{param2}")
+	findRoute(t, routes, "/ftp/order_{param2}.pdf")
+}
+
+func TestResolveUnrootedInheritsNonEmptyPrefixFromSameBase(t *testing.T) {
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/api/v2/reports", ""),
+		candidateOf("/reports/{param2}", "apiBase"),
+		candidateOf("/exports/{param2}", "apiBase"),
+	})
+
+	findRoute(t, routes, "/api/v2/reports/{param2}")
+	findRoute(t, routes, "/api/v2/exports/{param2}")
+}
+
+func TestResolveUnrootedDoesNotInheritAcrossDifferentBases(t *testing.T) {
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/api/v2/reports", ""),
+		candidateOf("/reports/{param2}", "apiBase"),
+		candidateOf("/exports/{param2}", "otherBase"),
+	})
+
+	findRoute(t, routes, "/api/v2/reports/{param2}")
+	for _, route := range routes {
+		if route.Path == "/api/v2/exports/{param2}" {
+			t.Errorf("a different base must not inherit the prefix")
+		}
+	}
+}
+
+func TestResolveUnrootedDoesNotInheritWhenBasePrefixesDisagree(t *testing.T) {
+	// The same base rooted two ways means its value is not consistent evidence.
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		tagged("/api/v2/reports", ""),
+		candidateOf("/rest/basket/{param2}", "base"),
+		candidateOf("/reports/{param2}", "base"),
+		candidateOf("/unseen/{param2}", "base"),
+	})
+
+	for _, route := range routes {
+		if route.Path == "/unseen/{param2}" || route.Path == "/api/v2/unseen/{param2}" {
+			t.Errorf("expected no inheritance from a base with disagreeing prefixes, got %q", route.Path)
+		}
+	}
+}
+
+func TestResolveUnrootedDoesNotInheritWithoutRecordedBase(t *testing.T) {
+	routes := discoverroute.ResolveUnrootedInterpolatedRoutes([]*discover.RouteDetails{
+		tagged("/rest/products", ""),
+		candidate("/rest/basket/{param2}"),
+		candidate("/ftp/order_{param2}.pdf"),
+	})
+
+	findRoute(t, routes, "/rest/basket/{param2}")
+	for _, route := range routes {
+		if route.Path == "/ftp/order_{param2}.pdf" {
+			t.Errorf("a candidate with no recorded base must not inherit")
+		}
+	}
+}


### PR DESCRIPTION
## Why

Interpolated route extraction (#496, shipped in v0.18.0) had three defects that compounded: on a real engagement **every recovered endpoint was wrong** — wrong path, wrong method, and invented parameter names. The wrong paths were verified against the target as non-existent.

The shape of the failure, with a neutral example:

```
reported                                     actual
GET  /reports/{reportId}                     GET  /api/v2/reports/{reportId}
GET  /sessions/{sessionId}/refresh           POST /api/v2/sessions/{sessionId}/refresh
GET  /widgets/archive/{archiveId}/id/{idId}  PUT  /api/v2/widgets/archive/{ownerId}/id/{widgetId}
```

A path missing the API prefix typically still returns 200 from the SPA shell, so the reported endpoint looks real enough to test, finds nothing, and the real endpoint is missed.

## The three defects

**Base prefix dropped.** A leading `${...}` was stripped and the remainder treated as rooted at the origin. That holds when the base is a host, but an API base routinely holds a path — a variable assigned `` `${host}/api/v2` `` — and the prefix was silently lost.

**Method hardcoded to GET.** There was no method detection for interpolated URLs at all, so every POST, PUT, PATCH and DELETE was reported as a GET.

**Parameter names invented from the preceding path segment.** In a minified bundle the expression is a single letter, so the fallback used the preceding segment — as often a verb as a resource, and nonsense when the segment is already `id`. The name followed whatever letter the minifier chose, so one route family fragmented into differently-named duplicates.

## How rooting works now

The base often cannot be resolved inside the bundle at all — it is populated from config at runtime. Rather than guess (the bug) or drop (safe but blunt), the candidate is carried forward with the tail that followed the base and rooted at merge time, where the full route set is available:

- the application serves the candidate's anchor **at the root** → no prefix needed
- it serves that anchor **only under a prefix** → that is the missing prefix
- **neither, or several** → dropped

Candidates sharing a base inherit whatever prefix corroboration established for it, provided every corroborated candidate for that base agreed.

**Only observed routes corroborate.** A route-table declaration is a client-side route, so an SPA serving `/products` while its API lives at `/api/v2/products` would otherwise confirm the wrong prefix — the same failure this exists to prevent. Bundle strings are ambiguous for the same reason, and an interpolated route can never corroborate itself or another candidate.

Candidates are rooted before the merge, so an unresolved path never merges with a real one, and `ApplyDeclaredRouteTemplates` drops any that somehow survive unresolved.

**Method** now comes from the enclosing call, a fetch options object, or a navigation sink (`window.open`, `location.href`) which is a GET by definition. Undeterminable means the route is skipped.

**Names** come from the interpolated expression, unwrapping a single-argument call so `encodeURIComponent(accountId)` yields `accountId`. Literal text inside the same segment is still used, since it is adjacent evidence — `order_${e}.pdf` yields `orderId`. The preceding-segment guess is gone; the fallback is a stable positional name that cannot fragment a route family across call sites.

## Measured against OWASP Juice Shop

| | shipped v0.18.0 | this PR |
|---|---|---|
| routes with path params | 4 | 4 |
| **correct methods** | 0 of 4 | 4 of 4 |
| unrooted leaks | n/a | 0 |

```
GET  /ftp/order_{orderId}.pdf
GET  /rest/basket/{param3}
POST /rest/basket/{param3}/checkout
PUT  /rest/basket/{param3}/coupon/{param5}
```

Juice Shop's base is `this.hostServer`, assigned from config, so nothing in the bundle states its value — every one of these is recovered by corroboration rather than resolution. v0.18.0 reported all four as GET; `/checkout` is a POST and `/coupon` a PUT. `/ftp/order_{orderId}.pdf` — the IDOR and traversal vector — is recovered through base inheritance, since the crawl never observes `/ftp` directly.

## Testing

`./godelw verify` passes. 15 tests for the rooting pass alone, covering: already-rooted acceptance, missing-prefix recovery, ambiguous-prefix drop, uncorroborated drop, self-corroboration refusal, client-route-declaration refusal, anchor selection past leading placeholders, base inheritance and its three refusal cases, method preservation, and the defence-in-depth drop. Plus regressions per original defect in the extractor suite.

Each defect was reproduced before being fixed. Fixtures use synthetic paths only.

## Note on already-collected data

v0.18.0 is in the ontology bump, so `WebEndpoint` and `WebEndpointParameter` objects already created from interpolated routes carry the wrong path and method and should be treated as suspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route-discovery output and merge ordering; incorrect corroboration could still drop or mis-prefix endpoints, but scope is limited to interpolated JS templates with new safeguards and tests.
> 
> **Overview**
> Fixes **interpolated JS route extraction** so discovered endpoints match real API paths, verbs, and stable parameter names instead of wrong GETs at the origin root with invented `*Id` names.
> 
> **Prefix:** When a base variable is assigned a known path (e.g. `` `${host}/api/v2` ``), that prefix is kept on the template. If the base cannot be resolved, candidates are tagged `interpolated-unrooted` and **`ResolveUnrootedInterpolatedRoutes`** roots them at crawl merge time using **only observed** routes (not declarations, bundle strings, or other interpolated hits), with optional same-base prefix inheritance; unresolved candidates are dropped before merge and in **`ApplyDeclaredRouteTemplates`**.
> 
> **Method:** Infers HTTP verb from the enclosing `.get`/`.post`/… call, `fetch` `method` options, or navigation sinks (`window.open`, `location`); skips literals with no determinable method (no default GET).
> 
> **Parameters:** Stops naming from the previous path segment; uses expression identifiers (including `encodeURIComponent(arg)` unwrap), same-segment literal hints, or **`paramN`** by segment index with **`RenumberPositionalParams`** so rooted vs direct literals align.
> 
> **Pipeline:** `route.go` calls rooting before **`MergeWebRoutes`**. Broad extractor and unrooted resolution tests added/updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6cd998e4e045b5353867590172b273fde954f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->