### PR TITLE
Return nonzero exit code for DAST report errors

### DIFF
--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -168,6 +168,9 @@ func (a *WebScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			if len(rep.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
 			a.OutputSignal.Content = rep
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,9 @@ func main() {
 	if err := webscan.RootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+	if webscan.OutputSignal.Status != 0 {
+		os.Exit(1)
+	}
 
 	os.Exit(0)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+const webscanHelperProcess = "WEBSCAN_HELPER_PROCESS"
+
+func TestDastRuntimeErrorExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=TestWebscanHelperProcess")
+	cmd.Env = append(os.Environ(),
+		webscanHelperProcess+"=1",
+		"WEBSCAN_TEST_OUTPUT="+filepath.Join(tempDir, "output.json"),
+		"WEBSCAN_TEST_MISSING_TEMPLATE="+filepath.Join(tempDir, "missing.yaml"),
+	)
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected webscan to exit nonzero when the DAST engine reports an error")
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected an exit error, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitErr.ExitCode())
+	}
+}
+
+func TestWebscanHelperProcess(t *testing.T) {
+	if os.Getenv(webscanHelperProcess) != "1" {
+		return
+	}
+
+	os.Args = []string{
+		"webscan",
+		"pentest", "application", "dast",
+		"--targets", "https://example.test",
+		"--http-methods", "GET",
+		"--template-paths", os.Getenv("WEBSCAN_TEST_MISSING_TEMPLATE"),
+		"--output", "json",
+		"--output-file", os.Getenv("WEBSCAN_TEST_OUTPUT"),
+	}
+	main()
+}


### PR DESCRIPTION
## Summary
- mark Web DAST output signals failed when the structured report contains engine errors
- return process exit code 1 whenever a Webscan output signal failed

## Test plan
- ./godelw verify
- red regression commit: 5fb60819
- green fix commit: 4e7b6853

This prevents runtime failures such as a missing Chrome browser from appearing as successful no-findings executions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI exit-code change. It can make previously “successful” DAST (and any other Status!=0) runs fail in automation.
> 
> **Overview**
> Web DAST no longer looks like a clean no-findings run when the engine recorded errors (for example a missing template or browser). If `rep.Errors` is non-empty, `OutputSignal.Status` is set to 1.
> 
> `main` now exits 1 whenever that status is non-zero after Cobra succeeds, so failed signals actually fail the process. A helper-process test covers a missing-template DAST invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7b68534451b7a39e5548714e161d7f69eceafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->