### PR TITLE
Preserve the trailing slash on request paths

### DIFF
--- a/internal/discover/directory/directory.go
+++ b/internal/discover/directory/directory.go
@@ -248,8 +248,9 @@ func sweepFrontier(ctx context.Context, baseURL string, current frontier, allPat
 
 	for _, path := range allPaths {
 		// Clean path (ie. /foo/bar/ -> /foo/bar or foo/bar -> /foo/bar)
-		cleanPath := strings.Trim(path, "/")
-		if cleanPath != "" { // If the path is not empty, add a leading slash else leave it as ""
+		// TrimLeft, not Trim: a trailing slash is the directory probe and must survive to the wire.
+		cleanPath := strings.TrimLeft(path, "/")
+		if cleanPath != "" {
 			cleanPath = fmt.Sprintf("/%s", cleanPath)
 		}
 		fullPath := fmt.Sprintf("%s%s", strings.TrimRight(current.basePath, "/"), cleanPath)

--- a/internal/discover/route/helpers/helpers.go
+++ b/internal/discover/route/helpers/helpers.go
@@ -15,6 +15,7 @@ import (
 
 	// Utils
 	utils "github.com/Method-Security/webscan/utils"
+	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 )
 
 type providerRouteNoiseSignature struct {
@@ -330,8 +331,9 @@ func ResolveURL(base, ref string) string {
 	if err != nil {
 		return ref
 	}
-	// Return with trailing slash removed
-	return strings.TrimRight(baseURL.ResolveReference(refURL).String(), "/")
+	resolved := baseURL.ResolveReference(refURL)
+	resolved.Path = requesthelpers.NormalizeTargetPath(resolved.Path)
+	return resolved.String()
 }
 
 // URLRemoveQueryParams removes query parameters from a URL string.

--- a/internal/enumerate/cms/drupal.go
+++ b/internal/enumerate/cms/drupal.go
@@ -277,7 +277,7 @@ func checkDrupalModuleInfoYml(ctx context.Context, baseURL, basePath string, con
 			continue
 		}
 		for _, modulePath := range drupalModulePaths {
-			infoYmlPath := fmt.Sprintf("%s%s%s/%s.info.yml", basePath, modulePath, module, module)
+			infoYmlPath := fmt.Sprintf("%s%s/%s.info.yml", requesthelpers.JoinPath(basePath, modulePath), module, module)
 			requestConfig := createDrupalSendHTTPRequestConfig(baseURL, infoYmlPath, common.HttpMethodHead, 0, config)
 			resp, err := request.SendRequest(ctx, requestConfig)
 			if err != nil {
@@ -317,7 +317,7 @@ func checkDrupalModuleChangelogs(ctx context.Context, baseURL, basePath string, 
 
 	for _, module := range discoveredModules {
 		for _, modulePath := range drupalModulePaths {
-			changelogPath := fmt.Sprintf("%s%s%s/CHANGELOG.txt", basePath, modulePath, module.Name)
+			changelogPath := fmt.Sprintf("%s%s/CHANGELOG.txt", requesthelpers.JoinPath(basePath, modulePath), module.Name)
 			requestConfig := createDrupalSendHTTPRequestConfig(baseURL, changelogPath, common.HttpMethodGet, 0, config)
 			resp, err := request.SendRequest(ctx, requestConfig)
 			if err != nil {
@@ -370,7 +370,7 @@ func checkDrupalModuleLicense(ctx context.Context, baseURL, basePath string, con
 			continue
 		}
 		for _, modulePath := range drupalModulePaths {
-			licensePath := fmt.Sprintf("%s%s%s/LICENSE.txt", basePath, modulePath, module)
+			licensePath := fmt.Sprintf("%s%s/LICENSE.txt", requesthelpers.JoinPath(basePath, modulePath), module)
 			requestConfig := createDrupalSendHTTPRequestConfig(baseURL, licensePath, common.HttpMethodHead, 0, config)
 			resp, err := request.SendRequest(ctx, requestConfig)
 			if err != nil {
@@ -420,7 +420,7 @@ func checkDrupalModuleReadme(ctx context.Context, baseURL, basePath string, conf
 				break
 			}
 			for _, readmeFile := range readmeFiles {
-				readmePath := fmt.Sprintf("%s%s%s/%s", basePath, modulePath, module, readmeFile)
+				readmePath := fmt.Sprintf("%s%s/%s", requesthelpers.JoinPath(basePath, modulePath), module, readmeFile)
 				requestConfig := createDrupalSendHTTPRequestConfig(baseURL, readmePath, common.HttpMethodGet, 0, config)
 				resp, err := request.SendRequest(ctx, requestConfig)
 				if err != nil {

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -243,7 +243,7 @@ func checkWordPressAPI(ctx context.Context, url string, config *enumeratecmsword
 		errors = append(errors, err.Error())
 		return pluginsList, errors
 	}
-	apiPath := fmt.Sprintf("%s/wp-json", path)
+	apiPath := requesthelpers.JoinPath(path, "wp-json")
 	requestConfig := createSendHTTPRequestConfig(baseURL, apiPath, 0, config)
 	apiRequest, err := request.SendRequest(ctx, requestConfig)
 	if err != nil {
@@ -425,7 +425,7 @@ func checkReadmeFiles(ctx context.Context, url string, config *enumeratecmswordp
 	}
 
 	for i, plugin := range config.Plugins {
-		readmePath := fmt.Sprintf("%s/wp-content/plugins/%s/readme.txt", path, plugin)
+		readmePath := requesthelpers.JoinPath(path, fmt.Sprintf("wp-content/plugins/%s/readme.txt", plugin))
 		requestConfig := createSendHTTPRequestConfig(baseURL, readmePath, 0, config)
 		readmeRequest, err := request.SendRequest(ctx, requestConfig)
 		if err != nil {

--- a/internal/enumerate/cms/wordpress.go
+++ b/internal/enumerate/cms/wordpress.go
@@ -323,7 +323,7 @@ func fetchPluginsFromAPI(ctx context.Context, targetURL string, path string, con
 	}
 
 	// Send Request
-	apiRequestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", targetPath, path), 0, config)
+	apiRequestConfig := createSendHTTPRequestConfig(baseURL, requesthelpers.JoinPath(targetPath, path), 0, config)
 	apiRequest, err := request.SendRequest(ctx, apiRequestConfig)
 	if err != nil || apiRequest.Response != nil && apiRequest.Response.StatusCode != nil && *apiRequest.Response.StatusCode != 200 {
 		return plugins

--- a/internal/enumerate/kube/kube.go
+++ b/internal/enumerate/kube/kube.go
@@ -3,7 +3,6 @@ package kube
 import (
 	// Standard
 	"context"
-	"fmt"
 	"time"
 
 	// Generated
@@ -72,7 +71,7 @@ func PerformAppEnumerateKube(ctx context.Context, config *enumeratekubefern.Enum
 	requests := []*common.HttpRequestResponse{}
 	for i, path := range commonKubepaths {
 		// Create Request Config
-		requestConfig := createSendHTTPRequestConfig(baseURL, fmt.Sprintf("%s%s", parsedTargetPath, path), config.VerifyTls, config.Timeout, config.UserAgent)
+		requestConfig := createSendHTTPRequestConfig(baseURL, requesthelpers.JoinPath(parsedTargetPath, path), config.VerifyTls, config.Timeout, config.UserAgent)
 
 		// Send Request
 		request, err := request.SendRequest(ctx, requestConfig)

--- a/internal/pentest/cms/wordpress/plugindeploy/plugindeploy.go
+++ b/internal/pentest/cms/wordpress/plugindeploy/plugindeploy.go
@@ -423,7 +423,7 @@ func PerformWordpressPluginDeploy(ctx context.Context, config pentestcmswordpres
 		}
 
 		fullLoginPath := installPath + loginPath
-		redirectTo := baseURL + installPath + "/wp-admin/"
+		redirectTo := baseURL + requesthelpers.JoinPath(installPath, "wp-admin/")
 
 		log.Info("WordPress plugin deploy starting",
 			svc1log.SafeParam("target", target),
@@ -622,7 +622,7 @@ func performPluginDeployAttempt(
 	// -------------------------------------------------------------------------
 	// Step 3: GET /wp-admin/update.php?action=upload-plugin for upload nonce
 	// -------------------------------------------------------------------------
-	uploadPagePath := installPath + "/wp-admin/update.php"
+	uploadPagePath := requesthelpers.JoinPath(installPath, "wp-admin/update.php")
 	uploadPageCfg := buildGetConfig(baseURL, uploadPagePath, cookieHeader,
 		map[string]string{"action": "upload-plugin"}, &config)
 	uploadPageResp, err := sendWithRetries(ctx, uploadPageCfg, config.Retries, config.Sleep)
@@ -672,7 +672,7 @@ func performPluginDeployAttempt(
 	// Step 5: POST the plugin zip to /wp-admin/update.php?action=upload-plugin
 	// -------------------------------------------------------------------------
 	zipFileName := slug + ".zip"
-	uploadCfg := buildMultipartUploadConfig(baseURL, installPath+"/wp-admin/update.php", cookieHeader, nonce, zipFileName, zipBytes, &config)
+	uploadCfg := buildMultipartUploadConfig(baseURL, requesthelpers.JoinPath(installPath, "wp-admin/update.php"), cookieHeader, nonce, zipFileName, zipBytes, &config)
 	uploadResp, err := sendWithRetries(ctx, uploadCfg, config.Retries, config.Sleep)
 	if err != nil {
 		log.Info("WP plugin deploy: upload failed",
@@ -705,7 +705,7 @@ func performPluginDeployAttempt(
 	// -------------------------------------------------------------------------
 	// Step 6a: GET /wp-admin/plugins.php to find the activation nonce
 	// -------------------------------------------------------------------------
-	pluginsPagePath := installPath + "/wp-admin/plugins.php"
+	pluginsPagePath := requesthelpers.JoinPath(installPath, "wp-admin/plugins.php")
 	pluginsPageCfg := buildGetConfig(baseURL, pluginsPagePath, cookieHeader, nil, &config)
 	pluginsPageResp, err := sendWithRetries(ctx, pluginsPageCfg, config.Retries, config.Sleep)
 	if err != nil {
@@ -747,7 +747,7 @@ func performPluginDeployAttempt(
 	// -------------------------------------------------------------------------
 	// Step 6b: GET activate URL — triggers register_activation_hook
 	// -------------------------------------------------------------------------
-	activatePath := installPath + "/wp-admin/plugins.php"
+	activatePath := requesthelpers.JoinPath(installPath, "wp-admin/plugins.php")
 	activateQP := map[string]string{
 		"action":   "activate",
 		"plugin":   pluginFile,
@@ -807,7 +807,7 @@ func performPluginDeployAttempt(
 	// -------------------------------------------------------------------------
 	// Step 7: Trigger (defensive second exec path)
 	// -------------------------------------------------------------------------
-	triggerPath := installPath + fmt.Sprintf("/wp-content/plugins/%s/%s.php", slug, slug)
+	triggerPath := requesthelpers.JoinPath(installPath, fmt.Sprintf("wp-content/plugins/%s/%s.php", slug, slug))
 	triggerParam := slug
 	if callbackToken != "" {
 		triggerParam = callbackToken
@@ -903,7 +903,7 @@ func performCleanup(
 	baseURL, installPath, cookieHeader, slug, pluginFile string,
 	steps *[]*pentestcmswordpressfern.PentestCmsWordpressPluginDeployStep,
 ) bool {
-	pluginsPath := installPath + "/wp-admin/plugins.php"
+	pluginsPath := requesthelpers.JoinPath(installPath, "wp-admin/plugins.php")
 
 	// Fetch plugins page again for deactivate nonce
 	pluginsPageCfg := buildGetConfig(baseURL, pluginsPath, cookieHeader, nil, &config)

--- a/internal/pentest/cms/wordpress/wploginbruteforce.go
+++ b/internal/pentest/cms/wordpress/wploginbruteforce.go
@@ -488,7 +488,7 @@ func PerformWordpressWpLoginBruteforce(ctx context.Context, config pentestcmswor
 
 		// Raw concatenation per xmlrpc precedent
 		fullLoginPath := installPath + loginPath
-		redirectTo := baseURL + installPath + "/wp-admin/"
+		redirectTo := baseURL + requesthelpers.JoinPath(installPath, "wp-admin/")
 
 		targetInfo := pentestcmswordpressfern.WpLoginBruteforceTarget{
 			Target:    target,

--- a/internal/pentest/cms/wordpress/xmlrpcbruteforce.go
+++ b/internal/pentest/cms/wordpress/xmlrpcbruteforce.go
@@ -189,7 +189,7 @@ func PerformWordpressXMLRPCBruteforce(ctx context.Context, config pentestcmsword
 			errors = append(errors, err.Error())
 			continue
 		}
-		xmlrpcFullPath := fmt.Sprintf("%s%s", path, xmlrpcPath)
+		xmlrpcFullPath := requesthelpers.JoinPath(path, xmlrpcPath)
 
 		var attempts []*pentestcmswordpressfern.XmlrpcBruteforceAttempt
 

--- a/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
+++ b/internal/pentest/cms/wordpress/xmlrpcfunctionsexposed.go
@@ -63,7 +63,7 @@ func PerformWordpressXMLRPCFunctionsExposed(ctx context.Context, config pentestc
 			errors = append(errors, err.Error())
 			continue
 		}
-		xmlrpcPathParsedPath := fmt.Sprintf("%s%s", path, xmlrpcPath)
+		xmlrpcPathParsedPath := requesthelpers.JoinPath(path, xmlrpcPath)
 
 		// Grab XMLRPC functions Request
 		bodyString := "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.listMethods</methodName></methodCall>"

--- a/tests/request/helpers/data_test.go
+++ b/tests/request/helpers/data_test.go
@@ -1,0 +1,59 @@
+package helpers_test
+
+import (
+	"testing"
+
+	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
+)
+
+func TestNormalizeTargetPath(t *testing.T) {
+	for path, want := range map[string]string{
+		"":               "",
+		"/":              "",
+		"//":             "",
+		"/static":        "/static",
+		"/static/":       "/static/",
+		"static/":        "/static/",
+		"//static/":      "/static/",
+		"/a/b/":          "/a/b/",
+		"/static/app.js": "/static/app.js",
+	} {
+		if got := requesthelpers.NormalizeTargetPath(path); got != want {
+			t.Errorf("NormalizeTargetPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestJoinPath(t *testing.T) {
+	for _, tc := range []struct{ base, child, want string }{
+		{"", "wp-json", "/wp-json"},
+		{"/", "wp-json", "/wp-json"},
+		{"/blog", "wp-json", "/blog/wp-json"},
+		{"/blog", "/wp-json", "/blog/wp-json"},
+		{"/blog/", "/wp-json", "/blog/wp-json"},
+		{"/blog/", "wp-json/", "/blog/wp-json/"},
+		{"/blog", "", "/blog/"},
+	} {
+		if got := requesthelpers.JoinPath(tc.base, tc.child); got != tc.want {
+			t.Errorf("JoinPath(%q, %q) = %q, want %q", tc.base, tc.child, got, tc.want)
+		}
+	}
+}
+
+func TestSplitTargetURLPreservesTrailingSlash(t *testing.T) {
+	for _, tc := range []struct{ target, wantBase, wantPath string }{
+		{"https://api.example.com/static/", "https://api.example.com", "/static/"},
+		{"https://api.example.com/static", "https://api.example.com", "/static"},
+		{"https://api.example.com/", "https://api.example.com", ""},
+		{"https://api.example.com", "https://api.example.com", ""},
+		{"https://api.example.com:8443/a/b/", "https://api.example.com:8443", "/a/b/"},
+	} {
+		base, path, _, err := requesthelpers.SplitTargetURL(tc.target)
+		if err != nil {
+			t.Fatalf("SplitTargetURL(%q) returned error: %v", tc.target, err)
+		}
+		if base != tc.wantBase || path != tc.wantPath {
+			t.Errorf("SplitTargetURL(%q) = (%q, %q), want (%q, %q)", tc.target, base, path, tc.wantBase, tc.wantPath)
+		}
+	}
+}

--- a/tests/request/standard/helpers/prepare_test.go
+++ b/tests/request/standard/helpers/prepare_test.go
@@ -1,0 +1,90 @@
+package helpers_test
+
+import (
+	"context"
+	"testing"
+
+	common "github.com/Method-Security/webscan/generated/go/common"
+	standardhelpers "github.com/Method-Security/webscan/utils/request/standard/helpers"
+)
+
+func constructed(t *testing.T, baseURL, path string, params common.HttpRequestParams) string {
+	t.Helper()
+	request := &common.HttpRequest{BaseUrl: baseURL, Path: path, Method: common.HttpMethodGet, Params: &params}
+	got, err := standardhelpers.ConstructURL(context.Background(), request)
+	if err != nil {
+		t.Fatalf("ConstructURL(%q, %q) returned error: %v", baseURL, path, err)
+	}
+	return *got
+}
+
+func TestConstructURLPreservesTrailingSlash(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		base string
+		path string
+		want string
+	}{
+		{
+			name: "trailing slash reaches the server",
+			base: "https://api.example.com",
+			path: "/static/",
+			want: "https://api.example.com/static/",
+		},
+		{
+			name: "no trailing slash stays bare",
+			base: "https://api.example.com",
+			path: "/static",
+			want: "https://api.example.com/static",
+		},
+		{
+			name: "nested directory form is preserved",
+			base: "https://api.example.com",
+			path: "/assets/js/",
+			want: "https://api.example.com/assets/js/",
+		},
+		{
+			name: "root path",
+			base: "https://api.example.com",
+			path: "/",
+			want: "https://api.example.com/",
+		},
+		{
+			name: "empty path",
+			base: "https://api.example.com",
+			path: "",
+			want: "https://api.example.com",
+		},
+		{
+			name: "file path is untouched",
+			base: "https://api.example.com",
+			path: "/static/app.js",
+			want: "https://api.example.com/static/app.js",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := constructed(t, tc.base, tc.path, common.HttpRequestParams{}); got != tc.want {
+				t.Errorf("ConstructURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConstructURLPathParamsAndQuery(t *testing.T) {
+	got := constructed(t, "https://api.example.com", "/api/v1/customers/{id}/", common.HttpRequestParams{
+		Path:  map[string]string{"id": "4021"},
+		Query: map[string]string{"expand": "orders"},
+	})
+	want := "https://api.example.com/api/v1/customers/4021/?expand=orders"
+	if got != want {
+		t.Errorf("ConstructURL() = %q, want %q", got, want)
+	}
+}
+
+func TestConstructURLEscapedPath(t *testing.T) {
+	got := constructed(t, "https://api.example.com", "/files/report%20final/", common.HttpRequestParams{})
+	want := "https://api.example.com/files/report%20final/"
+	if got != want {
+		t.Errorf("ConstructURL() = %q, want %q", got, want)
+	}
+}

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -225,12 +225,7 @@ func SplitTargetURL(target string) (string, string, map[string]string, error) {
 	baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
 	baseURL = strings.TrimRight(baseURL, "/")
 
-	// Standardize the path
-	// If the path is empty or '/', set it to "", else trim the trailing slash (ie. "/foo/" -> "/foo")
-	path := strings.Trim(parsedURL.Path, "/")
-	if path != "" {
-		path = fmt.Sprintf("/%s", path)
-	}
+	path := NormalizeTargetPath(parsedURL.Path)
 
 	// Parse query parameters
 	var queryParams map[string]string
@@ -450,4 +445,24 @@ func splitHeaderValue(key, value string) []string {
 // This is a compatibility wrapper that converts string to bytes
 func CreateHTTPResponse(statusCode int, redirectChain []string, headers map[string][]string, responseBody string) common.HttpResponse {
 	return CreateHTTPResponseFromBytes(statusCode, redirectChain, headers, []byte(responseBody))
+}
+
+// NormalizeTargetPath collapses the authority root to "" per RFC 3986 6.2.3 and leaves every
+// other path alone. A trailing slash on a non-empty path is part of the request, not noise.
+func NormalizeTargetPath(path string) string {
+	if strings.Trim(path, "/") == "" {
+		return ""
+	}
+	return "/" + strings.TrimLeft(path, "/")
+}
+
+// JoinPath joins a base path and a child path with exactly one separator, preserving the
+// child's trailing slash.
+func JoinPath(basePath, childPath string) string {
+	base := strings.TrimRight(basePath, "/")
+	child := strings.TrimLeft(childPath, "/")
+	if child == "" {
+		return base + "/"
+	}
+	return base + "/" + child
 }

--- a/utils/request/standard/helpers/prepare.go
+++ b/utils/request/standard/helpers/prepare.go
@@ -26,20 +26,20 @@ func ConstructURL(ctx context.Context, request *common.HttpRequest) (*string, er
 		return nil, err
 	}
 
-	// Path
-	standardizedPath := strings.TrimRight(request.Path, "/")
+	// Sent verbatim: a trailing slash is part of the request, and servers answer /x and /x/ differently.
+	requestPath := request.Path
 	if request.Params.Path != nil {
 		for k, v := range request.Params.Path {
-			standardizedPath = strings.ReplaceAll(standardizedPath, fmt.Sprintf("{%s}", k), url.PathEscape(v))
+			requestPath = strings.ReplaceAll(requestPath, fmt.Sprintf("{%s}", k), url.PathEscape(v))
 		}
 	}
 	parsedURL.RawPath = ""
-	decodedPath, err := url.PathUnescape(standardizedPath)
-	if err == nil && decodedPath != standardizedPath {
+	decodedPath, err := url.PathUnescape(requestPath)
+	if err == nil && decodedPath != requestPath {
 		parsedURL.Path = decodedPath
-		parsedURL.RawPath = standardizedPath
+		parsedURL.RawPath = requestPath
 	} else {
-		parsedURL.Path = standardizedPath
+		parsedURL.Path = requestPath
 	}
 
 	// Query


### PR DESCRIPTION
Aligned with Phil's review on the [RFC](https://app.notion.com/p/3c142e5796d88082a964fa6cfe12b250): trim `/` from base URLs but not from paths, and sweep the base+path joins for defensiveness. Full audit in the [appendix](https://app.notion.com/p/3c142e5796d8819db01ec6501d71d8f9).

`--add-slash` was split out into **[#514](https://github.com/method-security/webscan/pull/514)**, stacked on this branch — per Phil's point that it is net-new discovery capability rather than part of the normalization work.

## Why

`/x` and `/x/` are different URIs ([RFC 3986](https://www.rfc-editor.org/rfc/rfc3986)), and servers routinely answer them differently — nginx `location /x/` with `alias`, Apache `mod_dir`, IIS virtual directories, Tomcat context roots. The directory form is often the only one that reveals a directory exists.

We stripped it in three places on the way out, so no webscan code path could ask for `/x/`.

The failure mode was silent, which is the part that matters: a caller asking for `/static/` had `/static` sent and the 404 recorded against a path it never requested. An agent, a processor or a person reading that artifact sees a well-formed probe and a clean negative. Nothing errors. We didn't lose a capability so much as manufacture false confidence.

## What changed

| Site | Before | After |
|---|---|---|
| `utils/request/helpers/data.go` — `SplitTargetURL` | `strings.Trim(parsedURL.Path, "/")` | `NormalizeTargetPath` — root still collapses, non-empty paths preserved |
| `utils/request/standard/helpers/prepare.go` — `ConstructURL` | `strings.TrimRight(request.Path, "/")` | sent verbatim |
| `internal/discover/route/helpers/helpers.go` — `ResolveURL` | `TrimRight(resolved, "/")` | normalizes the path component only |
| `internal/discover/directory/directory.go` | `strings.Trim(path, "/")` on supplied paths | `TrimLeft` only, so a `--paths` entry can carry one |
| `wordpress.go:326`, `kube.go:75`, `xmlrpcbruteforce.go:192`, `xmlrpcfunctionsexposed.go:66` | `Sprintf("%s%s", a, b)` | shared `JoinPath` |

`SplitTargetURL` was the important find, and it is why this PR's original scope was insufficient. It has **33 call sites across 21 files** and runs before `ConstructURL`, so the agent's own `httprequest` tool (`internal/discover/request/request.go:26`) was still sending `/x` for `/x/` after the first commit. My earlier claim that fixing `ConstructURL` "made the wire honest" was wrong — it removed the last strip, not the first.

## Base URL normalization is untouched

Per Phil's point, an empty path and `/` are equivalent at the authority ([§6.2.3](https://www.rfc-editor.org/rfc/rfc3986#section-6.2.3)), so `NormalizeTargetPath` still collapses `""`, `"/"` and `"//"` to `""`. Only non-empty paths keep their trailing slash. Base URL construction is unchanged.

## The joins were latent, not safe

Four sites concatenated two path fragments with neither side trimmed. They were correct only because `SplitTargetURL` guaranteed the left operand never ended in a slash — so fixing the split would have started producing `//`. They now use a shared `JoinPath`. Eleven other join sites were already defensive and are untouched; the appendix lists all of them with verdicts.

## Testing

`./godelw verify` green, full `go test ./...` green.

- `tests/request/standard/helpers/prepare_test.go` — `ConstructURL`; confirmed failing against the pre-fix behaviour on five assertions before passing
- `tests/request/helpers/data_test.go` — `NormalizeTargetPath`, `JoinPath`, and `SplitTargetURL` round-trips including the root and `//` cases

End-to-end evidence that the two changes together reach a previously undiscoverable asset is in #514, since it needs both.

## Scope notes for review

`ResolveURL` isn't in Phil's four points; I included it because it's the same defect in the same direction — a crawled `href="/admin/"` lost its directory form before anything probed it. Easy to split out if you'd rather.

`internal/discover/wordlist/wordlist.go:165,307` still trims for its visited-set key. Left alone: that's identity, where collapsing is arguably right. Flagged in the appendix as needing a decision rather than changed here.

The ontology-side layers (`UrlUtils._parse_url`, `UrlHelpers.parse`) are the RFC's subject and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how URLs are built across discovery, enumeration, and pentest modules; incorrect path handling could alter probe targets or miss directory-only endpoints, but behavior is well-tested and scoped to path normalization.
> 
> **Overview**
> **Outgoing HTTP paths now keep trailing slashes** so `/x/` is not silently rewritten to `/x` before requests hit the wire.
> 
> `SplitTargetURL` uses new **`NormalizeTargetPath`** (authority root still collapses to `""`; non-empty paths keep a trailing `/`). **`ConstructURL`** no longer strips trailing slashes from `request.Path`. **`ResolveURL`** normalizes only the path component via `NormalizeTargetPath` instead of trimming the whole URL string.
> 
> **Directory discovery** cleans supplied paths with **`TrimLeft`** only, so a `--paths` entry ending in `/` survives as a directory probe.
> 
> **Path joining** is centralized in **`JoinPath`** and adopted across CMS enumeration (Drupal, WordPress), Kubernetes probes, WordPress pentest flows (plugin deploy, login/XML-RPC bruteforce), replacing raw `fmt.Sprintf` concatenation that could double slashes once paths stopped being normalized away.
> 
> **Tests** cover `NormalizeTargetPath`, `JoinPath`, `SplitTargetURL`, and `ConstructURL` trailing-slash behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13cb672a9b7ffcdbaee3f3e785bb4f54c5edb45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->