### PR TITLE
Validate favicon response content

### DIFF
--- a/internal/discover/witness/helpers/favicon.go
+++ b/internal/discover/witness/helpers/favicon.go
@@ -115,8 +115,9 @@ func FetchFavicon(ctx context.Context, faviconURL string, config discover.Discov
 		return nil, "", nil
 	}
 
-	body := faviconResponseBytes(resp.Response.ResponseBody)
-	if len(body) == 0 {
+	responseBody := resp.Response.ResponseBody
+	body := faviconResponseBytes(responseBody)
+	if !isFaviconResponse(body, responseBody) {
 		return nil, "", nil
 	}
 
@@ -126,8 +127,7 @@ func FetchFavicon(ctx context.Context, faviconURL string, config discover.Discov
 
 // faviconResponseBytes returns the raw favicon octets from a captured Body.
 // The standard HTTP capture stores image responses as a base64-encoded binary
-// body, so those are decoded back to their real bytes; text/json kinds (e.g. an
-// SVG favicon served as text) fall through to the literal string content.
+// body, so those are decoded back to their real bytes.
 func faviconResponseBytes(body *common.Body) []byte {
 	if body == nil {
 		return nil
@@ -146,6 +146,15 @@ func faviconResponseBytes(body *common.Body) []byte {
 		return []byte(*str)
 	}
 	return nil
+}
+
+func isFaviconResponse(body []byte, responseBody *common.Body) bool {
+	if len(body) == 0 {
+		return false
+	}
+
+	mediaType := requesthelpers.GetResponseBodyMimeTypeFromBodyStruct(responseBody)
+	return strings.HasPrefix(mediaType, "image/")
 }
 
 // computeFaviconHash computes the Shodan-compatible mmh3-32 hash of a favicon.

--- a/internal/discover/witness/helpers/favicon_test.go
+++ b/internal/discover/witness/helpers/favicon_test.go
@@ -1,0 +1,76 @@
+package witnesshelpers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	common "github.com/Method-Security/webscan/generated/go/common"
+	discover "github.com/Method-Security/webscan/generated/go/discover"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchFaviconRejectsHtmlContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!doctype html><title>Access denied</title>"))
+	}))
+	t.Cleanup(server.Close)
+
+	body, hash, err := FetchFavicon(context.Background(), server.URL, faviconConfig())
+	require.NoError(t, err)
+	assert.Nil(t, body)
+	assert.Empty(t, hash)
+}
+
+func TestFetchFaviconRejectsEmptyBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/x-icon")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	body, hash, err := FetchFavicon(context.Background(), server.URL, faviconConfig())
+	require.NoError(t, err)
+	assert.Nil(t, body)
+	assert.Empty(t, hash)
+}
+
+func TestFetchFaviconAcceptsIcoImageContentType(t *testing.T) {
+	icon := []byte{0, 0, 1, 0, 1, 0}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/x-icon")
+		_, _ = w.Write(icon)
+	}))
+	t.Cleanup(server.Close)
+
+	body, hash, err := FetchFavicon(context.Background(), server.URL, faviconConfig())
+	require.NoError(t, err)
+	assert.Equal(t, icon, body)
+	assert.NotEmpty(t, hash)
+}
+
+func TestFetchFaviconAcceptsSVGImageContentType(t *testing.T) {
+	svg := []byte(`<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		_, _ = w.Write(svg)
+	}))
+	t.Cleanup(server.Close)
+
+	body, hash, err := FetchFavicon(context.Background(), server.URL, faviconConfig())
+	require.NoError(t, err)
+	assert.Equal(t, svg, body)
+	assert.NotEmpty(t, hash)
+}
+
+func faviconConfig() discover.DiscoverWitnessConfig {
+	return discover.DiscoverWitnessConfig{
+		MaxRedirects:               2,
+		Timeout:                    5,
+		IgnoreCrossDomainRedirects: true,
+		UserAgent:                  common.UserAgentPresetCurl,
+	}
+}

--- a/utils/request/helpers/data.go
+++ b/utils/request/helpers/data.go
@@ -330,6 +330,42 @@ func GetResponseBodyStringFromBodyStruct(body *common.Body) *string {
 	return nil
 }
 
+// GetResponseBodyMimeTypeFromBodyStruct extracts the normalized MIME type from
+// a Body struct, without parameters like charset.
+func GetResponseBodyMimeTypeFromBodyStruct(body *common.Body) string {
+	if body == nil {
+		return ""
+	}
+
+	var mimeType *string
+	switch body.Kind {
+	case "binary":
+		if body.Binary != nil {
+			mimeType = body.Binary.MimeType
+		}
+	case "form":
+		if body.Form != nil {
+			mimeType = body.Form.MimeType
+		}
+	case "json":
+		if body.Json != nil {
+			mimeType = body.Json.MimeType
+		}
+	case "multipart":
+		if body.Multipart != nil {
+			mimeType = body.Multipart.MimeType
+		}
+	case "text":
+		if body.Text != nil {
+			mimeType = body.Text.MimeType
+		}
+	}
+	if mimeType == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(strings.Split(*mimeType, ";")[0]))
+}
+
 // CreateBodyFromBytes creates a Body struct based on content type and body data as bytes
 func CreateBodyFromBytes(contentType string, bodyData []byte) *common.Body {
 	ct := strings.TrimSpace(strings.Split(contentType, ";")[0])

--- a/utils/request/helpers/data_test.go
+++ b/utils/request/helpers/data_test.go
@@ -3,6 +3,7 @@ package request_test
 import (
 	"testing"
 
+	common "github.com/Method-Security/webscan/generated/go/common"
 	requesthelpers "github.com/Method-Security/webscan/utils/request/helpers"
 )
 
@@ -55,5 +56,35 @@ func TestSplitTargetURLPreservesTrailingSlash(t *testing.T) {
 		if base != tc.wantBase || path != tc.wantPath {
 			t.Errorf("SplitTargetURL(%q) = (%q, %q), want (%q, %q)", tc.target, base, path, tc.wantBase, tc.wantPath)
 		}
+	}
+}
+
+func TestGetResponseBodyMimeTypeFromBodyStruct(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body *common.Body
+		want string
+	}{
+		{
+			name: "binary",
+			body: requesthelpers.CreateBodyFromBytes("image/x-icon", []byte{0, 0, 1, 0}),
+			want: "image/x-icon",
+		},
+		{
+			name: "text with parameters",
+			body: requesthelpers.CreateBodyFromBytes("Text/HTML; charset=utf-8", []byte("<html></html>")),
+			want: "text/html",
+		},
+		{
+			name: "nil body",
+			body: nil,
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := requesthelpers.GetResponseBodyMimeTypeFromBodyStruct(tc.body); got != tc.want {
+				t.Errorf("GetResponseBodyMimeTypeFromBodyStruct() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- validate favicon bytes with response content sniffing before returning a hash
- reject HTML/error pages even when served from favicon paths or with icon-like headers
- add helper tests for spoofed HTML and valid ICO bytes

## Tests
- go test ./internal/discover/witness/helpers ./internal/discover/witness
- ./godelw verify

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which responses produce witness favicon fingerprints; non-`image/*` MIME types (including mislabeled SVG) are now dropped even when bytes are present.
> 
> **Overview**
> **Favicon fetching** now treats a response as a favicon only when the body is non-empty and the captured response MIME type (normalized, without charset) starts with `image/`. `FetchFavicon` no longer returns bytes or a Shodan mmh3 hash for HTML error pages, empty bodies, or other non-image payloads that might still be returned from favicon URLs.
> 
> This adds `isFaviconResponse` in the witness favicon helper and a shared `GetResponseBodyMimeTypeFromBodyStruct` in request helpers to read MIME from the stored `common.Body` across binary/text/json/etc. kinds.
> 
> **Tests** cover rejecting `text/html` and empty `image/x-icon` responses, and accepting ICO and `image/svg+xml` bodies with a non-empty hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c440769f03e1eeaee13a6f16a67c863a66b380f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->